### PR TITLE
chore(gitignore): add mykey.py to ignore sensitive API keys and credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ Thumbs.db
 auth.json
 model_responses.txt
 
+# Sensitive files (API keys, credentials)
+mykey.py
+
 tasks/
 
 *.zip


### PR DESCRIPTION
Add `mykey.py` to `.gitignore` to prevent accidental commits of files containing API keys or other sensitive credentials.