### PR TITLE
fix: Add moonshot API temperature=1.0 constraint

### DIFF
--- a/llmcore.py
+++ b/llmcore.py
@@ -84,7 +84,7 @@ class ClaudeSession:
         return result[::-1] or messages[-2:]
     def raw_ask(self, messages, model=None, temperature=0.5, max_tokens=6144):
         model = model or self.default_model
-        if 'kimi' in model.lower(): temperature = 1.0  # kimi only accepts temp 1.0
+        if 'kimi' in model.lower() or 'moonshot' in model.lower(): temperature = 1.0  # kimi/moonshot only accepts temp 1.0
         headers = {"x-api-key": self.api_key, "Content-Type": "application/json", "anthropic-version": "2023-06-01"}
         payload = {"model": model, "messages": messages, "temperature": temperature, "max_tokens": max_tokens, "stream": True}
         try:
@@ -169,7 +169,7 @@ class LLMSession:
 
     def raw_ask(self, messages, model=None, temperature=0.5):
         if model is None: model = self.default_model
-        if 'kimi' in model.lower(): temperature = 1.0  # kimi only accepts temp 1.0
+        if 'kimi' in model.lower() or 'moonshot' in model.lower(): temperature = 1.0  # kimi/moonshot only accepts temp 1.0
         headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json", "Accept": "text/event-stream"}
         if self.api_mode == "responses":
             url = auto_make_url(self.api_base, "responses")


### PR DESCRIPTION
## Problem
Moonshot API (like Kimi API) only accepts temperature=1.0, but the default value is 0.5, causing 400 errors.

## Solution
Added moonshot model detection in both `raw_ask` methods (ClaudeSession and LLMSession) to force temperature=1.0 when using moonshot models.

## Changes
- Modified 2 locations in `llmcore.py`
- Changed condition from `if 'kimi' in model.lower()` to `if 'kimi' in model.lower() or 'moonshot' in model.lower()`

## Testing
Verified that temperature=1.0 works correctly with moonshot API, while other values (0, 0.5, 0.7, 1.5, 2.0) cause 400 errors.