### PR TITLE
文本会话日志迁移到 temp/sessions

### DIFF
--- a/agentmain.py
+++ b/agentmain.py
@@ -8,6 +8,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from llmcore import SiderLLMSession, LLMSession, ToolClient, ClaudeSession, XaiSession, build_multimodal_content
 from agent_loop import agent_runner_loop, StepOutcome, BaseHandler
 from ga import GenericAgentHandler, smart_format, get_global_memory, format_error
+from session_store import SessionStore
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
 with open(os.path.join(script_dir, 'assets/tools_schema.json'), 'r', encoding='utf-8') as f:
@@ -53,7 +54,9 @@ class GeneraticAgent:
         if len(llm_sessions) > 0: self.llmclient = ToolClient(llm_sessions, auto_save_tokens=True)
         else: self.llmclient = None
         self.lock = threading.Lock()
-        self.history = []               
+        self.history = []
+        self.session_store = SessionStore(script_dir)
+        self.current_session = None
         self.task_queue = queue.Queue() 
         self.is_running, self.stop_sig = False, False
         self.llm_no = 0;  self.inc_out = False
@@ -72,6 +75,20 @@ class GeneraticAgent:
         if not self.is_running: return
         self.stop_sig = True
         if self.handler is not None: self.handler.code_stop_signal.append(1)
+
+    def clear_history(self):
+        self.history = []
+        self.current_session = None
+        self.session_store.clear_current()
+
+    def restore_latest_history(self):
+        restored_info, err = self.session_store.restore_latest_history()
+        if err:
+            return None, err
+        restored, fname, count, session = restored_info
+        self.current_session = session
+        self.history.extend(restored)
+        return (fname, count), None
             
     def put_task(self, query, source="user", images=None):
         display_queue = queue.Queue()
@@ -83,11 +100,18 @@ class GeneraticAgent:
             task = self.task_queue.get()
             self.is_running = True
             raw_query, source, images, display_queue = task["query"], task["source"], task.get("images") or [], task["output"]
+            script_dir = os.path.dirname(os.path.abspath(__file__))
             rquery = smart_format(raw_query.replace('\n', ' '), max_str_len=200)
+            if self.current_session is None:
+                self.current_session = self.session_store.start_session(
+                    title=raw_query,
+                    source=source,
+                    model=self.get_llm_name() if self.llmclient else "",
+                    cwd=script_dir,
+                )
             self.history.append(f"[USER]: {rquery}")
             
             sys_prompt = get_system_prompt()
-            script_dir = os.path.dirname(os.path.abspath(__file__))
             handler = GenericAgentHandler(None, self.history, os.path.join(script_dir, 'temp'))
             if self.handler and 'key_info' in self.handler.working: 
                 ki = re.sub(r'\n\[SYSTEM\] 此为.*?工作记忆[。\n]*', '', self.handler.working['key_info'])  # 去旧
@@ -104,6 +128,7 @@ class GeneraticAgent:
                 initial_user_content = build_multimodal_content(user_input, images)
             elif images:
                 print(f"[INFO] backend {type(self.llmclient.backend).__name__} does not support direct multimodal input, fallback to text attachment hints.")
+            self.llmclient.set_session_context(self.session_store, self.current_session)
             gen = agent_runner_loop(self.llmclient, sys_prompt, user_input, 
                                 handler, TOOLS_SCHEMA, max_turns=40, verbose=self.verbose,
                                 initial_user_content=initial_user_content)
@@ -126,6 +151,7 @@ class GeneraticAgent:
             finally:
                 self.is_running = self.stop_sig = False
                 self.task_queue.task_done()
+                self.llmclient.clear_session_context()
                 if self.handler is not None: self.handler.code_stop_signal.append(1)
 
     

--- a/chatapp_common.py
+++ b/chatapp_common.py
@@ -1,4 +1,4 @@
-import asyncio, glob, os, queue as Q, re, socket, sys, time
+import asyncio, os, queue as Q, re, socket, sys, time
 
 HELP_TEXT = "📖 命令列表:\n/help - 显示帮助\n/status - 查看状态\n/stop - 停止当前任务\n/new - 清空当前上下文\n/restore - 恢复上次对话历史\n/llm [n] - 查看或切换模型"
 FILE_HINT = "If you need to show files to user, use [FILE:filepath] in your response."
@@ -30,23 +30,12 @@ def split_text(text, limit):
     return parts + ([text] if text else []) or ["..."]
 
 
-def format_restore():
-    files = glob.glob("./temp/model_responses_*.txt")
-    if not files:
-        return None, "❌ 没有找到历史记录"
-    latest = max(files, key=os.path.getmtime)
-    with open(latest, "r", encoding="utf-8") as f:
-        content = f.read()
-    users = re.findall(r"=== USER ===\n(.+?)(?==== |$)", content, re.DOTALL)
-    resps = re.findall(r"=== Response ===.*?\n(.+?)(?==== Prompt|$)", content, re.DOTALL)
-    restored = []
-    for u, r in zip(users, resps):
-        u, r = u.strip(), r.strip()[:500]
-        if u and r:
-            restored.extend([f"[USER]: {u}", f"[Agent] {r}"])
-    if not restored:
-        return None, "❌ 历史记录里没有可恢复内容"
-    return (restored, os.path.basename(latest), len(restored) // 2), None
+def format_restore(agent):
+    restored_info, err = agent.restore_latest_history()
+    if err:
+        return None, err
+    fname, count = restored_info
+    return (fname, count), None
 
 
 def build_done_text(raw_text):
@@ -142,18 +131,17 @@ class AgentChatMixin:
             return await self.send_text(chat_id, "LLMs:\n" + "\n".join(lines), **ctx)
         if op == "/restore":
             try:
-                restored_info, err = format_restore()
+                restored_info, err = format_restore(self.agent)
                 if err:
                     return await self.send_text(chat_id, err, **ctx)
-                restored, fname, count = restored_info
                 self.agent.abort()
-                self.agent.history.extend(restored)
+                fname, count = restored_info
                 return await self.send_text(chat_id, f"✅ 已恢复 {count} 轮对话\n来源: {fname}\n(仅恢复上下文，请输入新问题继续)", **ctx)
             except Exception as e:
                 return await self.send_text(chat_id, f"❌ 恢复失败: {e}", **ctx)
         if op == "/new":
             self.agent.abort()
-            self.agent.history = []
+            self.agent.clear_history()
             return await self.send_text(chat_id, "🆕 已清空当前共享上下文", **ctx)
         return await self.send_text(chat_id, HELP_TEXT, **ctx)
 

--- a/fsapp.py
+++ b/fsapp.py
@@ -1,8 +1,6 @@
-import glob
 import json
 import os
 import queue as Q
-import re
 import sys
 import threading
 import time
@@ -516,7 +514,7 @@ def handle_command(open_id, cmd, chat_id=None):
         _send_cmd_response("正在停止...")
     elif cmd == "/new":
         agent.abort()
-        agent.history = []
+        agent.clear_history()
         _send_cmd_response("已清空当前共享上下文")
     elif cmd == "/help":
         _send_cmd_response("命令列表:\n/stop - 停止当前任务\n/status - 查看状态\n/restore - 恢复上次对话历史\n/new - 开启新对话\n/help - 显示帮助")
@@ -524,22 +522,12 @@ def handle_command(open_id, cmd, chat_id=None):
         _send_cmd_response(f"状态: {'空闲' if not agent.is_running else '运行中'}")
     elif cmd == "/restore":
         try:
-            files = glob.glob("./temp/model_responses_*.txt")
-            if not files:
-                return _send_cmd_response("没有找到历史记录")
-            latest = max(files, key=os.path.getmtime)
-            with open(latest, "r", encoding="utf-8") as f:
-                content = f.read()
-            users = re.findall(r"=== USER ===\n(.+?)(?==== |$)", content, re.DOTALL)
-            resps = re.findall(r"=== Response ===.*?\n(.+?)(?==== Prompt|$)", content, re.DOTALL)
-            count = 0
-            for u, r in zip(users, resps):
-                u, r = u.strip(), r.strip()[:500]
-                if u and r:
-                    agent.history.extend([f"[USER]: {u}", f"[Agent] {r}"])
-                    count += 1
             agent.abort()
-            _send_cmd_response(f"已恢复 {count} 轮对话\n来源: {os.path.basename(latest)}\n(仅恢复上下文，请输入新问题继续)")
+            restored_info, err = agent.restore_latest_history()
+            if err:
+                return _send_cmd_response(err.replace("❌ ", ""))
+            fname, count = restored_info
+            _send_cmd_response(f"已恢复 {count} 轮对话\n来源: {fname}\n(仅恢复上下文，请输入新问题继续)")
         except Exception as e:
             _send_cmd_response(f"恢复失败: {e}")
     else:

--- a/llmcore.py
+++ b/llmcore.py
@@ -421,10 +421,18 @@ class ToolClient:
         self.auto_save_tokens = auto_save_tokens
         self.last_tools = ''
         self.total_cd_tokens = 0
+        self.session_store = None
+        self.current_session = None
+
+    def set_session_context(self, session_store, session):
+        self.session_store = session_store
+        self.current_session = session
+
+    def clear_session_context(self):
+        self.session_store = None
+        self.current_session = None
 
     def chat(self, messages, tools=None):
-        script_dir = os.path.dirname(os.path.abspath(__file__))
-        log_path = os.path.join(script_dir, f'./temp/model_responses_{os.getpid()}.txt')
         if self._should_use_structured_messages(messages):
             backend_messages = self._build_backend_messages(messages, tools)
             print("Structured prompt length:", sum(self._estimate_content_len(m.get("content")) for m in backend_messages), 'chars')
@@ -435,8 +443,13 @@ class ToolClient:
             print("Full prompt length:", len(full_prompt), 'chars')
             prompt_log = full_prompt
             gen = self.backend.ask(full_prompt, stream=True)
-        with open(log_path, 'a', encoding='utf-8', errors="replace") as f:
-            f.write(f"=== Prompt === {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n{prompt_log}\n")
+        if self.session_store is not None and self.current_session is not None:
+            self.session_store.append_prompt(self.current_session, prompt_log)
+        else:
+            script_dir = os.path.dirname(os.path.abspath(__file__))
+            log_path = os.path.join(script_dir, f'./temp/model_responses_{os.getpid()}.txt')
+            with open(log_path, 'a', encoding='utf-8', errors="replace") as f:
+                f.write(f"=== Prompt === {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n{prompt_log}\n")
         raw_text = ''; summarytag = '[NextWillSummary]'
         for chunk in gen:
             raw_text += chunk
@@ -444,8 +457,11 @@ class ToolClient:
         print('Complete response received.')
         if raw_text.endswith(summarytag):
             self.last_tools = ''; raw_text = raw_text[:-len(summarytag)]
-        with open(log_path, 'a', encoding='utf-8', errors="replace") as f:
-            f.write(f"=== Response === {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n{raw_text}\n\n")
+        if self.session_store is not None and self.current_session is not None:
+            self.session_store.append_response(self.current_session, raw_text)
+        else:
+            with open(log_path, 'a', encoding='utf-8', errors="replace") as f:
+                f.write(f"=== Response === {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n{raw_text}\n\n")
         return self._parse_mixed_response(raw_text)
 
     def _should_use_structured_messages(self, messages):

--- a/session_store.py
+++ b/session_store.py
@@ -1,0 +1,71 @@
+import glob
+import os
+import re
+import uuid
+from datetime import datetime
+
+
+def _now():
+    return datetime.now().astimezone()
+
+
+class SessionStore:
+    """Manage human-readable text session logs under temp/sessions."""
+
+    def __init__(self, project_root):
+        self.project_root = os.path.abspath(project_root)
+        self.root_dir = os.path.join(self.project_root, "temp", "sessions")
+        os.makedirs(self.root_dir, exist_ok=True)
+
+    def start_session(self, title, source="user", model="", cwd=None):
+        now = _now()
+        session_id = uuid.uuid4().hex[:6]
+        path = os.path.join(
+            self.root_dir,
+            f"{now:%Y}",
+            f"{now:%m}",
+            f"{now:%d}",
+            f"{now:%H%M%S}-{session_id}.txt",
+        )
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        return {"path": path}
+
+    def clear_current(self):
+        return None
+
+    def append_prompt(self, session, prompt_text):
+        if not session or not session.get("path"):
+            return
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        with open(session["path"], "a", encoding="utf-8", errors="replace") as f:
+            f.write(f"=== Prompt === {timestamp}\n{prompt_text}\n")
+
+    def append_response(self, session, response_text):
+        if not session or not session.get("path"):
+            return
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        with open(session["path"], "a", encoding="utf-8", errors="replace") as f:
+            f.write(f"=== Response === {timestamp}\n{response_text}\n\n")
+
+    def restore_latest_history(self):
+        files = glob.glob(os.path.join(self.root_dir, "*", "*", "*", "*.txt"))
+        # 兼容旧版本的日志文件，之前保存在 temp/ 目录下，文件名以 model_responses_ 开头
+        legacy_files = glob.glob(os.path.join(self.project_root, "temp", "model_responses_*.txt")) 
+        all_files = files + legacy_files
+        if not all_files:
+            return None, "❌ 没有找到历史记录"
+        latest = max(all_files, key=os.path.getmtime)
+        with open(latest, "r", encoding="utf-8", errors="replace") as f:
+            content = f.read()
+        users = re.findall(r"=== USER ===\n(.+?)(?==== |$)", content, re.DOTALL)
+        resps = re.findall(r"=== Response ===.*?\n(.+?)(?==== Prompt|$)", content, re.DOTALL)
+        restored = []
+        for user_text, resp_text in zip(users, resps):
+            user_text = user_text.strip()
+            resp_text = resp_text.strip()[:500]
+            if user_text and resp_text:
+                restored.extend([f"[USER]: {user_text}", f"[Agent] {resp_text}"])
+        if not restored:
+            return None, "❌ 历史记录里没有可恢复内容"
+        session = {"path": latest}
+        return (restored, os.path.basename(latest), len(restored) // 2, session), None


### PR DESCRIPTION
## 变更说明

本 PR 将会话日志从原先分散的 `temp/model_responses_*.txt` 形式，整理为按日期归档的文本日志：`temp/sessions/YYYY/MM/DD/HHMMSS-xxxxxx.txt`。

- 新增 `session_store.py`，统一管理文本会话日志写入与恢复
- 日志写入改为 `temp/sessions/.../*.txt`，保留原有 `=== Prompt ===` / `=== Response ===` 的可读格式
- 保留首轮失败时先写 Prompt 的行为，便于排查问题 
- 旧路径：`temp/model_responses_*.txt`
- `/new`、`/restore` 相关入口改为复用统一的会话恢复逻辑

## 验证

- 已执行 `python3 -m py_compile` 验证相关文件语法
- 已做最小验证，确认新日志文件会按新路径生成
- 已做兼容验证，确认旧 `model_responses_*.txt` 仍可被 `/restore` 恢复