### PR TITLE
Replace deprecated Streamlit HTML injections with st.iframe

### DIFF
--- a/frontends/stapp.py
+++ b/frontends/stapp.py
@@ -139,7 +139,6 @@ for msg in st.session_state.messages:
 
 # Scroll-height ghost fix: during streaming, expander open/close mid-animation can leave
 # phantom height → scrollbar long but can't scroll to bottom. Periodically detect & reflow.
-import streamlit.components.v1 as components
 _js_scroll_fix = ("!function(){var p=window.parent;if(p.__sfx)return;p.__sfx=1;"
     "var d=p.document;setInterval(function(){"
     "var m=d.querySelector('section.main');if(!m)return;"
@@ -158,7 +157,7 @@ _js_ime_fix = ("" if os.name == 'nt' else
     "e.key==='Enter'&&!e.shiftKey&&(e.isComposing||c||e.keyCode===229)&&"
     "(e.stopImmediatePropagation(),e.preventDefault())},!0))})}"
     "f();new MutationObserver(f).observe(d.body,{childList:1,subtree:1})}()")
-components.html(f'<script>{_js_scroll_fix};{_js_ime_fix}</script>', height=0)
+st.iframe(f'<html><head><script>{_js_scroll_fix};{_js_ime_fix}</script></head><body></body></html>', height=1)
 
 if prompt := st.chat_input("请输入指令"):
     st.session_state.messages.append({"role": "user", "content": prompt})

--- a/frontends/stapp2.py
+++ b/frontends/stapp2.py
@@ -9,7 +9,6 @@ except: pass
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import streamlit as st
-import streamlit.components.v1 as components
 import time, json, re, threading, queue
 from datetime import datetime
 from agentmain import GeneraticAgent
@@ -951,8 +950,8 @@ init_session_state()
 # Inject Anthropic theme
 st.markdown(ANTHROPIC_CSS, unsafe_allow_html=True)
 st.markdown(build_dynamic_font_css(110.0), unsafe_allow_html=True)
-components.html(ANTHROPIC_SELECTBOX_SCRIPT, height=0, width=0)
-components.html(build_header_agent_badge_script(), height=0, width=0)
+st.iframe(ANTHROPIC_SELECTBOX_SCRIPT, height=1, width=1)
+st.iframe(build_header_agent_badge_script(), height=1, width=1)
 
 st.session_state.agent_name = 'Generic Agent'
 with st.chat_message("assistant"):


### PR DESCRIPTION
## Summary
- replace deprecated `streamlit.components.v1.html` injections with `st.iframe`
- remove the now-unused `streamlit.components.v1` import from `frontends/stapp2.py`
- use minimal valid iframe dimensions (`height=1`, `width=1` where needed) for hidden script injection

## Testing
- launched `frontends/stapp.py` and `frontends/stapp2.py` under Streamlit 1.56.0
- verified both pages open successfully
- verified the `st.components.v1.html will be removed after 2025-11-01` deprecation warning no longer appears
- verified injected iframe/script content is still present and page loads without new frontend errors

## Notes
- excluded unrelated local `.gitignore` change from this PR