### PR TITLE
Add CONTRIBUTING.md and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report
+about: Report something that isn't working correctly
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Bug Description
+<!-- A clear description of the bug. -->
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+
+## Expected Behavior
+<!-- What you expected to happen. -->
+
+## Environment
+- OS: 
+- Python version: 
+- GenericAgent version/commit: 
+
+## Relevant Code / Logs
+<!-- Paste relevant log output or code snippets here. -->
+
+## Additional Context
+<!-- Any other context about the problem. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussions
+    url: https://github.com/lsdefine/GenericAgent/discussions
+    about: Ask questions and share ideas here

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+<!-- What problem does this solve? Be specific. -->
+
+## Proposed Solution
+<!-- Describe your solution. -->
+
+## Use Case
+<!-- Who would use this and why? -->
+
+## Alternatives Considered
+<!-- Any other approaches you considered? -->
+
+## Additional Context
+<!-- Screenshots, mockups, or other context. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,16 @@
+---
+name: Question
+about: Ask a question about GenericAgent
+title: "[Question] "
+labels: question
+assignees: ''
+---
+
+## Question
+<!-- What do you want to ask? -->
+
+## Context
+<!-- Provide enough context for others to understand and help. -->
+
+## Additional Details
+<!-- Any other relevant information. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing to GenericAgent
+
+Thanks for your interest in contributing! GenericAgent is a minimal, self-evolving autonomous agent framework. Here are some guidelines to help you get started.
+
+## Code Style
+
+- **Python**: Follow [PEP 8](https://pep8.org/) with 4-space indentation.
+- **Type hints**: Use `typing` annotations where practical for function signatures.
+- **Dataclasses**: Use `@dataclass` for structured data objects (see `agent_loop.py`).
+- **Generators**: Use `yield from` for nested generators; wrap with `try_call_generator` helper.
+- **No heavy dependencies**: Keep the core lightweight. If a new dependency is needed, open an issue first.
+
+## Project Structure
+
+```
+GenericAgent/
+├── agent_loop.py      # Core agent loop (~100 lines)
+├── llmcore.py         # LLM provider abstraction
+├── agentmain.py       # Main entry point
+├── memory/            # Layered memory system
+├── reflect/           # Reflection and crystallization
+├── frontends/         # UI frontends (Streamlit, Qt, Telegram)
+├── tests/             # Unit and integration tests
+└── launch.pyw         # Desktop launcher
+```
+
+## Branch Strategy
+
+- `main` — stable release
+- Work on feature branches: `feature/your-feature-name`
+- Submit PRs against `main`
+
+## PR Checklist
+
+- [ ] Run existing tests: `python -m pytest tests/`
+- [ ] Add tests for new functionality
+- [ ] Keep core files focused (avoid bloating `llmcore.py` / `simphtml.py`)
+- [ ] Update relevant docs if behavior changes
+- [ ] PR title: short summary (< 72 chars)
+
+## Testing
+
+```bash
+# Unit tests
+python -m pytest tests/test_minimax.py -v
+
+# Integration tests (requires API key)
+python -m pytest tests/test_minimax_integration.py -v
+```
+
+## Reporting Issues
+
+- Use issue templates (Bug Report / Feature Request / Question)
+- Search existing issues before opening a new one
+- For bugs: include Python version, OS, and minimal reproduction steps
+
+## Questions?
+
+Open a Discussion or ask in the issues. Welcome aboard!


### PR DESCRIPTION
## Summary

Addresses issue #64 — adds contributor documentation and structured issue templates to improve the open-source contributor experience.

## Changes

- **CONTRIBUTING.md**: Code style guide (PEP 8, dataclasses, generators), project structure overview, branch strategy, PR checklist, and testing instructions.
- **Bug Report template**: Structured template for bug reports with environment info and reproduction steps.
- **Feature Request template**: Template for enhancements with problem/solution/use-case sections.
- **Question template**: For Q&A, with a link to Discussions.
- **config.yml**: Template chooser pointing users to Discussions for general questions.

## Why This Helps

The repo currently has no contributor onboarding docs. External contributors don't know the code style, testing expectations, or branch strategy. Issue #64 identified this as a key friction point. These docs lower the barrier to meaningful contributions.