### PR TITLE
fix(L4): preserve raw sessions skipped as recent(<2h)

### DIFF
--- a/memory/L4_raw_sessions/compress_session.py
+++ b/memory/L4_raw_sessions/compress_session.py
@@ -219,7 +219,8 @@ def batch_process(src, l4_dir=None, dry_run=True):
 
     # Phase 4: Delete raw files
     to_del = [rp for *_, rp in results]
-    for fname, _ in skipped:
+    for fname, reason in skipped:
+        if 'recent' in reason: continue  # active session still being written
         m = [f for f in raw_files if os.path.basename(f) == fname]
         if m: to_del.append(m[0])
     deleted = 0


### PR DESCRIPTION
## Problem

`memory/L4_raw_sessions/compress_session.py` Phase 4 builds the `to_del` list from both successfully-processed files and from every entry in `skipped`, regardless of skip reason:

```python
# Phase 4: Delete raw files
to_del = [rp for *_, rp in results]
for fname, _ in skipped:
    m = [f for f in raw_files if os.path.basename(f) == fname]
    if m: to_del.append(m[0])
```

Phase 1 deliberately skips files modified within the last 2 hours so a session that is still being written is not interrupted (line 175):

```python
cutoff = time.time() - 7200  # skip files modified within 2h
...
if os.path.getmtime(fp) > cutoff:
    skipped.append((fname, 'recent(<2h)')); continue
```

Phase 4 then deletes them anyway. Because `batch_process` is wired into the 12h scheduler cron, the raw session log of any agent run that started in the previous ~12 h is silently lost.

## Fix

Filter the skipped-loop by reason so `recent(<2h)` files are preserved while files skipped for `dup:*` or compression-error reasons keep the previous deletion behavior.

```diff
     # Phase 4: Delete raw files
     to_del = [rp for *_, rp in results]
-    for fname, _ in skipped:
+    for fname, reason in skipped:
+        if 'recent' in reason: continue  # active session still being written
         m = [f for f in raw_files if os.path.basename(f) == fname]
         if m: to_del.append(m[0])
```

## Reproduction

1. Drop a `model_responses_*.txt` file into the raw session directory and `touch` it (mtime within 2h).
2. Call `compress_session.batch_process(<dir>, dry_run=False)`.
3. Phase 1 prints `SKIP <fname>: recent(<2h)` and Phase 4 prints `Deleted N/M raw files` — the recent file is gone from disk.

After the patch, the recent file remains; processed files and other skip reasons are deleted as before.

## Verification

```
$ python -m py_compile memory/L4_raw_sessions/compress_session.py
```

Net line count: +1.