### PR TITLE
fix(schema): align file_write mode default with Python implementation

### DIFF
--- a/assets/tools_schema.json
+++ b/assets/tools_schema.json
@@ -32,7 +32,7 @@
     "description": "Create/overwrite/append files. ONLY for HUGE edits. Place <file_content>...</file_content> in reply body BEFORE the file_write call. Supports {{file:path:startLine:endLine}}, auto-expanded",
     "parameters": {"type": "object", "properties": {
       "path": {"type": "string", "description": "File path"},
-      "mode": {"type": "string", "enum": ["overwrite", "append", "prepend"], "description": "Write mode", "default": "append"}}}
+      "mode": {"type": "string", "enum": ["overwrite", "append", "prepend"], "description": "Write mode", "default": "overwrite"}}}
   }},
   {"type": "function", "function": {
     "name": "web_scan",


### PR DESCRIPTION
## Problem

`assets/tools_schema.json` (used for English-locale agents since the i18n
auto-detect in 7cadbd7) declares `file_write.mode` with a default of `\"append\"`:

```json
"mode": {"type": "string", "enum": ["overwrite", "append", "prepend"],
         "description": "Write mode", "default": "append"}
```

But `assets/tools_schema_cn.json` and the Python handler both default to
`\"overwrite\"`:

```json
// tools_schema_cn.json line 35
"default": "overwrite"
```

```python
# ga.py:369
mode = args.get("mode", "overwrite")
```

When the LLM trusts the English schema's documented default and omits
`mode`, the Python handler silently overwrites the file. Same call,
opposite behavior depending on which locale loaded the schema.

## Fix

Change the EN schema default to `\"overwrite\"` so all three sources of
truth — EN schema, CN schema, Python handler — agree:

```diff
-      "mode": {"type": "string", "enum": ["overwrite", "append", "prepend"], "description": "Write mode", "default": "append"}}}
+      "mode": {"type": "string", "enum": ["overwrite", "append", "prepend"], "description": "Write mode", "default": "overwrite"}}}
```

The reverse direction (changing CN + ga.py to `\"append\"`) was rejected
because:

- The Python handler has shipped `overwrite` since the introduction of
  the parameter, so `overwrite` is the de-facto behavior callers depend on.
- `file_write` in CONTRIBUTING-style usage (huge edits with the
  `<file_content>` block before the call) targets a fresh write, not an
  append; flipping the default to `append` would silently change semantics
  for every existing skill that omits `mode`.

## Verification

```
$ python -c "import json; json.load(open('assets/tools_schema.json'))"  # parses
$ diff <(grep -A0 '"default"' assets/tools_schema.json) <(grep -A0 '"default"' assets/tools_schema_cn.json)
# defaults match for file_write.mode
```

Net line count: 0.