### PR TITLE
test(minimax): use 'content' key so compress_history_tags actually runs

### DIFF
--- a/tests/test_minimax.py
+++ b/tests/test_minimax.py
@@ -145,15 +145,15 @@ class TestMiniMaxCompressHistoryTags(unittest.TestCase):
 
         long_think = "A" * 2000
         messages = [
-            {"role": "assistant", "prompt": f"<think>{long_think}</think>\nShort answer."},
-            {"role": "user", "prompt": "Follow up"},
-        ] + [{"role": "user", "prompt": f"msg{i}"} for i in range(12)]
+            {"role": "assistant", "content": f"<think>{long_think}</think>\nShort answer."},
+            {"role": "user", "content": "Follow up"},
+        ] + [{"role": "user", "content": f"msg{i}"} for i in range(12)]
 
         # Force compression (counter divisible by 5)
         compress_history_tags._cd = 4
         result = compress_history_tags(messages, keep_recent=10, max_len=800)
         # The first message's <think> content should be truncated
-        first_content = result[0]["prompt"]
+        first_content = result[0]["content"]
         self.assertIn("<think>", first_content)
         self.assertIn("...", first_content)
         self.assertLess(len(first_content), len(f"<think>{long_think}</think>\nShort answer."))


### PR DESCRIPTION
## Problem

`tests/test_minimax.py::TestMiniMaxCompressHistoryTags::test_think_tag_compressed_in_old_messages`
constructs its message fixture with the key `\"prompt\"`:

```python
messages = [
    {"role": "assistant", "prompt": f"<think>{long_think}</think>\nShort answer."},
    {"role": "user", "prompt": "Follow up"},
] + [{"role": "user", "prompt": f"msg{i}"} for i in range(12)]
```

But `compress_history_tags` in `llmcore.py` reads `msg['content']`:

```python
# llmcore.py:38
c = msg['content']
```

So the function raises `KeyError: 'content'` on the first iteration of the
compression loop. The assertion line that the test was written to exercise
is never reached.

```
$ pytest tests/test_minimax.py::TestMiniMaxCompressHistoryTags -v
E   KeyError: 'content'
llmcore.py:38: KeyError
FAILED tests/test_minimax.py::TestMiniMaxCompressHistoryTags::test_think_tag_compressed_in_old_messages
```

## Fix

Replace `\"prompt\"` with `\"content\"` in the fixture and in the
post-compression lookup so the test actually runs the compression
code path it claims to verify.

```diff
         messages = [
-            {"role": "assistant", "prompt": f"<think>{long_think}</think>\nShort answer."},
-            {"role": "user", "prompt": "Follow up"},
-        ] + [{"role": "user", "prompt": f"msg{i}"} for i in range(12)]
+            {"role": "assistant", "content": f"<think>{long_think}</think>\nShort answer."},
+            {"role": "user", "content": "Follow up"},
+        ] + [{"role": "user", "content": f"msg{i}"} for i in range(12)]
         ...
-        first_content = result[0]["prompt"]
+        first_content = result[0]["content"]
```

## Verification

```
$ pytest tests/test_minimax.py::TestMiniMaxCompressHistoryTags -v
PASSED
```

The test now exercises the real `<think>` tag truncation path against
`compress_history_tags`, which is what the test name promises.