### PR TITLE
fix(scheduler): reject zero/negative interval in every_N cooldown parsing

### DIFF
--- a/reflect/scheduler.py
+++ b/reflect/scheduler.py
@@ -39,6 +39,7 @@ def _parse_cooldown(repeat):
         try:
             parts = repeat.split('_')
             n = int(parts[1].rstrip('hdm'))
+            if n <= 0: raise ValueError(f'positive interval required, got {n}')
             u = parts[1][-1]
             if u == 'h': return timedelta(hours=n)
             if u == 'm': return timedelta(minutes=n)


### PR DESCRIPTION
## Problem

After PR #76 (which fixed the `ValueError`/`IndexError` crashes from
malformed `every_*` repeat values), `_parse_cooldown('every_0h')` still
silently returns `timedelta(0)`:

```python
>>> _parse_cooldown('every_0h')
datetime.timedelta(0)
```

Inside `check()`, the cooldown gate is:

```python
last = _last_run(tid, done_files)
cooldown = _parse_cooldown(repeat)
if last and (now - last) < cooldown: continue
```

With `cooldown = timedelta(0)`, `(now - last) < cooldown` is False from the
first cycle onward, so the task fires on every 120-second scheduler tick
instead of every N hours. For a side-effectful prompt (e.g. anything that
posts a message, schedules another task, or triggers a code_run with
external calls) this is a runaway loop.

## Fix

Add a positive-interval guard inside the existing `try` block so the
malformed value falls through to the same warning + 20h fallback that
`every_h` and `every_xyz` already use:

```diff
     if repeat.startswith('every_'):
         try:
             parts = repeat.split('_')
             n = int(parts[1].rstrip('hdm'))
+            if n <= 0: raise ValueError(f'positive interval required, got {n}')
             u = parts[1][-1]
             if u == 'h': return timedelta(hours=n)
             if u == 'm': return timedelta(minutes=n)
             if u == 'd': return timedelta(days=n)
         except (ValueError, IndexError):
             pass  # fall through to warning below
```

This keeps the change radius local to `_parse_cooldown` and reuses PR #76's
existing fallback path; no new control flow is added.

## Verification

REPL on the patched function:

```
every_0h  -> 20:00:00            (fallback)
every_-1h -> 20:00:00            (fallback, ValueError raised by int())
every_h   -> 20:00:00            (fallback)
every_1h  -> 1:00:00
every_30m -> 0:30:00
once      -> 999999 days, 0:00:00
```

Builds on PR #76.