### PR TITLE
fix(llmcore): include temperature when provider required clamping

### DIFF
--- a/llmcore.py
+++ b/llmcore.py
@@ -256,8 +256,9 @@ def _openai_stream(api_base, api_key, messages, model, api_mode='chat_completion
                    max_retries=0, connect_timeout=10, read_timeout=300, proxies=None):
     """Shared OpenAI-compatible streaming request with retry. Yields text chunks, returns list[content_block]."""
     ml = model.lower()
-    if 'kimi' in ml or 'moonshot' in ml: temperature = 1
-    elif 'minimax' in ml: temperature = max(0.01, min(temperature, 1.0))  # MiniMax requires temp in (0, 1]
+    _force_temp = False
+    if 'kimi' in ml or 'moonshot' in ml: temperature, _force_temp = 1, True
+    elif 'minimax' in ml: temperature, _force_temp = max(0.01, min(temperature, 1.0)), True  # MiniMax requires temp in (0, 1]
     headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json", "Accept": "text/event-stream"}
     if api_mode == "responses":
         url = auto_make_url(api_base, "responses")
@@ -267,7 +268,7 @@ def _openai_stream(api_base, api_key, messages, model, api_mode='chat_completion
         url = auto_make_url(api_base, "chat/completions")
         _stamp_oai_cache_markers(messages, model)
         payload = {"model": model, "messages": messages, "stream": True, "stream_options": {"include_usage": True}}
-        if temperature != 1: payload["temperature"] = temperature
+        if _force_temp or temperature != 1: payload["temperature"] = temperature
         if max_tokens: payload["max_tokens"] = max_tokens
         if reasoning_effort: payload["reasoning_effort"] = reasoning_effort
     if tools:


### PR DESCRIPTION
## Problem

Commit f418963 (\"refactor: omit temperature from payload when default (1)\")
changed the chat/completions branch of `_openai_stream` to:

```python
if temperature != 1: payload[\"temperature\"] = temperature
```

This is correct for OpenAI-compatible endpoints in the general case, but
the same function also force-clamps temperature for two providers earlier:

```python
if 'kimi' in ml or 'moonshot' in ml: temperature = 1
elif 'minimax' in ml: temperature = max(0.01, min(temperature, 1.0))
```

After clamping, MiniMax with any input temperature `≥ 1` ends up with
`temperature = 1.0`, and Kimi/Moonshot always end up with `temperature = 1`.
Both then take the `temperature != 1` branch as False and the field is
**omitted** from the payload. The provider sees no temperature value,
which is a behavior change versus the pre-refactor code that always sent
the clamped value explicitly.

The existing unit tests catch this:

```
$ pytest tests/test_minimax.py::TestMiniMaxTemperatureClamping -v
FAILED ... test_minimax_temp_one_preserved      -- KeyError: 'temperature'
FAILED ... test_minimax_temp_above_one_clamped  -- KeyError: 'temperature'
FAILED ... test_kimi_temp_still_forced          -- KeyError: 'temperature'
```

## Fix

Track whether the provider branch explicitly forced/clamped the value, and
include `temperature` in the payload whenever it did:

```diff
     ml = model.lower()
-    if 'kimi' in ml or 'moonshot' in ml: temperature = 1
-    elif 'minimax' in ml: temperature = max(0.01, min(temperature, 1.0))
+    _force_temp = False
+    if 'kimi' in ml or 'moonshot' in ml: temperature, _force_temp = 1, True
+    elif 'minimax' in ml: temperature, _force_temp = max(0.01, min(temperature, 1.0)), True
     ...
-        if temperature != 1: payload[\"temperature\"] = temperature
+        if _force_temp or temperature != 1: payload[\"temperature\"] = temperature
```

This preserves the f418963 optimization for non-clamped providers while
restoring the explicit-temperature contract that Kimi/Moonshot/MiniMax
require. The Responses API branch is unchanged (it never sent
`temperature` in the first place).

## Verification

```
$ pytest tests/test_minimax.py::TestMiniMaxTemperatureClamping -v
============================== 8 passed in 0.37s ===============================
```

All three previously-failing temperature tests pass; the existing 5 passing
tests continue to pass.

## Note on conflict with #89

PR #89 also touches `_openai_stream` (RETRYABLE set). The two changes are
on different lines and should rebase cleanly either way; happy to rebase
this branch after #89 lands if preferred.