### PR TITLE
feat(wechat): add wechat_allowed_users gating, mirror QQ adapter pattern

### DIFF
--- a/frontends/wechatapp.py
+++ b/frontends/wechatapp.py
@@ -6,6 +6,10 @@ from Crypto.Cipher import AES
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 _TEMP_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'temp')
 from agentmain import GeneraticAgent
+from llmcore import mykeys
+from chatapp_common import public_access
+
+ALLOWED = {str(x).strip() for x in mykeys.get('wechat_allowed_users', []) if str(x).strip()}
 
 # ── WxBotClient (inline from wx_bot_client.py) ──
 API = 'https://ilinkai.weixin.qq.com'
@@ -233,6 +237,9 @@ def on_message(bot, msg):
     text = bot.extract_text(msg).strip()
     uid = msg.get('from_user_id', '')
     ctx = msg.get('context_token', '')
+    if not public_access(ALLOWED) and uid not in ALLOWED:
+        print(f'[WX] unauthorized user: {uid}', file=sys.__stdout__)
+        return
     media_paths = _dl_media(msg.get('item_list', []))
     if not text and not media_paths: return
     if media_paths:

--- a/mykey_template.py
+++ b/mykey_template.py
@@ -392,6 +392,7 @@ native_oai_config = {
 # wecom_secret = 'your_bot_secret'
 # wecom_allowed_users = ['your_user_id']            # 留空或 ['*'] 表示允许所有企业微信用户
 # wecom_welcome_message = '你好，我在线上。'
+# wechat_allowed_users = ['from_user_id']           # 留空或 ['*'] 表示允许所有微信用户
 # dingtalk_client_id = 'your_app_key'
 # dingtalk_client_secret = 'your_app_secret'
 # dingtalk_allowed_users = ['your_staff_id']        # 留空或 ['*'] 表示允许所有钉钉用户


### PR DESCRIPTION
Closes #95.

## Problem

`frontends/wechatapp.py` is the only chat adapter that does not look at
an allow-list. Every other adapter under `frontends/` reads
`<platform>_allowed_users` from `mykey.py` and rejects unknown senders:

| Adapter             | Allow-list key                       |
|---------------------|--------------------------------------|
| `tgapp.py`          | `tg_allowed_users` (non-empty required) |
| `fsapp.py`          | `fs_allowed_users`                   |
| `qqapp.py`          | `qq_allowed_users`                   |
| `dingtalkapp.py`    | `dingtalk_allowed_users`             |
| `wecomapp.py`       | `wecom_allowed_users`                |
| **`wechatapp.py`**  | **(none)**                           |

After `python frontends/wechatapp.py` scans the QR code, anyone who
messages the bound personal WeChat account drives the agent — every
tool the agent has (`code_run`, `file_read`, `file_write`, web control)
is reachable to any contact, with no logging or rejection path.

## Fix

Mirror the QQ adapter pattern that PR #25 established:

```python
ALLOWED = {str(x).strip() for x in mykeys.get('wechat_allowed_users', []) if str(x).strip()}
...
if not public_access(ALLOWED) and uid not in ALLOWED:
    print(f'[WX] unauthorized user: {uid}', file=sys.__stdout__)
    return
```

Three deliberate decisions:

1. **Reuse `chatapp_common.public_access()`** rather than inlining
   `not allowed or '*' in allowed`, so the semantics stay locked to
   the same definition the other adapters use. If `public_access`
   ever changes, wechat picks it up for free.
2. **Default behavior is unchanged** — existing setups that don't set
   `wechat_allowed_users` get `ALLOWED == set()`, `public_access()`
   returns True, and every message still reaches the agent. This
   matches `qq`/`dingtalk`/`wecom`/`fs` exactly. (Telegram is the
   stricter exception that hard-fails on empty; not adopted here to
   avoid breaking existing wechat installs without warning.)
3. **Log line format** matches `qq`/`dingtalk`: `[WX] unauthorized
   user: <uid>`, so a user grepping `temp/wechatapp.log` sees the
   same shape as the other adapters' logs.

`mykey_template.py` gets the matching `# wechat_allowed_users = ['from_user_id']`
comment line in the existing chat-platform block so the option is
discoverable.

## Verification

- `python -m py_compile frontends/wechatapp.py mykey_template.py` — passes.
- Existing wechat installs (no `wechat_allowed_users` in mykey) keep working
  unchanged because `ALLOWED` is empty → `public_access(ALLOWED)` is True
  → the new check is skipped.
- New installs that opt in via `wechat_allowed_users = ['<from_user_id>']`
  get the same allow-list semantics as `qqapp.py` (uid must be in the set).

Diff size: +8 / -0 across 2 files.