### PR TITLE
add: right-click of changing skin for desktop pet 

### DIFF
--- a/frontends/desktop_pet_v2.pyw
+++ b/frontends/desktop_pet_v2.pyw
@@ -307,6 +307,7 @@ if sys.platform == 'darwin':
 
             # Load skin
             self.load_skin(skin_name)
+            self.available_skins = SkinLoader.list_skins()
 
             # Get screen size
             from AppKit import NSScreen, NSWindowCollectionBehaviorCanJoinAllSpaces, NSWindowCollectionBehaviorStationary
@@ -391,6 +392,29 @@ if sys.platform == 'darwin':
                 def acceptsFirstMouse_(self, event):
                     """Accept first mouse click"""
                     return True
+
+                def rightMouseDown_(self, event):
+                    from AppKit import NSMenu, NSMenuItem, NSApp
+
+                    menu = NSMenu.alloc().init()
+                    pet = self.window().delegate()  # Assuming the window’s delegate is MacPet instance
+
+                    for skin_name in pet.available_skins:  # preload this in MacPet.__init__
+                        item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+                            skin_name,
+                            'changeSkin:',
+                            ''
+                        )
+                        item.setTarget_(pet)
+                        item.setRepresentedObject_(skin_name)
+                        menu.addItem_(item)
+
+                    menu.addItem_(NSMenuItem.separatorItem())
+                    quit_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_('Quit', 'terminate:', '')
+                    menu.addItem_(quit_item)
+
+                    NSApp.activateIgnoringOtherApps_(True)
+                    NSMenu.popUpContextMenu_withEvent_forView_(menu, event, self)
 
             # Create draggable view
             self.content_view = DraggableImageView.alloc().initWithFrame_(
@@ -587,6 +611,13 @@ if sys.platform == 'darwin':
         def run(self):
             """Run the application"""
             AppHelper.runEventLoop()
+        
+        def changeSkin_(self, sender):
+            skin_name = sender.representedObject()
+            print(f"Changing skin to: {skin_name}")
+            self.load_skin(skin_name)
+            self.current_state = 'idle'
+            self.frame_idx = 0
 
 # ============================================================================
 # Windows Implementation - tkinter with transparentcolor
@@ -626,6 +657,7 @@ else:
             self.label.bind('<Button-1>', lambda e: setattr(self, '_d', (e.x, e.y)))
             self.label.bind('<B1-Motion>', self._drag)
             self.label.bind('<Double-1>', lambda e: (self.root.destroy(), os._exit(0)))
+            self.label.bind('<Button-3>', self._on_right_click)
 
             # Animation state
             self.current_state = 'idle'
@@ -765,6 +797,24 @@ else:
         def run(self):
             """Run the application (already in mainloop)"""
             pass
+        
+        def _on_right_click(self, event):
+            # Build a dynamic menu of all available skins
+            menu = tk.Menu(self.root, tearoff=0)
+            for skin_name in SkinLoader.list_skins():
+                menu.add_command(
+                    label=skin_name,
+                    command=lambda name=skin_name: self._change_skin(name)
+                )
+            menu.add_separator()
+            menu.add_command(label="Quit", command=lambda: (self.root.destroy(), os._exit(0)))
+            menu.tk_popup(event.x_root, event.y_root)
+
+        def _change_skin(self, skin_name):
+            print(f"Changing skin to: {skin_name}")
+            self.load_skin(skin_name)
+            self.current_state = 'idle'
+            self.frame_idx = 0
 
 if __name__ == '__main__':
     # Singleton: if port already in use, another instance is running

--- a/frontends/skins/boy/skin.json
+++ b/frontends/skins/boy/skin.json
@@ -7,8 +7,8 @@
   "style": "pixel",
   "format": "sprite",
   "size": {
-    "width": 40,
-    "height": 61
+    "width": 80,
+    "height": 122
   },
   "animations": {
     "idle": {

--- a/frontends/skins/dinosaur/skin.json
+++ b/frontends/skins/dinosaur/skin.json
@@ -6,7 +6,7 @@
   "description": "像素风小恐龙 Dinosaur",
   "style": "pixel",
   "format": "sprite",
-  "size": { "width": 64, "height": 64 },
+  "size": { "width": 128, "height": 128 },
   "animations": {
     "idle": {
       "file": "skin.png",

--- a/frontends/skins/doux/skin.json
+++ b/frontends/skins/doux/skin.json
@@ -7,7 +7,7 @@
   "description": "像素风小恐龙 Doux",
   "style": "pixel",
   "format": "sprite",
-  "size": { "width": 48, "height": 48 },
+  "size": { "width": 128, "height": 128 },
   "animations": {
     "idle": {
       "file": "skin.png",

--- a/frontends/skins/line/skin.json
+++ b/frontends/skins/line/skin.json
@@ -6,7 +6,7 @@
   "description": "Line 角色皮肤",
   "style": "pixel",
   "format": "sprite",
-  "size": { "width": 39, "height": 46 },
+  "size": { "width": 128, "height": 128 },
   "animations": {
     "idle": {
       "file": "skin.png",

--- a/frontends/skins/mort/skin.json
+++ b/frontends/skins/mort/skin.json
@@ -7,7 +7,7 @@
   "description": "像素风小恐龙 Mort",
   "style": "pixel",
   "format": "sprite",
-  "size": { "width": 48, "height": 48 },
+  "size": { "width": 128, "height": 128 },
   "animations": {
     "idle": {
       "file": "skin.png",

--- a/frontends/skins/tard/skin.json
+++ b/frontends/skins/tard/skin.json
@@ -7,7 +7,7 @@
   "description": "像素风小恐龙 Tard",
   "style": "pixel",
   "format": "sprite",
-  "size": { "width": 48, "height": 48 },
+  "size": { "width": 128, "height": 128 },
   "animations": {
     "idle": {
       "file": "skin.png",


### PR DESCRIPTION
Hi, I'm Keeper, I was totally shocked by this amazing program. 

I read the _Frontends_ logic and add a new function of changing skin for the desktop pet, which is mentioned in the _DESKTOP_PET_README.md_ though missing the logic. XD

It works perfectly in my computer (windows11, python 3.12), please consider to merge this function.  :)

<img width="200" height="236" alt="1-1" src="https://github.com/user-attachments/assets/939c1a03-fe80-4dc6-9495-94246d591641" />
<img width="203" height="247" alt="1-2" src="https://github.com/user-attachments/assets/1554a3f4-8e4f-4541-9d60-8b3f60b12dc8" />
<img width="272" height="264" alt="1-3" src="https://github.com/user-attachments/assets/70c56ff4-5fd7-45f9-a0e0-b8dbd442f36c" />
