### PR TITLE
docs: add issue and PR templates for contribution hygiene

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Report a reproducible issue
+labels: bug
+---
+
+## Summary
+A clear and concise description of the bug.
+
+## Environment
+- OS:
+- Python version:
+- GenericAgent commit/version:
+- Model/provider:
+
+## Steps To Reproduce
+1.
+2.
+3.
+
+## Expected Behavior
+What should happen.
+
+## Actual Behavior
+What actually happens.
+
+## Logs / Screenshots
+Paste relevant logs or screenshots.
+
+## Additional Context
+Anything else that helps reproduction.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Propose an improvement
+labels: enhancement
+---
+
+## Problem
+What user pain or workflow issue does this solve?
+
+## Proposed Solution
+Describe the expected behavior and UX.
+
+## Alternatives Considered
+Any other options considered.
+
+## Scope
+- [ ] Docs only
+- [ ] Small code change
+- [ ] Cross-module change
+
+## Success Criteria
+How we can verify this feature is done.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+Describe what this PR changes and why.
+
+## Related Issue
+Closes #
+
+## Type of Change
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Tests
+
+## Validation
+- [ ] I ran relevant tests/checks locally
+- [ ] I verified no obvious regressions
+- [ ] I updated docs when behavior changed
+
+## Notes for Reviewers
+Anything reviewers should pay attention to.


### PR DESCRIPTION
## Summary
This PR adds baseline collaboration templates so new issues and pull requests are easier to triage and reproduce.

## What changed
- Added .github/ISSUE_TEMPLATE/bug_report.md
- Added .github/ISSUE_TEMPLATE/feature_request.md
- Added .github/PULL_REQUEST_TEMPLATE.md

## Why
Issue #64 requests contributor-friendliness improvements (templates/standards/CI direction). This PR focuses on the lowest-friction first step: standardizing incoming issue and PR quality.

## Notes
- This is intentionally lightweight and non-breaking.
- It can be followed by CI/lint policy improvements in a separate PR.

Closes #64