### PR TITLE
feat: NativeClaudeSession 在 fake_cc_system_prompt 模式下支持可选 CCH 签名

### DIFF
--- a/llmcore.py
+++ b/llmcore.py
@@ -85,6 +85,14 @@ def trim_messages_history(history, context_win):
             cost = sum(len(json.dumps(m, ensure_ascii=False)) for m in history)
         print(f'[Debug] Trimmed context, current: {cost} chars, {len(history)} messages.')
 
+try: from xxhash import xxh64 as _xxh64
+except ImportError: _xxh64 = None
+
+def _cc_serialize(payload):
+    body = json.dumps(payload, ensure_ascii=False, separators=(',', ':')).encode('utf-8')
+    if not _xxh64 or b'cch=00000;' not in body: return body
+    return body.replace(b'cch=00000;', ('cch=%05x;' % (_xxh64(body, seed=0x6E52736AC806831E).intdigest() & 0xFFFFF)).encode(), 1)
+
 def auto_make_url(base, path):
     b, p = base.rstrip('/'), path.strip('/')
     if b.endswith('$'): return b[:-1].rstrip('/')
@@ -541,16 +549,17 @@ class NativeClaudeSession(BaseSession):
             tools = [dict(t) for t in claude_tools]; tools[-1]["cache_control"] = {"type": "ephemeral"}
             payload["tools"] = tools
         else: print("[ERROR] No tools provided for this session.")
-        payload['system'] = [{"type": "text", "text": "You are Claude Code, Anthropic's official CLI for Claude.", "cache_control": {"type": "ephemeral"}}]
+        payload['system'] = [{"type": "text", "text": "x-anthropic-billing-header: cc_version=2.1.90.527; cc_entrypoint=cli; cch=00000;"},
+            {"type": "text", "text": "You are Claude Code, Anthropic's official CLI for Claude.", "cache_control": {"type": "ephemeral"}}]
         if self.system:
             if self.fake_cc_system_prompt: messages[0]["content"].insert(0, {"type": "text", "text": self.system})
-            else: payload["system"] = [{"type": "text", "text": self.system}]
+            else: payload["system"][1] = {"type": "text", "text": self.system, "cache_control": {"type": "ephemeral"}}
         user_idxs = [i for i, m in enumerate(messages) if m['role'] == 'user']
         for idx in user_idxs[-2:]:
             messages[idx] = {**messages[idx], "content": list(messages[idx]["content"])}
             messages[idx]["content"][-1] = dict(messages[idx]["content"][-1], cache_control={"type": "ephemeral"})
         try:
-            with requests.post(auto_make_url(self.api_base, "messages")+'?beta=true', headers=headers, json=payload, stream=self.stream, timeout=(self.connect_timeout, self.read_timeout)) as resp:
+            with requests.post(auto_make_url(self.api_base, "messages")+'?beta=true', headers=headers, data=_cc_serialize(payload), stream=self.stream, timeout=(self.connect_timeout, self.read_timeout)) as resp:
                 if resp.status_code != 200: raise Exception(f"HTTP {resp.status_code} {resp.content.decode('utf-8', errors='replace')[:500]}")
                 if self.stream: return (yield from _parse_claude_sse(resp.iter_lines())) or []
                 else:

--- a/mykey_template.py
+++ b/mykey_template.py
@@ -107,6 +107,10 @@
 #                   默认 False。关键字段：**所有反代/镜像 Claude Code 协议的渠道
 #                   都必须置 True**（CC switch、anyrouter、claude-relay-service
 #                   等）。真 Anthropic 端点（sk-ant-）不需要开。
+#
+#   CCH 签名        部分代理会校验 Claude Code 客户端身份（CCH）。安装 xxhash
+#                   （pip install xxhash）后自动启用签名；未安装则跳过，不影响
+#                   不校验 CCH 的渠道。
 # ══════════════════════════════════════════════════════════════════════════════
 
 


### PR DESCRIPTION
## 说明

本 PR 为 `NativeClaudeSession` 在 `fake_cc_system_prompt` 模式下补充可选的 CCH 签名支持，以兼容会校验 Claude Code 客户端身份的代理。

当前已有的 `fake_cc_system_prompt` 逻辑主要用于模拟 Claude Code 请求形态；但对于进一步校验 CCH 的代理，仅伪装 system prompt 仍不足以通过校验。本改动在不扩大影响范围的前提下，补齐这一路径所需的签名步骤。

## 改动

在 `llmcore.py` 中新增 `_cc_serialize(payload)`，用于：
- 将 payload 序列化为稳定的 JSON bytes
- 在存在 `cch=00000;` 占位符且安装了 `xxhash` 时计算并回填 CCH
- 在 `fake_cc_system_prompt` 路径下补充 Claude Code 风格的 header block
- 将请求发送方式从 `json=payload` 调整为 `data=_cc_serialize(payload)`，确保签名内容与实际发送字节一致
- 在 `mykey_template.py` 中补充 `xxhash` 为可选依赖的说明

## 兼容性

- 仅影响 `NativeClaudeSession`
- 且仅在 `fake_cc_system_prompt` 启用时生效
- 未安装 `xxhash` 时保持兼容降级
- 其他 session 类型不受影响
- **真 Anthropic 端点（`sk-ant-*`）不启用 `fake_cc_system_prompt`，不会进入本 PR 的代码路径，行为与 main 完全一致**

## 测试

- [x] 未安装 `xxhash` 时，原有行为保持一致
- [x] 安装 `xxhash` 后，可通过校验 CCH 的 Claude Code 兼容代理
- [ ] 未对真 Anthropic 端点单独验证；该路径不受本 PR 影响（见"兼容性"）

Closes #106