### PR TITLE
feat: add auto-follow supervisor with auto-stop

### DIFF
--- a/agentmain.py
+++ b/agentmain.py
@@ -39,29 +39,32 @@ def get_system_prompt():
     prompt += get_global_memory()
     return prompt
 
+def build_llm_clients():
+    from llmcore import mykeys
+    llm_sessions = []
+    for k, cfg in mykeys.items():
+        if not any(x in k for x in ['api', 'config', 'cookie']): continue
+        try:
+            if 'native' in k and 'claude' in k: llm_sessions += [NativeToolClient(NativeClaudeSession(cfg=cfg))]
+            elif 'native' in k and 'oai' in k: llm_sessions += [NativeToolClient(NativeOAISession(cfg=cfg))]
+            elif 'claude' in k: llm_sessions += [ToolClient(ClaudeSession(cfg=cfg))]
+            elif 'oai' in k: llm_sessions += [ToolClient(LLMSession(cfg=cfg))]
+            elif 'mixin' in k: llm_sessions += [{'mixin_cfg': cfg}]
+        except: pass
+    for i, s in enumerate(llm_sessions):
+        if isinstance(s, dict) and 'mixin_cfg' in s:
+            try:
+                mixin = MixinSession(llm_sessions, s['mixin_cfg'])
+                if isinstance(mixin._sessions[0], (NativeClaudeSession, NativeOAISession)): llm_sessions[i] = NativeToolClient(mixin)
+                else: llm_sessions[i] = ToolClient(mixin)
+            except Exception as e: print(f'[WARN] Failed to init MixinSession with cfg {s["mixin_cfg"]}: {e}')
+    return llm_sessions
+
 class GeneraticAgent:
     def __init__(self):
         script_dir = os.path.dirname(os.path.abspath(__file__))
         os.makedirs(os.path.join(script_dir, 'temp'), exist_ok=True)
-        from llmcore import mykeys
-        llm_sessions = []
-        for k, cfg in mykeys.items():
-            if not any(x in k for x in ['api', 'config', 'cookie']): continue
-            try:
-                if 'native' in k and 'claude' in k: llm_sessions += [NativeToolClient(NativeClaudeSession(cfg=cfg))]
-                elif 'native' in k and 'oai' in k: llm_sessions += [NativeToolClient(NativeOAISession(cfg=cfg))]
-                elif 'claude' in k: llm_sessions += [ToolClient(ClaudeSession(cfg=cfg))]
-                elif 'oai' in k: llm_sessions += [ToolClient(LLMSession(cfg=cfg))]
-                elif 'mixin' in k: llm_sessions += [{'mixin_cfg': cfg}]
-            except: pass
-        for i, s in enumerate(llm_sessions):
-            if isinstance(s, dict) and 'mixin_cfg' in s:
-                try:
-                    mixin = MixinSession(llm_sessions, s['mixin_cfg'])
-                    if isinstance(mixin._sessions[0], (NativeClaudeSession, NativeOAISession)): llm_sessions[i] = NativeToolClient(mixin)
-                    else: llm_sessions[i] = ToolClient(mixin)
-                except Exception as e: print(f'[WARN] Failed to init MixinSession with cfg {s["mixin_cfg"]}: {e}')
-        self.llmclients = llm_sessions
+        self.llmclients = build_llm_clients()
         self.lock = threading.Lock()
         self.task_dir = None
         self.history = []

--- a/frontends/stapp.py
+++ b/frontends/stapp.py
@@ -35,9 +35,49 @@ st.title("🖥️ Cowork")
 if 'autonomous_enabled' not in st.session_state: st.session_state.autonomous_enabled = False
 if 'auto_reply_enabled' not in st.session_state: st.session_state.auto_reply_enabled = False
 if 'auto_cycle_enabled' not in st.session_state: st.session_state.auto_cycle_enabled = False
+if 'auto_follow_enabled' not in st.session_state:
+    st.session_state.auto_follow_enabled = bool(
+        st.session_state.auto_reply_enabled or st.session_state.auto_cycle_enabled
+    )
 if 'auto_stop_on_done_enabled' not in st.session_state: st.session_state.auto_stop_on_done_enabled = False
 if 'last_prompt' not in st.session_state: st.session_state.last_prompt = ''
 if 'streaming' not in st.session_state: st.session_state.streaming = False
+
+def set_auto_follow(enabled):
+    enabled = bool(enabled)
+    st.session_state.auto_follow_enabled = enabled
+    st.session_state.auto_reply_enabled = enabled
+    st.session_state.auto_cycle_enabled = enabled
+
+set_auto_follow(st.session_state.auto_follow_enabled)
+
+def _parse_json_dict(text):
+    text = (text or '').strip()
+    if not text:
+        return {}
+    try:
+        data = json.loads(text)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+def extract_ask_user_payload(output_text):
+    text = output_text or ''
+    inline_matches = re.findall(r'ask_user\((\{.*?\})\)', text, flags=re.DOTALL)
+    for snippet in reversed(inline_matches):
+        payload = _parse_json_dict(snippet)
+        if payload.get('question'):
+            return payload
+    block_matches = re.findall(
+        r'Tool:\s*`ask_user`.*?`{3,}(?:text|json)?\s*(\{.*?\})\s*`{3,}',
+        text,
+        flags=re.DOTALL,
+    )
+    for snippet in reversed(block_matches):
+        payload = _parse_json_dict(snippet)
+        if payload.get('question'):
+            return payload
+    return {}
 
 @st.fragment
 def render_sidebar():
@@ -80,15 +120,11 @@ def render_sidebar():
         st.toast("桌面宠物已启动")
 
     st.divider()
-    auto_reply = st.checkbox("自动代答 ask_user", value=st.session_state.auto_reply_enabled, help="当 Agent 主动提问或一轮结束后，自动生成下一条输入继续推进")
-    if auto_reply != st.session_state.auto_reply_enabled:
-        st.session_state.auto_reply_enabled = auto_reply
-        st.toast("已开启自动代答" if auto_reply else "已关闭自动代答"); st.rerun()
-    auto_cycle = st.checkbox("自动续跑", value=st.session_state.auto_cycle_enabled, help="兼容旧开关；开启后也会在一轮结束后自动继续")
-    if auto_cycle != st.session_state.auto_cycle_enabled:
-        st.session_state.auto_cycle_enabled = auto_cycle
-        st.toast("已开启自动续跑" if auto_cycle else "已关闭自动续跑"); st.rerun()
-    auto_stop = st.checkbox("完成后自动停", value=st.session_state.auto_stop_on_done_enabled, help="由监督模型判断任务已完成后自动关闭自动代答和自动续跑")
+    auto_follow = st.checkbox("自动跟进（代答 + 续跑）", value=st.session_state.auto_follow_enabled, help="Agent 主动 ask_user 时自动代答；一轮结束后自动生成下一条输入继续推进。")
+    if auto_follow != st.session_state.auto_follow_enabled:
+        set_auto_follow(auto_follow)
+        st.toast("已开启自动跟进" if auto_follow else "已关闭自动跟进"); st.rerun()
+    auto_stop = st.checkbox("完成后自动停", value=st.session_state.auto_stop_on_done_enabled, help="由监督模型判断任务已完成后自动关闭自动跟进")
     if auto_stop != st.session_state.auto_stop_on_done_enabled:
         st.session_state.auto_stop_on_done_enabled = auto_stop
         st.toast("已开启完成后自动停" if auto_stop else "已关闭完成后自动停"); st.rerun()
@@ -241,14 +277,19 @@ if st.session_state.autonomous_enabled:
     st.markdown(f"""<div id="last-reply-time" style="display:none">{st.session_state.get('last_reply_time', int(time.time()))}</div>""", unsafe_allow_html=True)
 
 last_assistant = next((m["content"] for m in reversed(st.session_state.messages) if m["role"] == "assistant"), "")
+last_ask_user = extract_ask_user_payload(last_assistant)
+assistant_revision = sum(1 for m in st.session_state.messages if m["role"] == "assistant")
 st.markdown(
     f"""
     <div id="last-user-prompt" style="display:none">{html.escape(st.session_state.get('last_prompt', ''))}</div>
     <div id="last-assistant-reply" style="display:none">{html.escape(last_assistant)}</div>
+    <div id="assistant-revision" style="display:none">{assistant_revision}</div>
+    <div id="last-ask-user-payload" style="display:none">{html.escape(json.dumps(last_ask_user, ensure_ascii=False))}</div>
     <div id="streaming-flag" style="display:none">{1 if st.session_state.get('streaming', False) else 0}</div>
     <div id="autonomous-enabled" style="display:none">{1 if st.session_state.get('autonomous_enabled', False) else 0}</div>
-    <div id="auto-reply-enabled" style="display:none">{1 if st.session_state.get('auto_reply_enabled', False) else 0}</div>
-    <div id="auto-cycle-enabled" style="display:none">{1 if st.session_state.get('auto_cycle_enabled', False) else 0}</div>
+    <div id="auto-follow-enabled" style="display:none">{1 if st.session_state.get('auto_follow_enabled', False) else 0}</div>
+    <div id="auto-reply-enabled" style="display:none">{1 if st.session_state.get('auto_follow_enabled', False) else 0}</div>
+    <div id="auto-cycle-enabled" style="display:none">{1 if st.session_state.get('auto_follow_enabled', False) else 0}</div>
     <div id="auto-stop-on-done-enabled" style="display:none">{1 if st.session_state.get('auto_stop_on_done_enabled', False) else 0}</div>
     """,
     unsafe_allow_html=True

--- a/frontends/stapp.py
+++ b/frontends/stapp.py
@@ -1,4 +1,4 @@
-import os, sys, subprocess
+import os, sys, subprocess, html
 from urllib.request import urlopen
 from urllib.parse import quote
 if sys.stdout is None: sys.stdout = open(os.devnull, "w")
@@ -33,6 +33,11 @@ agent = init()
 st.title("🖥️ Cowork")
 
 if 'autonomous_enabled' not in st.session_state: st.session_state.autonomous_enabled = False
+if 'auto_reply_enabled' not in st.session_state: st.session_state.auto_reply_enabled = False
+if 'auto_cycle_enabled' not in st.session_state: st.session_state.auto_cycle_enabled = False
+if 'auto_stop_on_done_enabled' not in st.session_state: st.session_state.auto_stop_on_done_enabled = False
+if 'last_prompt' not in st.session_state: st.session_state.last_prompt = ''
+if 'streaming' not in st.session_state: st.session_state.streaming = False
 
 @st.fragment
 def render_sidebar():
@@ -73,8 +78,21 @@ def render_sidebar():
             if ctx.get('exit_reason'): _pet_req('state=idle')
         agent._turn_end_hooks['pet'] = _pet_hook
         st.toast("桌面宠物已启动")
-    
+
     st.divider()
+    auto_reply = st.checkbox("自动代答 ask_user", value=st.session_state.auto_reply_enabled, help="当 Agent 主动提问或一轮结束后，自动生成下一条输入继续推进")
+    if auto_reply != st.session_state.auto_reply_enabled:
+        st.session_state.auto_reply_enabled = auto_reply
+        st.toast("已开启自动代答" if auto_reply else "已关闭自动代答"); st.rerun()
+    auto_cycle = st.checkbox("自动续跑", value=st.session_state.auto_cycle_enabled, help="兼容旧开关；开启后也会在一轮结束后自动继续")
+    if auto_cycle != st.session_state.auto_cycle_enabled:
+        st.session_state.auto_cycle_enabled = auto_cycle
+        st.toast("已开启自动续跑" if auto_cycle else "已关闭自动续跑"); st.rerun()
+    auto_stop = st.checkbox("完成后自动停", value=st.session_state.auto_stop_on_done_enabled, help="由监督模型判断任务已完成后自动关闭自动代答和自动续跑")
+    if auto_stop != st.session_state.auto_stop_on_done_enabled:
+        st.session_state.auto_stop_on_done_enabled = auto_stop
+        st.toast("已开启完成后自动停" if auto_stop else "已关闭完成后自动停"); st.rerun()
+
     if st.button("开始空闲自主行动"):
         st.session_state.last_reply_time = int(time.time()) - 1800
         st.toast("已将上次回复时间设为1800秒前"); st.rerun()
@@ -195,6 +213,8 @@ if prompt := st.chat_input("any task?"):
             {"role": "assistant", "content": handle_frontend_command(agent, cmd), "time": ts},
         ]
         _reset_and_rerun()
+    st.session_state.last_prompt = prompt
+    st.session_state.streaming = True
     st.session_state.messages.append({"role": "user", "content": prompt})
     if hasattr(agent, '_pet_req') and not prompt.startswith('/'): agent._pet_req('state=walk')
     with st.chat_message("user"): st.markdown(prompt)
@@ -215,6 +235,21 @@ if prompt := st.chat_input("any task?"):
             if i < len(segs) - 1: live = st.empty()
     st.session_state.messages.append({"role": "assistant", "content": response})
     st.session_state.last_reply_time = int(time.time())
+    st.session_state.streaming = False
 
 if st.session_state.autonomous_enabled:
     st.markdown(f"""<div id="last-reply-time" style="display:none">{st.session_state.get('last_reply_time', int(time.time()))}</div>""", unsafe_allow_html=True)
+
+last_assistant = next((m["content"] for m in reversed(st.session_state.messages) if m["role"] == "assistant"), "")
+st.markdown(
+    f"""
+    <div id="last-user-prompt" style="display:none">{html.escape(st.session_state.get('last_prompt', ''))}</div>
+    <div id="last-assistant-reply" style="display:none">{html.escape(last_assistant)}</div>
+    <div id="streaming-flag" style="display:none">{1 if st.session_state.get('streaming', False) else 0}</div>
+    <div id="autonomous-enabled" style="display:none">{1 if st.session_state.get('autonomous_enabled', False) else 0}</div>
+    <div id="auto-reply-enabled" style="display:none">{1 if st.session_state.get('auto_reply_enabled', False) else 0}</div>
+    <div id="auto-cycle-enabled" style="display:none">{1 if st.session_state.get('auto_cycle_enabled', False) else 0}</div>
+    <div id="auto-stop-on-done-enabled" style="display:none">{1 if st.session_state.get('auto_stop_on_done_enabled', False) else 0}</div>
+    """,
+    unsafe_allow_html=True
+)

--- a/launch.pyw
+++ b/launch.pyw
@@ -1,9 +1,20 @@
-import webview, threading, subprocess, sys, time, os, ctypes, atexit, socket, random
+import webview, threading, subprocess, sys, time, os, ctypes, atexit, socket, random, re, traceback
+
+from agentmain import build_llm_clients
+from self_supervisor import AutoReplySupervisor
 
 WINDOW_WIDTH, WINDOW_HEIGHT, RIGHT_PADDING, TOP_PADDING = 600, 900, 0, 100
+AUTO_IDLE_SECONDS = 1800
+AUTO_MIN_INTERVAL_SECONDS = 12
+ASK_USER_PATTERNS = (
+    'waiting for your answer', 'ask_user', 'please provide input', 'need your input', 'which option',
+    '请提供输入', '请选择', '请你确认', '需要你', '请回答', '请先确认', '请先回复', '请回复', '请回复我',
+    '你想要', '你希望', '是否需要', '先确认 3 个问题',
+)
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
 frontends_dir = os.path.join(script_dir, "frontends")
+window = None
 
 def find_free_port(lo=18501, hi=18599):
     ports = list(range(lo, hi+1)); random.shuffle(ports)
@@ -23,6 +34,7 @@ def start_streamlit(port):
     atexit.register(proc.kill)
 
 def inject(text):
+    if window is None: return
     window.evaluate_js(f"""
         const textarea = document.querySelector('textarea[data-testid="stChatInputTextArea"]');
         if (textarea) {{
@@ -36,31 +48,117 @@ def inject(text):
             // 4. 延迟提交
             setTimeout(() => {{
                 const btn = document.querySelector('[data-testid="stChatInputSubmitButton"]');
-                if (btn) {{btn.click();console.log('Submitted:', {repr(text)});}}
+                if (btn) btn.click();
             }}, 200);
         }}""")
 
-def get_last_reply_time():
-    last = window.evaluate_js("""
-        const el = document.getElementById('last-reply-time');
-        el ? parseInt(el.textContent) : 0;
-    """) or 0
-    return last or int(time.time())
+def get_ui_state():
+    if window is None: return {}
+    raw_state = window.evaluate_js("""
+        (() => {
+            const txt = (id) => {
+                const el = document.getElementById(id);
+                return el ? (el.textContent || '') : '';
+            };
+            return {
+                last_reply_time: parseInt(txt('last-reply-time') || '0') || 0,
+                last_user_prompt: txt('last-user-prompt'),
+                last_assistant_reply: txt('last-assistant-reply'),
+                streaming: txt('streaming-flag') === '1',
+                autonomous_enabled: txt('autonomous-enabled') === '1',
+                auto_reply_enabled: txt('auto-reply-enabled') === '1',
+                auto_cycle_enabled: txt('auto-cycle-enabled') === '1',
+                auto_stop_on_done_enabled: txt('auto-stop-on-done-enabled') === '1'
+            };
+        })();
+    """)
+    if raw_state is None:
+        return {}
+    if isinstance(raw_state, dict): return dict(raw_state)
+    try: return dict(raw_state)
+    except Exception: return {}
 
-def idle_monitor():
+def looks_like_ask_user(text):
+    lowered = (text or '').lower()
+    if any(p in lowered for p in ASK_USER_PATTERNS): return True
+    stripped = (text or '').strip()
+    if not stripped: return False
+    if stripped.count('?') + stripped.count('？') >= 2: return True
+    if len(re.findall(r'^\s*(?:\d+[\.\u3001\)]|[-*])\s+.+(?:\?|\uFF1F|[:\uFF1A])\s*$', stripped, re.M)) >= 2: return True
+    return any(p in stripped for p in ('请先提问', '请先确认', '先确认', '先回答', '请回答', '问题'))
+
+def set_ui_toggle(label_text, enabled):
+    if window is None: return
+    target = 'true' if enabled else 'false'
+    window.evaluate_js(f"""
+        (() => {{
+            const labels = [...document.querySelectorAll('label')];
+            const label = labels.find(el => (el.textContent || '').includes({repr(label_text)}));
+            const input = label ? label.querySelector('input[type="checkbox"]') : null;
+            if (!input) return false;
+            if (input.checked === {target}) return true;
+            input.click();
+            return true;
+        }})();""")
+
+def disable_auto_followups():
+    set_ui_toggle("自动代答 ask_user", False)
+    set_ui_toggle("自动续跑", False)
+
+def idle_monitor(supervisor):
     last_trigger_time = 0
+    last_handled_reply = ''
     while True:
         time.sleep(5)
         try:
             now = time.time()
-            if now - last_trigger_time < 120: continue
-            last_reply = get_last_reply_time()
-            if now - last_reply > 1800:
-                print('[Idle Monitor] Detected idle state, injecting task...')
-                inject("[AUTO]🤖 用户已经离开超过30分钟，作为自主智能体，请阅读自动化sop，执行自动任务。")
-                last_trigger_time = now
+            if now - last_trigger_time < AUTO_MIN_INTERVAL_SECONDS: continue
+            state = get_ui_state()
+            if not isinstance(state, dict) or not state: continue
+            gs = lambda k, default=None: state[k] if k in state else default
+            if gs('streaming'): continue
+            last_reply = gs('last_reply_time', 0) or int(time.time())
+            last_user_prompt = gs('last_user_prompt', '')
+            last_assistant_reply = gs('last_assistant_reply', '')
+            autonomous_enabled = gs('autonomous_enabled', False)
+            auto_reply_enabled = gs('auto_reply_enabled', False)
+            auto_cycle_enabled = gs('auto_cycle_enabled', False)
+            auto_stop_on_done_enabled = gs('auto_stop_on_done_enabled', False)
+            auto_follow_enabled = auto_reply_enabled or auto_cycle_enabled
+            if not last_assistant_reply or last_assistant_reply == last_handled_reply:
+                if autonomous_enabled and now - last_reply > AUTO_IDLE_SECONDS:
+                    print('[Idle Monitor] Detected idle state, injecting task...')
+                    inject("[AUTO]🤖 用户已经离开超过30分钟，作为自主智能体，请阅读自动化sop，执行自动任务。")
+                    last_trigger_time = now
+                continue
+            if supervisor is not None and auto_stop_on_done_enabled:
+                should_stop, stop_reason = supervisor.should_auto_stop(last_user_prompt, last_assistant_reply)
+                if should_stop:
+                    print(f'[Idle Monitor] AI decided to stop auto followups: {stop_reason}')
+                    disable_auto_followups()
+                    last_trigger_time = now
+                    last_handled_reply = last_assistant_reply
+                    continue
+            if supervisor is not None and auto_reply_enabled and looks_like_ask_user(last_assistant_reply):
+                generated, reason = supervisor.generate_next_input(last_user_prompt, last_assistant_reply, None)
+                if generated:
+                    print(f'[UI AutoReply/{reason}] {generated[:100]}')
+                    inject(generated)
+                    last_trigger_time = now
+                    last_handled_reply = last_assistant_reply
+                    continue
+            if supervisor is not None and auto_follow_enabled:
+                generated, reason = supervisor.generate_next_input(last_user_prompt, last_assistant_reply, {'result': 'CURRENT_TASK_DONE'})
+                if generated:
+                    print(f'[UI AutoReply/{reason}] {generated[:100]}')
+                    inject(generated)
+                    last_trigger_time = now
+                    last_handled_reply = last_assistant_reply
+                    continue
+            last_handled_reply = last_assistant_reply
         except Exception as e:
-            print(f'[Idle Monitor] Error: {e}')
+            print(f'[Idle Monitor] Error: {e!r}')
+            print(traceback.format_exc())
 
 if __name__ == '__main__':
     import argparse
@@ -114,7 +212,16 @@ if __name__ == '__main__':
         print('[Launch] Task Scheduler started (duplicate prevented by scheduler port lock)')
     else: print('[Launch] Task Scheduler not enabled (--sched)')
 
-    monitor_thread = threading.Thread(target=idle_monitor, daemon=True)
+    ui_supervisor = None
+    try:
+        auto_clients = build_llm_clients()
+        auto_llm_no = (args.llm_no + 1) % len(auto_clients)
+        ui_supervisor = AutoReplySupervisor(auto_clients, auto_llm_no, auto_cycle=True)
+        print(f'[Launch] UI supervisor ready with {ui_supervisor.get_llm_name()}')
+    except Exception as e:
+        print(f'[Launch] UI supervisor unavailable: {e}')
+
+    monitor_thread = threading.Thread(target=idle_monitor, args=(ui_supervisor,), daemon=True)
     monitor_thread.start()
     if os.name == 'nt':
         screen_width = get_screen_width()

--- a/launch.pyw
+++ b/launch.pyw
@@ -1,4 +1,4 @@
-import webview, threading, subprocess, sys, time, os, ctypes, atexit, socket, random, re, traceback
+import webview, threading, subprocess, sys, time, os, ctypes, atexit, socket, random, re, traceback, json
 
 from agentmain import build_llm_clients
 from self_supervisor import AutoReplySupervisor
@@ -64,8 +64,11 @@ def get_ui_state():
                 last_reply_time: parseInt(txt('last-reply-time') || '0') || 0,
                 last_user_prompt: txt('last-user-prompt'),
                 last_assistant_reply: txt('last-assistant-reply'),
+                assistant_revision: parseInt(txt('assistant-revision') || '0') || 0,
+                last_ask_user_payload: txt('last-ask-user-payload'),
                 streaming: txt('streaming-flag') === '1',
                 autonomous_enabled: txt('autonomous-enabled') === '1',
+                auto_follow_enabled: txt('auto-follow-enabled') === '1',
                 auto_reply_enabled: txt('auto-reply-enabled') === '1',
                 auto_cycle_enabled: txt('auto-cycle-enabled') === '1',
                 auto_stop_on_done_enabled: txt('auto-stop-on-done-enabled') === '1'
@@ -74,9 +77,26 @@ def get_ui_state():
     """)
     if raw_state is None:
         return {}
-    if isinstance(raw_state, dict): return dict(raw_state)
-    try: return dict(raw_state)
-    except Exception: return {}
+    if isinstance(raw_state, dict):
+        state = dict(raw_state)
+    else:
+        try: state = dict(raw_state)
+        except Exception: return {}
+    state['auto_follow_enabled'] = bool(
+        state.get('auto_follow_enabled')
+        or state.get('auto_reply_enabled')
+        or state.get('auto_cycle_enabled')
+    )
+    payload_text = (state.get('last_ask_user_payload') or '').strip()
+    if payload_text:
+        try:
+            payload = json.loads(payload_text)
+            state['last_ask_user_payload'] = payload if isinstance(payload, dict) else {}
+        except Exception:
+            state['last_ask_user_payload'] = {}
+    else:
+        state['last_ask_user_payload'] = {}
+    return state
 
 def looks_like_ask_user(text):
     lowered = (text or '').lower()
@@ -102,12 +122,13 @@ def set_ui_toggle(label_text, enabled):
         }})();""")
 
 def disable_auto_followups():
+    set_ui_toggle("自动跟进", False)
     set_ui_toggle("自动代答 ask_user", False)
     set_ui_toggle("自动续跑", False)
 
 def idle_monitor(supervisor):
     last_trigger_time = 0
-    last_handled_reply = ''
+    last_handled_revision = -1
     while True:
         time.sleep(5)
         try:
@@ -120,12 +141,12 @@ def idle_monitor(supervisor):
             last_reply = gs('last_reply_time', 0) or int(time.time())
             last_user_prompt = gs('last_user_prompt', '')
             last_assistant_reply = gs('last_assistant_reply', '')
+            assistant_revision = gs('assistant_revision', 0)
+            ask_user_payload = gs('last_ask_user_payload', {}) or {}
             autonomous_enabled = gs('autonomous_enabled', False)
-            auto_reply_enabled = gs('auto_reply_enabled', False)
-            auto_cycle_enabled = gs('auto_cycle_enabled', False)
+            auto_follow_enabled = gs('auto_follow_enabled', False)
             auto_stop_on_done_enabled = gs('auto_stop_on_done_enabled', False)
-            auto_follow_enabled = auto_reply_enabled or auto_cycle_enabled
-            if not last_assistant_reply or last_assistant_reply == last_handled_reply:
+            if not last_assistant_reply or assistant_revision <= last_handled_revision:
                 if autonomous_enabled and now - last_reply > AUTO_IDLE_SECONDS:
                     print('[Idle Monitor] Detected idle state, injecting task...')
                     inject("[AUTO]🤖 用户已经离开超过30分钟，作为自主智能体，请阅读自动化sop，执行自动任务。")
@@ -137,25 +158,22 @@ def idle_monitor(supervisor):
                     print(f'[Idle Monitor] AI decided to stop auto followups: {stop_reason}')
                     disable_auto_followups()
                     last_trigger_time = now
-                    last_handled_reply = last_assistant_reply
-                    continue
-            if supervisor is not None and auto_reply_enabled and looks_like_ask_user(last_assistant_reply):
-                generated, reason = supervisor.generate_next_input(last_user_prompt, last_assistant_reply, None)
-                if generated:
-                    print(f'[UI AutoReply/{reason}] {generated[:100]}')
-                    inject(generated)
-                    last_trigger_time = now
-                    last_handled_reply = last_assistant_reply
+                    last_handled_revision = assistant_revision
                     continue
             if supervisor is not None and auto_follow_enabled:
-                generated, reason = supervisor.generate_next_input(last_user_prompt, last_assistant_reply, {'result': 'CURRENT_TASK_DONE'})
+                loop_result = None
+                if isinstance(ask_user_payload, dict) and ask_user_payload.get('question'):
+                    loop_result = {'result': 'INTERRUPT', 'ask_user': ask_user_payload}
+                elif not looks_like_ask_user(last_assistant_reply):
+                    loop_result = {'result': 'CURRENT_TASK_DONE'}
+                generated, reason = supervisor.generate_next_input(last_user_prompt, last_assistant_reply, loop_result)
                 if generated:
-                    print(f'[UI AutoReply/{reason}] {generated[:100]}')
+                    print(f'[UI AutoFollow/{reason}] {generated[:100]}')
                     inject(generated)
                     last_trigger_time = now
-                    last_handled_reply = last_assistant_reply
+                    last_handled_revision = assistant_revision
                     continue
-            last_handled_reply = last_assistant_reply
+            last_handled_revision = assistant_revision
         except Exception as e:
             print(f'[Idle Monitor] Error: {e!r}')
             print(traceback.format_exc())

--- a/self_supervisor.py
+++ b/self_supervisor.py
@@ -1,0 +1,183 @@
+import json
+import re
+
+
+def _exhaust(gen):
+    try:
+        while True:
+            next(gen)
+    except StopIteration as e:
+        return e.value
+
+
+class AutoReplySupervisor:
+    def __init__(self, llmclients, llm_no=0, auto_cycle=False):
+        if not llmclients:
+            raise ValueError('No llm clients available for auto supervisor.')
+        self.llmclients = llmclients
+        self.llm_no = llm_no % len(llmclients)
+        self.llmclient = self.llmclients[self.llm_no]
+        self.auto_cycle = auto_cycle
+
+    def get_llm_name(self):
+        b = self.llmclient.backend
+        return f"{type(b).__name__}/{b.name}"
+
+    def _reset_history(self):
+        if hasattr(self.llmclient.backend, 'history'):
+            self.llmclient.backend.history = []
+
+    def _ask_llm(self, system, user):
+        self._reset_history()
+        resp = _exhaust(self.llmclient.chat([
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ]))
+        return self._clean_reply(getattr(resp, 'content', '') if resp is not None else '')
+
+    def _clean_reply(self, text):
+        text = (text or '').strip()
+        if text.startswith('```'):
+            lines = text.splitlines()
+            if len(lines) >= 3 and lines[-1].strip().startswith('```'):
+                text = '\n'.join(lines[1:-1]).strip()
+        text = re.sub(r'^\s*(reply|input|message)\s*:\s*', '', text, flags=re.I)
+        return text.strip().strip('"').strip()
+
+    def _parse_json_object(self, text):
+        text = (text or '').strip()
+        if not text:
+            return {}
+        fenced = re.search(r'```(?:json)?\s*(\{.*\})\s*```', text, re.DOTALL | re.I)
+        if fenced:
+            text = fenced.group(1).strip()
+        try:
+            data = json.loads(text)
+            return data if isinstance(data, dict) else {}
+        except Exception:
+            pass
+        match = re.search(r'(\{.*\})', text, re.DOTALL)
+        if not match:
+            return {}
+        try:
+            data = json.loads(match.group(1))
+            return data if isinstance(data, dict) else {}
+        except Exception:
+            return {}
+
+    def _extract_question(self, loop_result, output_text):
+        data = (loop_result or {}).get('data') or {}
+        payload = data.get('data') if isinstance(data, dict) else {}
+        if not isinstance(payload, dict):
+            payload = {}
+        question = payload.get('question', '')
+        candidates = payload.get('candidates') or []
+        if question:
+            return question, candidates
+        m = re.search(r'ask_user\((\{.*?\})\)', output_text or '', re.DOTALL)
+        if not m:
+            return self._extract_natural_questions(output_text), []
+        try:
+            args = json.loads(m.group(1))
+        except Exception:
+            args = {}
+        question = args.get('question', '')
+        candidates = args.get('candidates') or []
+        if question:
+            return question, candidates
+        return self._extract_natural_questions(output_text), []
+
+    def _extract_natural_questions(self, output_text):
+        text = output_text or ''
+        text = re.sub(r'<thinking>.*?</thinking>', '', text, flags=re.DOTALL | re.I)
+        text = re.sub(r'<summary>.*?</summary>', '', text, flags=re.DOTALL | re.I)
+        text = re.sub(r'```.*?```', '', text, flags=re.DOTALL)
+        prompt_tokens = ('请先确认', '请先回答', '你想要什么', '你希望', '是否需要', '只需回答')
+        lines = []
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            line = re.sub(r'^\s*(?:[-*]|\d+[\.\)\u3001\uFF09])\s*', '', line)
+            if not line:
+                continue
+            if '?' in line or '\uFF1F' in line:
+                lines.append(line)
+                continue
+            if any(token in line for token in prompt_tokens):
+                lines.append(line)
+        if not lines:
+            return ''
+        return '\n'.join(lines[:5])
+
+    def _generate_human_answer(self, last_input, output_text, loop_result, question, candidates):
+        result_name = (loop_result or {}).get('result', 'UNKNOWN')
+        system = (
+            "You are a supervisor for an autonomous agent.\n"
+            "Your only job is to generate the user reply that should be sent back to the main agent.\n"
+            "Output only the reply text itself. Do not explain. Do not use markdown.\n"
+            "Answer the agent's question directly, using the provided candidates when useful.\n"
+            "Keep it short and concrete."
+        )
+        user = (
+            f"Last user input:\n{last_input}\n\n"
+            f"Loop result:\n{result_name}\n\n"
+            f"Assistant output:\n{output_text[-12000:]}\n\n"
+            f"Question to answer:\n{question}\n\n"
+        )
+        if candidates:
+            user += f"Candidates:\n{json.dumps(candidates, ensure_ascii=False)}\n\n"
+        user += "Return the reply text only."
+        text = self._ask_llm(system, user)
+        if text:
+            return text
+        return candidates[0] if candidates else f"按你的判断继续，问题是：{question}"
+
+    def _generate_autonomous_input(self, last_input, output_text, loop_result):
+        result_name = (loop_result or {}).get('result', 'UNKNOWN')
+        system = (
+            "You are a supervisor for an autonomous agent.\n"
+            "Generate the next user input that should be sent to the main agent so it can keep moving.\n"
+            "Output only the next input text itself. Do not explain. Do not pretend to be answering ask_user.\n"
+            "Prefer a short, concrete instruction.\n"
+            "If the previous result is CURRENT_TASK_DONE, move it into the next meaningful action or review.\n"
+            "If the previous result is MAX_TURNS_EXCEEDED, first ask it to summarize the blocker and then continue with a new strategy."
+        )
+        user = (
+            f"Last user input:\n{last_input}\n\n"
+            f"Loop result:\n{result_name}\n\n"
+            f"Assistant output:\n{output_text[-12000:]}\n\n"
+            "Generate the next input."
+        )
+        text = self._ask_llm(system, user)
+        if text:
+            return text
+        if result_name == 'MAX_TURNS_EXCEEDED':
+            return "[AUTO] 先读取 autonomous_operation_sop 和当前工作记忆，总结上一轮卡住的原因，换一种策略继续推进；如果没有高价值继续路径，就转入自主任务规划。"
+        return "[AUTO] 先读取 autonomous_operation_sop，检查上一轮结果是否还有遗漏；若当前任务已完成，就按自主行动 SOP 选择一个新的高价值 TODO 并执行。"
+
+    def should_auto_stop(self, last_input, output_text):
+        system = (
+            "You are a supervisor for an autonomous agent UI.\n"
+            "Decide whether the current task is truly complete and the UI should disable both auto-reply and auto-cycle.\n"
+            "Return JSON only: {\"stop\": true/false, \"reason\": \"short reason\"}.\n"
+            "Use stop=true only when the assistant has already completed the user's requested task or clearly states that no further action is needed.\n"
+            "If the assistant is asking questions, waiting for confirmation, proposing next steps, or obvious follow-up work remains, return stop=false."
+        )
+        user = (
+            f"Last user input:\n{(last_input or '')[-6000:]}\n\n"
+            f"Assistant reply:\n{(output_text or '')[-12000:]}\n\n"
+            "Should the UI auto-stop now?"
+        )
+        payload = self._parse_json_object(self._ask_llm(system, user))
+        stop = bool(payload.get('stop', False))
+        reason = str(payload.get('reason', '') or '').strip()
+        return stop, reason or ('llm_decision_stop' if stop else 'llm_decision_continue')
+
+    def generate_next_input(self, last_input, output_text, loop_result=None):
+        question, candidates = self._extract_question(loop_result, output_text)
+        if question:
+            return self._generate_human_answer(last_input, output_text, loop_result, question, candidates), 'ask_user'
+        if not self.auto_cycle:
+            return None, 'noop'
+        return self._generate_autonomous_input(last_input, output_text, loop_result), 'auto_cycle'

--- a/self_supervisor.py
+++ b/self_supervisor.py
@@ -65,26 +65,53 @@ class AutoReplySupervisor:
         except Exception:
             return {}
 
-    def _extract_question(self, loop_result, output_text):
-        data = (loop_result or {}).get('data') or {}
-        payload = data.get('data') if isinstance(data, dict) else {}
+    def _normalize_ask_user_payload(self, payload):
         if not isinstance(payload, dict):
-            payload = {}
-        question = payload.get('question', '')
+            return {}
+        question = str(payload.get('question', '') or '').strip()
         candidates = payload.get('candidates') or []
-        if question:
-            return question, candidates
-        m = re.search(r'ask_user\((\{.*?\})\)', output_text or '', re.DOTALL)
-        if not m:
-            return self._extract_natural_questions(output_text), []
-        try:
-            args = json.loads(m.group(1))
-        except Exception:
-            args = {}
-        question = args.get('question', '')
-        candidates = args.get('candidates') or []
-        if question:
-            return question, candidates
+        if not isinstance(candidates, list):
+            candidates = [candidates]
+        return {'question': question, 'candidates': candidates} if question else {}
+
+    def _extract_ask_user_payload(self, loop_result):
+        if not isinstance(loop_result, dict):
+            return {}
+        candidates = [loop_result.get('ask_user')]
+        data = loop_result.get('data')
+        if isinstance(data, dict):
+            candidates.extend([data, data.get('ask_user'), data.get('data')])
+        for payload in candidates:
+            normalized = self._normalize_ask_user_payload(payload)
+            if normalized:
+                return normalized
+        return {}
+
+    def _extract_ask_user_payload_from_text(self, output_text):
+        text = output_text or ''
+        inline_matches = re.findall(r'ask_user\((\{.*?\})\)', text, flags=re.DOTALL)
+        for snippet in reversed(inline_matches):
+            payload = self._normalize_ask_user_payload(self._parse_json_object(snippet))
+            if payload:
+                return payload
+        block_matches = re.findall(
+            r'Tool:\s*`ask_user`.*?`{3,}(?:text|json)?\s*(\{.*?\})\s*`{3,}',
+            text,
+            flags=re.DOTALL,
+        )
+        for snippet in reversed(block_matches):
+            payload = self._normalize_ask_user_payload(self._parse_json_object(snippet))
+            if payload:
+                return payload
+        return {}
+
+    def _extract_question(self, loop_result, output_text):
+        payload = self._extract_ask_user_payload(loop_result)
+        if payload:
+            return payload.get('question', ''), payload.get('candidates') or []
+        payload = self._extract_ask_user_payload_from_text(output_text)
+        if payload:
+            return payload.get('question', ''), payload.get('candidates') or []
         return self._extract_natural_questions(output_text), []
 
     def _extract_natural_questions(self, output_text):
@@ -100,6 +127,8 @@ class AutoReplySupervisor:
                 continue
             line = re.sub(r'^\s*(?:[-*]|\d+[\.\)\u3001\uFF09])\s*', '', line)
             if not line:
+                continue
+            if 'Tool:' in line or '`ask_user`' in line or 'Waiting for your answer' in line:
                 continue
             if '?' in line or '\uFF1F' in line:
                 lines.append(line)
@@ -159,7 +188,7 @@ class AutoReplySupervisor:
     def should_auto_stop(self, last_input, output_text):
         system = (
             "You are a supervisor for an autonomous agent UI.\n"
-            "Decide whether the current task is truly complete and the UI should disable both auto-reply and auto-cycle.\n"
+            "Decide whether the current task is truly complete and the UI should disable auto-follow.\n"
             "Return JSON only: {\"stop\": true/false, \"reason\": \"short reason\"}.\n"
             "Use stop=true only when the assistant has already completed the user's requested task or clearly states that no further action is needed.\n"
             "If the assistant is asking questions, waiting for confirmation, proposing next steps, or obvious follow-up work remains, return stop=false."


### PR DESCRIPTION
## Summary
- add UI-level auto-follow that can automatically reply to ask_user prompts and continue after a turn completes
- add "auto-stop on done" so the supervisor can disable auto-follow when the task is complete
- preserve structured ask_user payloads and use assistant revision tracking to avoid repeated-text dedupe bugs
## Validation
- python -m py_compile agentmain.py frontends/stapp.py launch.pyw self_supervisor.py
- verified ask_user extraction with both structured loop_result and rendered tool-log samples