### PR TITLE
fix: GPT-5.4空转修复 + file_patch行尾保持

### DIFF
--- a/ga.py
+++ b/ga.py
@@ -186,17 +186,26 @@ def expand_file_refs(text, base_dir=None):
     return re.sub(pattern, replacer, text)
     
 def file_patch(path: str, old_content: str, new_content: str):
-    """在文件中寻找唯一的 old_content 块并替换为 new_content"""
+    """文件局部修改，保持原始行尾格式"""
     path = str(Path(path).resolve())
     try:
         if not os.path.exists(path): return {"status": "error", "msg": "文件不存在"}
-        with open(path, 'r', encoding='utf-8') as f: full_text = f.read()
+        with open(path, 'rb') as f: raw = f.read()
+        _has_crlf = b'\r\n' in raw
+        full_text = raw.decode('utf-8')
+        if _has_crlf:
+            old_content = old_content.replace('\n', '\r\n')
+            new_content = new_content.replace('\n', '\r\n')
+            full_text = full_text.replace('\r\n', '\n')
         if not old_content: return {"status": "error", "msg": "old_content 为空，请确认 arguments"}
         count = full_text.count(old_content)
         if count == 0: return {"status": "error", "msg": "未找到匹配的旧文本块，建议：先用 file_read 确认当前内容，再分小段进行 patch。若多次失败则询问用户，严禁自行使用 overwrite 或代码替换。"}
         if count > 1: return {"status": "error", "msg": f"找到 {count} 处匹配，无法确定唯一位置。请提供更长、更具体的旧文本块以确保唯一性。建议：包含上下文行来增强特征，或分小段逐个修改。"}
         updated_text = full_text.replace(old_content, new_content)
-        with open(path, 'w', encoding='utf-8') as f: f.write(updated_text)
+        with open(path, 'wb') as f:
+            data = updated_text.encode('utf-8')
+            if _has_crlf: data = data.replace(b'\n', b'\r\n')
+            f.write(data)
         return {"status": "success", "msg": "文件局部修改成功"}
     except Exception as e: return {"status": "error", "msg": str(e)}
 

--- a/llmcore.py
+++ b/llmcore.py
@@ -911,13 +911,13 @@ class NativeToolClient:
     def _thinking_prompt(): return THINKING_PROMPT_EN if os.environ.get('GA_LANG') == 'en' else THINKING_PROMPT_ZH
     def __init__(self, backend):
         self.backend = backend
-        self.backend.system = self._thinking_prompt()
+        self.backend.system = ''
         self.name = self.backend.name
         self._pending_tool_ids = []
     def set_system(self, extra_system):
-        combined = f"{extra_system}\n\n{self._thinking_prompt()}" if extra_system else self._thinking_prompt()
-        if combined != self.backend.system: print(f"[Debug] Updated system prompt, length {len(combined)} chars.")
-        self.backend.system = combined
+        if extra_system != self.backend.system:
+            print(f"[Debug] Updated system prompt, length {len(extra_system)} chars.")
+        self.backend.system = extra_system or ''
     def chat(self, messages, tools=None):
         if tools: self.backend.tools = tools
         combined_content = []; resp = None; tool_results = []


### PR DESCRIPTION
## 修复内容

### 1. GPT-5.4 空转修复 (llmcore.py)
- **问题**: NativeToolClient 在初始化时将 THINKING_PROMPT 注入 system prompt，导致 GPT-5.4 按文本协议输出 tool call 而非使用原生 tool_calls 字段
- **修复**: NativeToolClient 不再注入 THINKING_PROMPT，只使用 agent 传入的 system prompt
- **影响**: GPT-5.4 恢复正常的 tool_calls 返回

### 2. file_patch 行尾保持 (ga.py)
- **问题**: file_patch 在 Windows 上使用文本模式读写，自动将 LF 转为 CRLF，破坏原始行尾格式
- **修复**: 改用二进制模式读写，检测并保持原文件的 LF/CRLF 格式
- **影响**: patch 后文件行尾格式与原文件一致