### PR TITLE
fix: quote tg_allowed_users value and fix star-history badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Full guide: [GETTING_STARTED.md](GETTING_STARTED.md)
 ```python
 # mykey.py
 tg_bot_token = 'YOUR_BOT_TOKEN'
-tg_allowed_users = [YOUR_USER_ID]
+tg_allowed_users = ["YOUR_USER_ID"]
 ```
 
 ```bash
@@ -461,7 +461,7 @@ MIT License — 详见 [LICENSE](LICENSE)
 
 ## 📈 Star History
 
-<a href="https://star-history.com/#lsdefine/GenericAgent&Date">
+<a href="https://star-history.com/#lsdefine/GenericAgent&type=Date&theme=dark">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=lsdefine/GenericAgent&type=Date&theme=dark" />
    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=lsdefine/GenericAgent&type=Date" />


### PR DESCRIPTION
Good day

Found two small issues in README.md:

1. `tg_allowed_users = [YOUR_USER_ID]` — the value is missing quotes while all other `*_allowed_users` variables correctly use quoted string arrays (e.g. `qq_allowed_users = ["YOUR_USER_OPENID"]`). Fixed to `["YOUR_USER_ID"]`.
2. Star-history badge URL was missing query params — fixed to include `type=Date&theme=dark`.

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly,
RoomWithOutRoof