### PR TITLE
fix(cli): 修复中文退格显示残影

### DIFF
--- a/agentmain.py
+++ b/agentmain.py
@@ -1,5 +1,9 @@
 import os, sys, threading, queue, time, json, re, random, locale
 os.environ.setdefault('GA_LANG', 'zh' if any(k in (locale.getlocale()[0] or '').lower() for k in ('zh', 'chinese')) else 'en')
+try:
+    import readline
+except Exception:
+    readline = None
 if sys.stdout is None: sys.stdout = open(os.devnull, "w")
 elif hasattr(sys.stdout, 'reconfigure'): sys.stdout.reconfigure(errors='replace')
 if sys.stderr is None: sys.stderr = open(os.devnull, "w")


### PR DESCRIPTION
## 摘要

  这个 PR 在 CLI 入口启用 Python 的 `readline` 行编辑支持。

  在 macOS 终端中使用中文/CJK 输入时，当前 `input("> ")` 的默认输入循环在退格删除时可能出现显示残影，表现为输入内容看起来删不掉，或实际输入缓冲区与终端显示不同步。导入`readline` 后，终端会启用更完整的行编辑能力，可以改善宽字符输入时的退格显示行为。
  该导入做了异常保护：如果当前平台没有 `readline`，会自动跳过，不影响原有行为。

## 说明

- 该问题是在 macOS 终端中文输入场景下观察到的。
- 这个问题可能与终端、系统 locale、中文输入法和宽字符显示有关，不一定只限于 macOS。
- 我搜索了 upstream issues，未发现相同的 CLI 中文退格/显示残影问题。

## 测试

```bash
uv run python -m py_compile agentmain.py