### PR TITLE
feat: LLM 配置热重载，修改 mykey.py 后无需重启

### DIFF
--- a/agentmain.py
+++ b/agentmain.py
@@ -10,7 +10,7 @@ if sys.stderr is None: sys.stderr = open(os.devnull, "w")
 elif hasattr(sys.stderr, 'reconfigure'): sys.stderr.reconfigure(errors='replace')
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from llmcore import LLMSession, ToolClient, ClaudeSession, MixinSession, NativeToolClient, NativeClaudeSession, NativeOAISession
+from llmcore import LLMSession, ToolClient, ClaudeSession, MixinSession, NativeToolClient, NativeClaudeSession, NativeOAISession, reload_mykeys, reload_mykeys_if_changed
 from agent_loop import agent_runner_loop
 from ga import GenericAgentHandler, smart_format, get_global_memory, format_error, consume_file
 
@@ -47,7 +47,20 @@ class GeneraticAgent:
     def __init__(self):
         script_dir = os.path.dirname(os.path.abspath(__file__))
         os.makedirs(os.path.join(script_dir, 'temp'), exist_ok=True)
-        from llmcore import mykeys
+        self.lock = threading.Lock()
+        self.task_dir = None
+        self.history = []
+        self.task_queue = queue.Queue() 
+        self.is_running = False; self.stop_sig = False
+        self.llm_no = 0;  self.inc_out = False
+        self.handler = None; self.verbose = True
+        self._build_llm_clients()
+        self.llmclient = self.llmclients[self.llm_no]
+
+    def _build_llm_clients(self, mykeys=None):
+        """从 mykeys 字典构建 llmclients 列表。"""
+        if mykeys is None:
+            from llmcore import mykeys
         llm_sessions = []
         for k, cfg in mykeys.items():
             if not any(x in k for x in ['api', 'config', 'cookie']): continue
@@ -66,16 +79,32 @@ class GeneraticAgent:
                     else: llm_sessions[i] = ToolClient(mixin)
                 except Exception as e: print(f'[WARN] Failed to init MixinSession with cfg {s["mixin_cfg"]}: {e}')
         self.llmclients = llm_sessions
-        self.lock = threading.Lock()
-        self.task_dir = None
-        self.history = []
-        self.task_queue = queue.Queue() 
-        self.is_running = False; self.stop_sig = False
-        self.llm_no = 0;  self.inc_out = False
-        self.handler = None; self.verbose = True
+
+    def reload_llm_configs(self, force=False):
+        """热重载 mykey.py，重建所有 LLM 客户端。
+        force=False 时仅在文件修改后才重载，force=True 时强制重载。"""
+        if force:
+            mk = reload_mykeys()
+        else:
+            changed, mk = reload_mykeys_if_changed()
+            if not changed:
+                return [(i, self.get_llm_name(b), i == self.llm_no) for i, b in enumerate(self.llmclients)]
+        old_history = None
+        try: old_history = self.llmclient.backend.history
+        except: pass
+        self._build_llm_clients(mk)
+        if not self.llmclients:
+            raise RuntimeError('重载后没有可用的 LLM 配置')
+        self.llm_no = min(self.llm_no, len(self.llmclients) - 1)
         self.llmclient = self.llmclients[self.llm_no]
+        if old_history:
+            try: self.llmclient.backend.history = old_history
+            except: pass
+        print(f'[HotReload] LLM configs reloaded, {len(self.llmclients)} clients available.')
+        return [(i, self.get_llm_name(b), i == self.llm_no) for i, b in enumerate(self.llmclients)]
 
     def next_llm(self, n=-1):
+        self.reload_llm_configs()
         self.llm_no = ((self.llm_no + 1) if n < 0 else n) % len(self.llmclients)
         lastc = self.llmclient
         self.llmclient = self.llmclients[self.llm_no]
@@ -85,7 +114,9 @@ class GeneraticAgent:
         name = self.get_llm_name(model=True)
         if 'glm' in name or 'minimax' in name or 'kimi' in name: load_tool_schema('_cn')
         else: load_tool_schema()
-    def list_llms(self): return [(i, self.get_llm_name(b), i == self.llm_no) for i, b in enumerate(self.llmclients)]
+    def list_llms(self):
+        self.reload_llm_configs()
+        return [(i, self.get_llm_name(b), i == self.llm_no) for i, b in enumerate(self.llmclients)]
     def get_llm_name(self, b=None, model=False):
         b = self.llmclient if b is None else b
         if isinstance(b, dict): return 'BADCONFIG_MIXIN'

--- a/frontends/stapp.py
+++ b/frontends/stapp.py
@@ -43,6 +43,14 @@ def render_sidebar():
         st.caption(f"空闲时间：{int(time.time()) - last_reply_time}秒", help="当超过30分钟未收到回复时，系统会自动任务")
     if st.button("切换备用链路"):
         agent.next_llm(); st.rerun(scope="fragment")
+    if st.button("🔄 重载 LLM 配置"):
+        try:
+            result = agent.reload_llm_configs(force=True)
+            names = ', '.join(name for _, name, _ in result)
+            st.toast(f"✅ 已重载，{len(result)} 个 LLM: {names}")
+        except Exception as e:
+            st.toast(f"❌ 重载失败: {e}")
+        st.rerun(scope="fragment")
     if st.button("强行停止任务"):
         agent.abort(); st.toast("已发送停止信号"); st.rerun()
     if st.button("重新注入工具"):

--- a/llmcore.py
+++ b/llmcore.py
@@ -11,6 +11,38 @@ def _load_mykeys():
     if not os.path.exists(p): raise Exception('[ERROR] mykey.py or mykey.json not found, please create one from mykey_template.')
     with open(p, encoding='utf-8') as f: return json.load(f)
 
+def reload_mykeys():
+    """强制重新加载 mykey.py / mykey.json，刷新全局 mykeys 和 proxies 缓存。"""
+    import importlib
+    try:
+        import mykey
+        importlib.reload(mykey)
+    except ImportError:
+        pass
+    mk = _load_mykeys()
+    proxy = mk.get("proxy", 'http://127.0.0.1:2082')
+    px = {"http": proxy, "https": proxy} if proxy else None
+    globals().update(mykeys=mk, proxies=px)
+    return mk
+
+_mykey_mtime = 0
+
+def _get_mykey_mtime():
+    for name in ('mykey.py', 'mykey.json'):
+        p = os.path.join(os.path.dirname(os.path.abspath(__file__)), name)
+        if os.path.exists(p):
+            return os.path.getmtime(p)
+    return 0
+
+def reload_mykeys_if_changed():
+    """仅当 mykey 文件被修改过时才重载，返回 (是否重载, mykeys)。"""
+    global _mykey_mtime
+    mtime = _get_mykey_mtime()
+    if mtime > _mykey_mtime:
+        _mykey_mtime = mtime
+        return True, reload_mykeys()
+    return False, globals().get('mykeys') or _load_mykeys()
+
 def __getattr__(name):  # once guard in PEP 562
     if name in ('mykeys', 'proxies'):  
         mk = _load_mykeys()


### PR DESCRIPTION
## 动机

目前修改 `mykey.py` 后必须重启整个进程才能生效。对于需要频繁调试 API Key、切换模型或调整提供商配置的场景，这很不方便。

## 改动内容

### llmcore.py

- 新增 `reload_mykeys()`：通过 `importlib.reload(mykey)` 强制重新导入 mykey.py，刷新全局 `mykeys` 和 `proxies` 缓存
- 新增 `reload_mykeys_if_changed()`：基于文件 mtime 检测，仅在 mykey.py/mykey.json 被修改后才执行 reload，未修改时零开销直接返回缓存

### agentmain.py

- 提取 `_build_llm_clients()` 方法，将 `__init__` 中的 LLM 构建逻辑独立出来，避免重复代码
- 新增 `reload_llm_configs(force=False)`：
  - `force=False`（默认）：通过 mtime 自动检测，文件没变就跳过
  - `force=True`：强制重载，用于手动触发场景
  - 重载时保留当前对话历史（`backend.history`）并迁移到新 client
  - 自动修正 `llm_no` 防止越界
- `next_llm()` 和 `list_llms()` 开头自动调用 `reload_llm_configs()`，所有前端（Streamlit、Telegram、QQ、飞书、钉钉、企微、WebView）无需任何改动即可受益

### frontends/stapp.py

- 侧边栏新增「🔄 重载 LLM 配置」按钮（`force=True`），用于手动强制重载

## 使用方式

**自动模式**（推荐）：修改 mykey.py → 点「切换备用链路」或任何触发 `next_llm()`/`list_llms()` 的操作 → 自动检测文件变化并重载

**手动模式**：点「🔄 重载 LLM 配置」按钮 → 强制重载（即使文件未变也重建所有 client）

## 兼容性

- 不改变任何现有 API 签名
- `next_llm(n)` / `list_llms()` 行为完全向后兼容
- 未修改 mykey.py 时 mtime 检测直接跳过，无性能影响
- 所有前端（stapp/tgapp/qqapp/fsapp/wecomapp/dingtalkapp/qtapp/wechatapp）无需改动，自动受益