### PR TITLE
fix: handle os.getlogin() OSError in keychain.py

### DIFF
--- a/memory/keychain.py
+++ b/memory/keychain.py
@@ -2,7 +2,11 @@
 import json, os, hashlib, pathlib
 
 _PATH = pathlib.Path.home() / "ga_keychain.enc"
-_MASK = hashlib.sha256(f"{os.getlogin()}@ga_keychain".encode()).digest()
+try:
+    _user = os.getlogin()
+except OSError:
+    _user = os.environ.get('USER', os.environ.get('USERNAME', 'default'))
+_MASK = hashlib.sha256(f"{_user}@ga_keychain".encode()).digest()
 
 def _xor(data: bytes) -> bytes:
     return bytes(b ^ _MASK[i % len(_MASK)] for i, b in enumerate(data))


### PR DESCRIPTION
## Problem

In `memory/keychain.py`, `os.getlogin()` is called at module import time to generate the encryption mask:

```python
_MASK = hashlib.sha256(f"{os.getlogin()}@ga_keychain".encode()).digest()
```

`os.getlogin()` raises `OSError` when there is no controlling terminal. This happens in:
- Docker containers
- systemd services
- CI/CD environments (GitHub Actions, etc.)
- Some WSL configurations

When this fails, the entire `keychain` module cannot be imported, breaking any code that depends on it.

## Fix

Catch `OSError` and fall back to environment variables:

```python
try:
    _user = os.getlogin()
except OSError:
    _user = os.environ.get('USER', os.environ.get('USERNAME', 'default'))
_MASK = hashlib.sha256(f"{_user}@ga_keychain".encode()).digest()
```

`USER` is the standard variable on Linux/macOS, `USERNAME` on Windows. The `'default'` fallback ensures the module always loads.

## Impact

- `keychain` module now works in headless/CI environments
- Encryption mask remains deterministic per-user (same user → same mask)
- No behavior change for normal terminal sessions