### PR TITLE
fix: add missing delay between clicks in MouseDClick()

### DIFF
--- a/memory/ljqCtrl.py
+++ b/memory/ljqCtrl.py
@@ -37,9 +37,8 @@ def MouseClick(staytime=0.05):
 	MouseUp(); time.sleep(0.05)
 
 def MouseDClick(staytime=0.05):
-	MouseDown(); MouseUp() 
-	MouseDown(); MouseUp() 
-	time.sleep(0.05)
+	MouseDown(); time.sleep(staytime); MouseUp(); time.sleep(0.05)
+	MouseDown(); time.sleep(staytime); MouseUp(); time.sleep(0.05)
 
 def SetCursorPos(z):
 	z = tuple(map(lambda v:int(v*dpi_scale), z))


### PR DESCRIPTION
## Problem

In `memory/ljqCtrl.py`, `MouseDClick()` fires two rapid click events without any delay between `MouseDown()` and `MouseUp()`:

```python
def MouseDClick(staytime=0.05):
    MouseDown(); MouseUp() 
    MouseDown(); MouseUp() 
    time.sleep(0.05)
```

Compare with `MouseClick()` which has `time.sleep(staytime)` between down/up. Without this delay, the OS may interpret the two rapid clicks as a single long press rather than a double-click, making `MouseDClick()` unreliable.

## Fix

Add `time.sleep(staytime)` between each `MouseDown()`/`MouseUp()` pair, and `time.sleep(0.05)` between the two clicks, matching `MouseClick()` behavior:

```python
def MouseDClick(staytime=0.05):
    MouseDown(); time.sleep(staytime); MouseUp(); time.sleep(0.05)
    MouseDown(); time.sleep(staytime); MouseUp(); time.sleep(0.05)
```

## Impact

- Double-click operations now work reliably on Windows
- Behavior is consistent with `MouseClick()` implementation