### PR TITLE
fix: correct regex replacement logic in _clean_content()

### DIFF
--- a/agent_loop.py
+++ b/agent_loop.py
@@ -106,8 +106,8 @@ def _clean_content(text):
         preview = '\n'.join(body[:5])
         return f'```{lang}\n{preview}\n  ... ({len(body)} lines)\n```'
     text = re.sub(r'```[\s\S]*?```', _shrink_code, text)
-    for p in [r'<file_content>[\s\S]*?</file_content>', r'<tool_(?:use|call)>[\s\S]*?</tool_(?:use|call)>', r'(\r?\n){3,}']:
-        text = re.sub(p, '\n\n' if '\\n' in p else '', text)
+    for p, repl in [(r'<file_content>[\s\S]*?</file_content>', ''), (r'<tool_(?:use|call)>[\s\S]*?</tool_(?:use|call)>', ''), (r'(\r?\n){3,}', '\n\n')]:
+        text = re.sub(p, repl, text)
     return text.strip()
 
 def _compact_tool_args(name, args):


### PR DESCRIPTION
## Problem

In `agent_loop.py`, the `_clean_content()` function used a heuristic `'\\n' in p` to decide whether to replace with `'\n\n'` or `''`:

```python
for p in [r'<file_content>[\s\S]*?</file_content>', r'<tool_(?:use|call)>[\s\S]*?</tool_(?:use|call)>', r'(\r?\n){3,}']:
    text = re.sub(p, '\n\n' if '\\n' in p else '', text)
```

In Python raw strings, `\n` is stored as the literal two characters `\` and `n`, so `'\\n' in r'(\r?\n){3,}'` evaluates to `True`. This means **all three patterns** were replaced with `'\n\n'`, including `<file_content>` and `<tool_use>` tags which should be replaced with an empty string `''` to remove them entirely.

## Fix

Replace the heuristic with explicit pattern-replacement pairs:

```python
for p, repl in [(r'<file_content>[\s\S]*?</file_content>', ''), (r'<tool_(?:use|call)>[\s\S]*?</tool_(?:use|call)>', ''), (r'(\r?\n){3,}', '\n\n')]:
    text = re.sub(p, repl, text)
```

## Impact

- `<file_content>` and `<tool_use>` tags are now correctly stripped (replaced with empty string) instead of leaving extra newlines
- Reduces unnecessary token consumption in compressed history messages