### PR TITLE
fix: prevent uncaught JSONDecodeError in tryparse() fallback

### DIFF
--- a/llmcore.py
+++ b/llmcore.py
@@ -858,7 +858,8 @@ def tryparse(json_str):
     try: return json.loads(json_str[:-1])
     except: pass
     if '}' in json_str: json_str = json_str[:json_str.rfind('}') + 1]
-    return json.loads(json_str)
+    try: return json.loads(json_str)
+    except: return {"_raw": json_str}
 
 class MixinSession:
     """Multi-session fallback with spring-back to primary."""


### PR DESCRIPTION
## Problem

In `llmcore.py`, the `tryparse()` function attempts multiple strategies to recover malformed JSON from LLM output. However, the final `json.loads()` call after trimming to the last `}` is not wrapped in a try/except block:

```python
if '}' in json_str: json_str = json_str[:json_str.rfind('}') + 1]
return json.loads(json_str)  # ← can still throw JSONDecodeError
```

When all recovery attempts fail, this raises an uncaught `JSONDecodeError` that crashes the tool call parser.

## Fix

Wrap the final `json.loads()` in a try/except, returning `{"_raw": json_str}` on failure. This is consistent with the behavior of `_try_parse_tool_args()` which also returns a fallback dict when parsing fails.

## Impact

- Prevents agent loop crashes when LLM returns completely unparseable tool call output
- The `{"_raw": ...}` fallback allows downstream code to still access the raw text for debugging