### PR TITLE
fix(sandbox): patch Popen + block startfile to prevent window leaks

### DIFF
--- a/assets/code_run_header.py
+++ b/assets/code_run_header.py
@@ -19,4 +19,12 @@ def _run(*a, **k):
         if r.stderr is not None: r.stderr = _d(r.stderr)
     return r
 subprocess.run = _run
+_Pi = subprocess.Popen.__init__
+def _pinit(self, *a, **k):
+    if os.name == 'nt': k['creationflags'] = (k.get('creationflags') or 0) | 0x08000000
+    _Pi(self, *a, **k)
+subprocess.Popen.__init__ = _pinit
+if hasattr(os, 'startfile'):
+    def _nosf(*a, **k): raise RuntimeError("startfile disabled in sandbox")
+    os.startfile = _nosf
 sys.excepthook = lambda t, v, tb: (sys.__excepthook__(t, v, tb), print(f"\n[Agent Hint]: NO GUESSING! You MUST probe first. If missing common package, pip.")) if issubclass(t, (ImportError, AttributeError)) else sys.__excepthook__(t, v, tb)


### PR DESCRIPTION
## What
`subprocess.Popen` and `os.startfile` were unprotected — agent code could open visible GUI windows.

## Fix
- Monkey-patch `Popen.__init__` to auto-inject `CREATE_NO_WINDOW` on Windows
- Block `os.startfile` with `RuntimeError`

## Testing
Verified in the live sandbox:
- `subprocess.Popen(['notepad.exe'])` → no visible window
- `os.startfile(...)` → raises `RuntimeError`

## Checklist
- [x] Net line count: +8 (minimal)
- [x] No new dependencies
- [x] No comments added (per CONTRIBUTING.md)
- [x] One concern, one PR