### PR TITLE
Fix Telegram startup without a configured proxy

### DIFF
--- a/frontends/tgapp.py
+++ b/frontends/tgapp.py
@@ -371,8 +371,11 @@ if __name__ == '__main__':
     sys.stdout = sys.stderr = _logf
     print('[NEW] New process starting, the above are history infos ...')
     threading.Thread(target=agent.run, daemon=True).start()
-    proxy = mykeys.get('proxy', 'http://127.0.0.1:2082')
-    print('proxy:', proxy)
+    proxy = mykeys.get('proxy')
+    if proxy:
+        print('proxy:', proxy)
+    else:
+        print('proxy: <disabled>')
 
     async def _error_handler(update, context: ContextTypes.DEFAULT_TYPE):
         print(f"[{time.strftime('%m-%d %H:%M')}] TG error: {context.error}", flush=True)
@@ -381,7 +384,10 @@ if __name__ == '__main__':
         try:
             print(f"TG bot starting... {time.strftime('%m-%d %H:%M')}")
             # Recreate request and app objects on each restart to avoid stale connections
-            request = HTTPXRequest(proxy=proxy, read_timeout=30, write_timeout=30, connect_timeout=30, pool_timeout=30)
+            request_kwargs = dict(read_timeout=30, write_timeout=30, connect_timeout=30, pool_timeout=30)
+            if proxy:
+                request_kwargs['proxy'] = proxy
+            request = HTTPXRequest(**request_kwargs)
             app = (ApplicationBuilder().token(mykeys['tg_bot_token'])
                    .request(request).get_updates_request(request).post_init(_sync_commands).build())
             app.add_handler(MessageHandler(filters.COMMAND, handle_command))

--- a/llmcore.py
+++ b/llmcore.py
@@ -317,18 +317,29 @@ def _stamp_oai_cache_markers(messages, model):
             c = list(c); c[-1] = dict(c[-1], cache_control={'type': 'ephemeral'})
             messages[idx] = {**messages[idx], 'content': c}
 
+def _oai_max_tokens_key(model, api_mode="chat_completions"):
+    if api_mode == "responses": return "max_output_tokens"
+    ml = str(model or "").lower()
+    if ml.startswith("gpt-5") or (len(ml) > 1 and ml[0] == 'o' and ml[1].isdigit()):
+        return "max_completion_tokens"
+    return "max_tokens"
+
 def _openai_stream(api_base, api_key, messages, model, api_mode='chat_completions', *,
                    system=None, temperature=0.5, max_tokens=None, tools=None, reasoning_effort=None,
                    max_retries=0, connect_timeout=10, read_timeout=300, proxies=None, stream=True):
     """Shared OpenAI-compatible streaming request with retry. Yields text chunks, returns list[content_block]."""
     ml = model.lower()
-    if 'kimi' in ml or 'moonshot' in ml: temperature = 1
-    elif 'minimax' in ml: temperature = max(0.01, min(temperature, 1.0))  # MiniMax requires temp in (0, 1]
+    force_temperature = False
+    if 'kimi' in ml or 'moonshot' in ml:
+        temperature = 1; force_temperature = True
+    elif 'minimax' in ml:
+        temperature = max(0.01, min(temperature, 1.0)); force_temperature = True  # MiniMax requires temp in (0, 1]
     headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json", "Accept": "text/event-stream"}
     if api_mode == "responses":
         url = auto_make_url(api_base, "responses")
         payload = {"model": model, "input": _to_responses_input(messages), "stream": stream, 
                    "prompt_cache_key": _RESP_CACHE_KEY, "instructions": system or "You are an Omnipotent Executor."}
+        if max_tokens: payload[_oai_max_tokens_key(model, api_mode)] = max_tokens
         if reasoning_effort: payload["reasoning"] = {"effort": reasoning_effort}
     else:
         url = auto_make_url(api_base, "chat/completions")
@@ -336,8 +347,8 @@ def _openai_stream(api_base, api_key, messages, model, api_mode='chat_completion
         _stamp_oai_cache_markers(messages, model)
         payload = {"model": model, "messages": messages, "stream": stream}
         if stream: payload["stream_options"] = {"include_usage": True}
-        if temperature != 1: payload["temperature"] = temperature
-        if max_tokens: payload["max_tokens"] = max_tokens
+        if temperature != 1 or force_temperature: payload["temperature"] = temperature
+        if max_tokens: payload[_oai_max_tokens_key(model, api_mode)] = max_tokens
         if reasoning_effort: payload["reasoning_effort"] = reasoning_effort
     if tools: payload["tools"] = _prepare_oai_tools(tools, api_mode)
     RETRYABLE = {408, 409, 425, 429, 500, 502, 503, 504, 529}

--- a/tests/test_openai_payloads.py
+++ b/tests/test_openai_payloads.py
@@ -1,0 +1,57 @@
+"""Regression tests for OpenAI payload field selection."""
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestOpenAIMaxTokenFields(unittest.TestCase):
+    def _capture_payload(self, *, model, api_mode='chat_completions', max_tokens=4096):
+        from llmcore import _openai_stream
+
+        captured = {}
+
+        def fake_post(url, headers=None, json=None, stream=None, timeout=None, proxies=None):
+            captured['payload'] = json
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.iter_lines.return_value = iter([b'data: [DONE]'])
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = MagicMock(return_value=False)
+            return resp
+
+        with patch('llmcore.requests.post', side_effect=fake_post):
+            gen = _openai_stream(
+                'https://api.openai.com/v1',
+                'test-key',
+                [{"role": "user", "content": "hi"}],
+                model,
+                api_mode=api_mode,
+                max_tokens=max_tokens,
+            )
+            for _ in gen:
+                pass
+
+        return captured['payload']
+
+    def test_gpt5_chat_uses_max_completion_tokens(self):
+        payload = self._capture_payload(model='gpt-5.4')
+        self.assertEqual(payload['max_completion_tokens'], 4096)
+        self.assertNotIn('max_tokens', payload)
+
+    def test_gpt4o_chat_keeps_max_tokens(self):
+        payload = self._capture_payload(model='gpt-4o')
+        self.assertEqual(payload['max_tokens'], 4096)
+        self.assertNotIn('max_completion_tokens', payload)
+
+    def test_responses_uses_max_output_tokens(self):
+        payload = self._capture_payload(model='gpt-5.4', api_mode='responses')
+        self.assertEqual(payload['max_output_tokens'], 4096)
+        self.assertNotIn('max_tokens', payload)
+        self.assertNotIn('max_completion_tokens', payload)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Only use `mykeys['proxy']` when it is explicitly set. This avoids forcing the dead default proxy `http://127.0.0.1:2082` and restores Telegram startup.

Closes #175