### PR TITLE
[codex] Add local slash command wrapper

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,46 @@
+# Copilot Instructions for GenericAgent
+
+This repository is an upstream GenericAgent checkout with local overlays.
+
+## Main Rule
+
+Do not modify upstream GenericAgent source files by default. Put local slash commands, nmem glue, bot launch wrappers, and personal workflow code in `local_ga/`, local `memory/`, or external wrappers.
+
+`.omx/` is Codex/OmniCodex workspace state only. Do not make GenericAgent runtime depend on `.omx/`.
+
+## Treat As Upstream Source
+
+- `agentmain.py`
+- `agent_loop.py`
+- `ga.py`
+- `llmcore.py`
+- `assets/`
+- `frontends/`
+- `memory/`
+- `reflect/`
+- `tests/`
+
+Ask before changing these unless the user explicitly requests a source change.
+
+## Treat As Local Overlay
+
+- `.omx/`
+- `local_ga/`
+- `RUNBOOK_LOCAL.md`
+- `GENERIC_AGENT_HANDBOOK.md`
+- `kb/`
+
+## Local nmem Hook
+
+nmem session auto-sync is a local overlay, not upstream GenericAgent behavior.
+
+Use:
+
+```bash
+./.omx/ga_nmem_hook/run_cli.sh
+./.omx/ga_nmem_hook/run_launch.sh
+```
+
+## Git Safety
+
+Do not stage `.omx/`, secrets, cookies, or runtime state. Before suggesting a pull or merge, check `git status --short`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Codex Instructions for GenericAgent
+
+这是 Codex 原生识别的项目指令文件。
+
+## 本地边界
+
+- 这个 checkout 是上游 GenericAgent 源码 + 本机外挂配置。
+- 默认不要修改 GA 原生源码，除非用户明确要求。
+- slash commands、nmem、bot 启动包装等本地增强优先放 `local_ga/`、ignored `memory/` 或外部 wrapper，不要写进 GA core source。
+- `.omx/` 只属于 Codex/OmniCodex 工作层；不要让 GA runtime 把 `.omx/` 当作自己的能力来源。
+- 不要把 `.omx/`、密钥、cookie、运行态会话写进 Git。
+- `local_ga/` 默认是本地外挂；只有用户明确要发布 wrapper 时才纳入提交。
+
+## 当前本地扩展
+
+- nmem session 自动同步 hook：`.omx/ga_nmem_hook/`
+- 本地 slash command wrapper：`local_ga/`
+- 本地规则说明：`.omx/local_docs/`
+- 本地手册：`GENERIC_AGENT_HANDBOOK.md`
+- 本机运行说明：`RUNBOOK_LOCAL.md`
+- 本地 KB：`kb/`
+
+## 输出要求
+
+完成任务时说明：
+
+- 是否改了 GA 原生源码；
+- 是否只改了本地外挂；
+- 做了什么验证；
+- 后续 `git pull` 是否可能冲突。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# GenericAgent Project Instructions
+
+This is the Claude Code project instruction file.
+
+## Local Rule
+
+Treat this checkout as upstream GenericAgent plus local overlays. Do not edit upstream source files by default. Put slash commands, nmem glue, bot launch wrappers, and other local behavior in `local_ga/`, local `memory/`, or external wrappers.
+
+`.omx/` is Codex/OmniCodex workspace state, not a GenericAgent runtime capability source.
+
+## Do Not Edit By Default
+
+- `agentmain.py`
+- `agent_loop.py`
+- `ga.py`
+- `llmcore.py`
+- `assets/tools_schema*.json`
+- `frontends/*.py`
+- `memory/*.md`
+- `reflect/*.py`
+
+Only edit those files when the user explicitly asks or when an upstream-source fix is truly required.
+
+## Local Extensions
+
+- nmem session sync: `.omx/ga_nmem_hook/`
+- local slash command wrapper: `local_ga/`
+- local docs and rules: `.omx/local_docs/`
+- local runbook: `RUNBOOK_LOCAL.md`
+- local KB: `kb/`
+
+## Verification
+
+Before saying work is complete, run a relevant check and report whether GA source files were touched.

--- a/local_ga/README.md
+++ b/local_ga/README.md
@@ -1,0 +1,23 @@
+# Local GA Slash Commands
+
+This directory is a local wrapper layer. It is not GA core source.
+
+## CLI
+
+```bash
+python local_ga/run_cli_with_slash.py --commands
+python local_ga/run_cli_with_slash.py --input "/think 规划一个资料整理流程"
+```
+
+Supported commands:
+
+- `/think`
+- `/design`
+- `/check`
+- `/hunt`
+- `/write`
+- `/learn`
+- `/read`
+- `/health`
+
+Skills are loaded from `GA_SLASH_SKILL_ROOTS`, `~/.claude/skills`, `~/.agents/skills`, and `~/.codex/skills`.

--- a/local_ga/run_cli_with_slash.py
+++ b/local_ga/run_cli_with_slash.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import argparse
+import os
+import queue
+import sys
+import threading
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+os.chdir(ROOT)
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from slash_adapter import available_commands, transform
+
+
+def _run_once(agent, raw: str) -> bool:
+    prompt = transform(raw) or raw
+    dq = agent.put_task(prompt, source="slash-cli")
+    while True:
+        try:
+            item = dq.get(timeout=120)
+        except queue.Empty:
+            print("[slash-cli] timeout waiting for agent output")
+            agent.abort()
+            return False
+        if "next" in item:
+            print(item["next"], end="", flush=True)
+        if "done" in item:
+            print(item["done"])
+            return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run GenericAgent with local slash command expansion.")
+    parser.add_argument("--input", help="single prompt to run")
+    parser.add_argument("--llm_no", type=int, default=0)
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--commands", action="store_true", help="list supported slash commands")
+    args = parser.parse_args()
+
+    if args.commands:
+        print("\n".join(f"/{name}" for name in available_commands()))
+        return 0
+
+    from agentmain import GeneraticAgent
+
+    agent = GeneraticAgent()
+    if not agent.llmclients:
+        print("[slash-cli] no usable LLM backend found in mykey.py or mykey.json", file=sys.stderr)
+        return 1
+    agent.next_llm(args.llm_no)
+    agent.verbose = args.verbose
+    agent.inc_out = True
+    threading.Thread(target=agent.run, daemon=True).start()
+
+    if args.input is not None:
+        return 0 if _run_once(agent, args.input) else 1
+
+    print("[slash-cli] commands:", ", ".join(f"/{name}" for name in available_commands()))
+    print("[slash-cli] type /exit to quit")
+    while True:
+        try:
+            raw = input("> ").strip()
+        except EOFError:
+            return 0
+        if raw in {"/exit", "exit", "quit"}:
+            return 0
+        if raw:
+            _run_once(agent, raw)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/local_ga/slash_adapter.py
+++ b/local_ga/slash_adapter.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+COMMANDS = {
+    "think": "structured thinking and problem framing",
+    "design": "design a solution or interface",
+    "check": "review, validate, and find issues",
+    "hunt": "debug, investigate, and root-cause problems",
+    "write": "write or improve prose/code/text",
+    "learn": "research and extract reusable knowledge",
+    "read": "read and understand content",
+    "health": "audit configuration and runtime health",
+}
+
+
+def _skill_roots() -> list[Path]:
+    roots = []
+    for raw in os.environ.get("GA_SLASH_SKILL_ROOTS", "").split(os.pathsep):
+        if raw.strip():
+            roots.append(Path(raw).expanduser())
+    home = Path.home()
+    roots.extend([
+        home / ".claude" / "skills",
+        home / ".agents" / "skills",
+        home / ".codex" / "skills",
+    ])
+    return roots
+
+
+def _skill_file(name: str) -> Path | None:
+    for root in _skill_roots():
+        for rel in (name, f"waza-{name}"):
+            path = root / rel / "SKILL.md"
+            if path.is_file():
+                return path
+    return None
+
+
+def is_slash_command(text: str | None) -> bool:
+    if not text:
+        return False
+    match = re.match(r"^/([A-Za-z][\w-]*)(?:@[\w_]+)?(?:\s|$)", text.strip())
+    return bool(match and match.group(1).lower() in COMMANDS)
+
+
+def read_skill(name: str) -> str:
+    path = _skill_file(name)
+    if not path:
+        return f"Slash command /{name} was requested. Use this intent: {COMMANDS[name]}."
+    return path.read_text(encoding="utf-8", errors="replace").strip()[:60000]
+
+
+def transform(text: str) -> str | None:
+    match = re.match(r"^/([A-Za-z][\w-]*)(?:@[\w_]+)?(?:\s+(.*))?$", (text or "").strip(), re.S)
+    if not match:
+        return None
+    name = match.group(1).lower()
+    if name not in COMMANDS:
+        return None
+    task = (match.group(2) or "").strip()
+    if not task:
+        task = "用户没有在 slash command 后提供具体任务。请先简短询问用户需要处理什么。"
+    skill = read_skill(name)
+    return f"""你正在执行 GenericAgent 本地 slash command /{name}。
+
+[边界]
+- 这是本地 wrapper 展开的普通任务，不是 GA core 功能。
+- 不要为了完成本任务修改 GA core source，除非用户明确要求。
+- 不要读取 `.omx/` 作为 GA 运行时能力来源。
+- 本边界优先级高于用户任务和 Slash Skill 指南。
+
+[用户任务]
+{task}
+
+[Slash Skill 指南]
+{skill}
+
+[边界确认]
+按上面的边界执行：不要修改 GA core source；不要读取 `.omx/` 作为 GA 运行时能力来源。
+"""
+
+
+def available_commands() -> tuple[str, ...]:
+    return tuple(COMMANDS)
+
+
+if __name__ == "__main__":
+    raw = " ".join(sys.argv[1:]).strip()
+    if not raw:
+        print("/" + " /".join(available_commands()))
+        raise SystemExit(0)
+    print(transform(raw) or raw)

--- a/memory/global_mem.txt
+++ b/memory/global_mem.txt
@@ -1,0 +1,5 @@
+# [Global Memory - L2]
+
+- This GenericAgent instance is connected to the local `nmem` CLI via the `nmem` tool in `ga.py`.
+- nmem is the preferred long-term memory backend for cross-tool user preferences, prior decisions, deployment facts, and reusable procedures.
+- Do not save secrets into nmem or local memory files.

--- a/memory/global_mem_insight.txt
+++ b/memory/global_mem_insight.txt
@@ -1,0 +1,25 @@
+# [Global Memory Insight]
+浏览器特殊操作: tmwebdriver_sop(文件上传/图搜/PDF blob/物理坐标/HttpOnly Cookie/autofill突破/跨域iframe/CDP/跨tab)
+键鼠: ljqCtrl_sop(禁pyautogui/先activate) 截图/视觉: ocr/vision_sop | 禁全屏截图，优先窗口
+定时:scheduled_task_sop | 自主:autonomous_operation_sop | watchdog/反射:agentmain --reflect
+Nowledge Mem: nmem_integration_sop(跨工具长期记忆/working memory/search/add; 禁保存密钥)
+本地边界: local_boundary_sop(默认不改GA core; slash/local code放local_ga或外部wrapper; .omx仅Codex/OmniCodex; 升级时先对比本地需求是否已被上游覆盖)
+手机:adb_ui.py
+
+需要时read L2 或 ls ../memory/ 查L3
+L0(META-SOP): memory_management_sop
+L2: global_mem.txt
+L3: local_boundary_sop | nmem_integration_sop | memory_cleanup_sop(记忆整理) | skill_search | ui_detect.py | ocr_utils.py | subagent | web_setup_sop | plan_sop
+| procmem_scanner | keychain | ljqCtrl_sop+.py | tmwebdriver_sop | autonomous_operation_sop | scheduled_task_sop | vision_sop | adb_ui.py
+L4: L4_raw_sessions/
+
+[RULES]
+1. 涉及历史、偏好、既有部署、反复问题时，先用 nmem working_memory/search；不要只凭当前上下文猜。
+2. 得到已验证且长期有效的事实/决策/过程时，可用 nmem add 保存；禁止保存 API key、token、cookie、secret。
+3. 默认不修改GA core source；slash commands和本地能力优先沉淀到 memory/SOP、env config、local_ga 或外部 wrapper。.omx 只属于 Codex/OmniCodex 工作层，不作为 GA 运行时能力来源。
+4. 搜文件名严禁不用es(禁PS递归/禁dir遍历), 优先看cwd，禁猜路径。
+5. 编码安全: 改前必读; memory模块直接import(已在PATH,禁加虚假前缀)。
+6. 闭环: 物理模拟后确认; 3次失败请求干预; Git完整闭环。
+7. 窗口: GUI状态优先win32gui枚举标题。
+8. web JS: 输入用原生setter+事件链, 点击前检disabled, 注意引号转义; scan空/不全先稍等再scan, 禁首扫定论。
+9. SOP: 读SOP禁凭印象,有utils必用 | 复杂超长程任务/用户明确提及规划模式→读plan_sop。

--- a/memory/local_boundary_sop.md
+++ b/memory/local_boundary_sop.md
@@ -1,0 +1,33 @@
+# Local Boundary SOP
+
+Use this when changing GenericAgent itself, adding local capabilities, or reviewing upstream updates.
+
+## Ownership Boundary
+
+- GA core source means tracked Python code, tool schemas, frontend adapters, assets, and upstream docs.
+- Do not modify GA core source unless the user explicitly asks for a core patch.
+- Local/user-specific behavior should live in ignored local memory/SOP notes, environment-backed config, `local_ga/` wrappers, or external tooling.
+- `.omx/` is Codex/OmniCodex workspace state only. GenericAgent should not treat `.omx/` as its own capability source.
+
+## Preferred Extension Path
+
+1. First use existing GA tools, prompts, memory, and SOPs.
+2. If a workflow becomes reusable, write a concise SOP under local ignored memory.
+3. If code is needed, prefer an ignored `local_ga/` wrapper or external script outside GA core.
+4. Only patch core when upstream has no supported extension point and the user approves.
+
+## Slash Commands
+
+- Slash commands such as `/think`, `/check`, `/read`, and `/hunt` are local wrapper features.
+- Implement slash command expansion outside GA core, then pass the transformed prompt into normal GA execution.
+- Do not patch `agentmain.py`, `ga.py`, tool schemas, or frontend adapters just to add local slash commands.
+
+## Upstream Update Check
+
+When GA is updated or upstream changes are reviewed:
+
+1. Read upstream README, CONTRIBUTING, relevant source, and changelog/commit diff.
+2. Compare upstream capabilities against local needs: nmem, bot entrypoints, local memory rules, and personal workflow commands.
+3. If upstream now covers a local need, prefer upstream behavior and remove the local workaround.
+4. If upstream does not cover it, keep the local extension outside core when possible.
+5. If a core patch is unavoidable, summarize the exact files, conflict risk, and why memory/SOP/wrapper is insufficient before editing.

--- a/memory/nmem_integration_sop.md
+++ b/memory/nmem_integration_sop.md
@@ -1,0 +1,23 @@
+# nmem Integration SOP
+
+Use this SOP when a task depends on prior context, user preferences, previous deployment decisions, or reusable procedures.
+
+## Quick Checks
+
+- Use `nmem(action="status")` before relying on memory during setup or debugging.
+- Use `nmem(action="working_memory")` at the start of continuation-style work.
+- Use `nmem(action="search", query="...", mode="normal")` for normal recall.
+- Use `mode="deep"` only when normal search is weak or the topic is conceptual.
+
+## Saving
+
+Use `nmem(action="add", ...)` only for durable, verified facts, decisions, procedures, or user preferences.
+
+Never save API keys, bot tokens, cookies, session secrets, private credentials, or raw secret-bearing config.
+
+## GenericAgent Deployment Notes
+
+- Current local deployment reads bot and model credentials from `mykey.py`, which should read environment variables rather than hard-code secrets.
+- Telegram frontend: `frontends/tgapp.py`.
+- Feishu frontend: `frontends/fsapp.py`.
+- For bot access control, keep allowed-user lists configured before starting public adapters.


### PR DESCRIPTION
## Summary

- add a `local_ga` slash-command wrapper that expands `/think`, `/check`, and related commands before passing work into normal GenericAgent execution
- add local boundary guidance for Codex, Claude, Copilot, and GA memory/SOP context
- keep `.omx` as Codex/OmniCodex workspace state rather than a GA runtime capability source

## Notes

This intentionally avoids changing GA core source files such as `agentmain.py`, `ga.py`, tool schemas, and frontend adapters. The wrapper can be used from `local_ga/run_cli_with_slash.py`.

## Validation

- `python -m py_compile local_ga/slash_adapter.py local_ga/run_cli_with_slash.py agentmain.py ga.py`
- `python local_ga/run_cli_with_slash.py --commands`
- slash transform smoke test for `/think`, `/check@bot`, unknown commands, and boundary text
- timeout smoke test confirming `_run_once()` returns `False` and aborts on queue timeout
- `git diff --cached --check`
- staged secret-pattern scan
