### PR TITLE
[codex] add external CLI delegation tools

### DIFF
--- a/assets/tools_schema.json
+++ b/assets/tools_schema.json
@@ -66,6 +66,31 @@
       "candidates": {"type": "array", "items": {"type": "string"}, "description": "Optional quick-select choices for the user"}}}
   }},
   {"type": "function", "function": {
+    "name": "delegate_cli_task",
+    "description": "Delegate an independent task to another local LLM CLI (gemini/qwen/claude/codex). Use for second opinions, parallel investigation, or backup execution. Defaults to async launch so GA is not blocked. Set wait=true only when the current turn must collect the CLI output",
+    "parameters": {"type": "object", "properties": {
+      "target": {"type": "string", "enum": ["gemini", "qwen", "claude", "codex"], "description": "Local CLI to run", "default": "gemini"},
+      "prompt": {"type": "string", "description": "Self-contained task prompt for the delegated CLI"},
+      "cwd": {"type": "string", "description": "Working directory for delegated CLI. Defaults to current GA temp cwd"},
+      "timeout": {"type": "integer", "description": "Timeout in seconds", "default": 600},
+      "mode": {"type": "string", "enum": ["default", "read_only", "auto_edit", "yolo"], "description": "Permission mode passed to the target CLI", "default": "default"},
+      "extra_args": {"type": "array", "items": {"type": "string"}, "description": "Optional extra CLI arguments appended after built-in args"},
+      "dry_run": {"type": "boolean", "description": "Return the command without executing it", "default": false},
+      "wait": {"type": "boolean", "description": "Wait for final CLI output. Default false launches in Terminal and returns output/status file paths immediately", "default": false}},
+      "required": ["prompt"]}
+  }},
+  {"type": "function", "function": {
+    "name": "check_cli_task",
+    "description": "Check an async delegate_cli_task result. Pass output_file/status_file returned by delegate_cli_task(wait=false). Returns running/success/error and current stdout. Use cleanup=true after consuming a completed result",
+    "parameters": {"type": "object", "properties": {
+      "output_file": {"type": "string", "description": "Output file returned by delegate_cli_task"},
+      "status_file": {"type": "string", "description": "Status file returned by delegate_cli_task"},
+      "prompt_file": {"type": "string", "description": "Optional prompt file returned by delegate_cli_task; used only for cleanup"},
+      "cleanup": {"type": "boolean", "description": "Delete output/status/prompt files after reading a completed result", "default": false},
+      "max_chars": {"type": "integer", "description": "Maximum stdout chars to return", "default": 20000}},
+      "required": ["output_file"]}
+  }},
+  {"type": "function", "function": {
     "name": "start_long_term_update",
     "description": "Start distilling long-term memory. Call when discovering info worth remembering (env facts/user prefs/lessons learned). Skip if memory already updated or in autonomous flow. Must call when a task that took 15+ turns is completed",
     "parameters": {"type": "object", "properties": {}}}

--- a/assets/tools_schema_cn.json
+++ b/assets/tools_schema_cn.json
@@ -66,6 +66,31 @@
       "candidates": {"type": "array", "items": {"type": "string"}, "description": "提供给用户的可选快捷选项列表"}}}
   }},
   {"type": "function", "function": {
+    "name": "delegate_cli_task",
+    "description": "把独立子任务委托给本机其它 LLM CLI（gemini/qwen/claude/codex）。适合二次意见、并行调查、替补执行。默认异步投递，不阻塞 GA；只有当前回合必须收集 CLI 输出时才设置 wait=true",
+    "parameters": {"type": "object", "properties": {
+      "target": {"type": "string", "enum": ["gemini", "qwen", "claude", "codex"], "description": "要调用的本地 CLI", "default": "gemini"},
+      "prompt": {"type": "string", "description": "交给目标 CLI 的自包含任务说明"},
+      "cwd": {"type": "string", "description": "目标 CLI 的工作目录。默认使用当前 GA temp cwd"},
+      "timeout": {"type": "integer", "description": "超时时间（秒）", "default": 600},
+      "mode": {"type": "string", "enum": ["default", "read_only", "auto_edit", "yolo"], "description": "传给目标 CLI 的权限模式", "default": "default"},
+      "extra_args": {"type": "array", "items": {"type": "string"}, "description": "追加到内置参数后的可选 CLI 参数"},
+      "dry_run": {"type": "boolean", "description": "只返回命令，不真正执行", "default": false},
+      "wait": {"type": "boolean", "description": "等待最终 CLI 输出。默认 false 会在 Terminal 中启动并立即返回输出文件/status 文件路径", "default": false}},
+      "required": ["prompt"]}
+  }},
+  {"type": "function", "function": {
+    "name": "check_cli_task",
+    "description": "检查异步 delegate_cli_task 结果。传入 delegate_cli_task(wait=false) 返回的 output_file/status_file，返回 running/success/error 和当前 stdout。读完已完成结果后可用 cleanup=true 清理临时文件",
+    "parameters": {"type": "object", "properties": {
+      "output_file": {"type": "string", "description": "delegate_cli_task 返回的输出文件路径"},
+      "status_file": {"type": "string", "description": "delegate_cli_task 返回的状态文件路径"},
+      "prompt_file": {"type": "string", "description": "delegate_cli_task 返回的可选 prompt 文件路径，仅用于 cleanup"},
+      "cleanup": {"type": "boolean", "description": "读取已完成结果后删除 output/status/prompt 文件", "default": false},
+      "max_chars": {"type": "integer", "description": "最多返回多少字符 stdout", "default": 20000}},
+      "required": ["output_file"]}
+  }},
+  {"type": "function", "function": {
     "name": "start_long_term_update",
     "description": "准备开始提炼记忆。发现值得长期记忆的信息（环境事实/用户偏好/避坑经验）时调用此工具。已记忆更新或在自主流程内时无需调用。超15轮完成的任务必须调用以沉淀经验",
     "parameters": {"type": "object", "properties": {}}}

--- a/ga.py
+++ b/ga.py
@@ -1,7 +1,7 @@
 import sys, os, re, json, time, threading, importlib
 from datetime import datetime
 from pathlib import Path
-import tempfile, traceback, subprocess, itertools, collections, difflib
+import tempfile, traceback, subprocess, itertools, collections, difflib, shutil
 if sys.stdout is None: sys.stdout = open(os.devnull, "w")
 if sys.stderr is None: sys.stderr = open(os.devnull, "w")
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -93,6 +93,227 @@ def ask_user(question, candidates=None):
     """question: 向用户提出的问题。candidates: 可选的候选项列表"""
     return {"status": "INTERRUPT", "intent": "HUMAN_INTERVENTION",
         "data": {"question": question, "candidates": candidates or []}}
+
+CLI_DELEGATE_PROFILES = {
+    "gemini": {
+        "binary": "gemini",
+        "base_args": ["--skip-trust", "-p", "{prompt}", "--output-format", "text"],
+        "modes": {
+            "read_only": ["--approval-mode", "plan"],
+            "auto_edit": ["--approval-mode", "auto_edit"],
+            "yolo": ["--yolo"],
+        },
+    },
+    "qwen": {
+        "binary": "qwen",
+        "base_args": ["--bare", "--prompt", "{prompt}", "--output-format", "text"],
+        "modes": {
+            "read_only": ["--approval-mode", "plan"],
+            "auto_edit": ["--approval-mode", "auto-edit"],
+            "yolo": ["--yolo"],
+        },
+    },
+    "claude": {
+        "binary": "claude",
+        "base_args": ["-p", "{prompt}", "--output-format", "text"],
+        "modes": {
+            "read_only": ["--permission-mode", "plan"],
+            "auto_edit": ["--permission-mode", "acceptEdits"],
+            "yolo": ["--dangerously-skip-permissions"],
+        },
+    },
+    "codex": {
+        "binary": "codex",
+        "base_args": ["exec", "{prompt}"],
+        "modes": {
+            "read_only": ["--sandbox", "read-only", "--ask-for-approval", "never"],
+            "auto_edit": ["--full-auto"],
+            "yolo": ["--dangerously-bypass-approvals-and-sandbox"],
+        },
+    },
+}
+
+CLI_DELEGATE_SYSTEM_PROMPT = """You are a delegated CLI agent called by GenericAgent.
+Answer in Chinese unless the task explicitly asks otherwise.
+Work on the requested task only. Preserve user work. Do not expose secrets.
+Before destructive actions, credential/account changes, publishing, or third-party submissions, stop and say what approval is needed.
+Return a concise report with: result, evidence, files changed, verification, and blockers."""
+
+def _build_cli_delegate_command(target, prompt, mode="default", extra_args=None):
+    target = (target or "").strip().lower()
+    if target not in CLI_DELEGATE_PROFILES:
+        return None, f"Unsupported target: {target}. Available: {', '.join(sorted(CLI_DELEGATE_PROFILES))}"
+    profile = CLI_DELEGATE_PROFILES[target]
+    exe = shutil.which(profile["binary"])
+    if not exe:
+        return None, f"CLI not found in PATH: {profile['binary']}"
+    cmd = [exe]
+    mode_args = profile.get("modes", {}).get((mode or "default").strip().lower(), [])
+    for item in profile["base_args"] + mode_args + list(extra_args or []):
+        cmd.append(prompt if item == "{prompt}" else str(item))
+    return cmd, None
+
+def _strip_ansi(text):
+    return re.sub(r"\x1B\[[0-?]*[ -/]*[@-~]", "", text or "")
+
+def _shell_quote(value):
+    return "'" + str(value).replace("'", "'\"'\"'") + "'"
+
+def _run_cli_delegate_in_terminal(run_cmd, cwd, timeout, prompt_value=None, wait=True):
+    prompt_file = out_file = marker_file = None
+    try:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as f:
+            prompt_file = f.name
+            f.write(prompt_value or "")
+        out_fd, out_file = tempfile.mkstemp(prefix="ga-cli-delegate-", suffix=".out")
+        marker_fd, marker_file = tempfile.mkstemp(prefix="ga-cli-delegate-", suffix=".status")
+        os.close(out_fd); os.close(marker_fd)
+        try: os.unlink(marker_file)
+        except OSError: pass
+
+        parts = []
+        for item in run_cmd:
+            if prompt_value is not None and item == prompt_value:
+                parts.append('"$(cat ' + _shell_quote(prompt_file) + ')"')
+            else:
+                parts.append(_shell_quote(item))
+        shell_cmd = (
+            "cd " + _shell_quote(cwd)
+            + " && " + " ".join(parts)
+            + " 2>&1 | tee " + _shell_quote(out_file)
+            + "; printf '%s' \"$?\" > " + _shell_quote(marker_file)
+        )
+        osa = 'tell application "Terminal" to do script ' + repr(shell_cmd)
+        subprocess.run(["osascript", "-e", osa], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+        if not wait:
+            return 0, json.dumps({
+                "launched": True,
+                "output_file": out_file,
+                "status_file": marker_file,
+                "prompt_file": prompt_file,
+                "note": "CLI task launched in Terminal. Read output_file/status_file later; temporary files are intentionally kept for async mode.",
+            }, ensure_ascii=False), ""
+        start = time.time()
+        while True:
+            if os.path.exists(marker_file):
+                try:
+                    exit_code = int((open(marker_file, encoding="utf-8").read() or "1").strip())
+                except ValueError:
+                    exit_code = 1
+                output = open(out_file, encoding="utf-8", errors="replace").read() if os.path.exists(out_file) else ""
+                return exit_code, _strip_ansi(output).strip(), ""
+            if time.time() - start > int(timeout or 600):
+                output = open(out_file, encoding="utf-8", errors="replace").read() if os.path.exists(out_file) else ""
+                return None, _strip_ansi(output).strip(), f"CLI delegate timed out after {timeout}s"
+            time.sleep(0.5)
+    finally:
+        if wait:
+            for path in (prompt_file, out_file, marker_file):
+                if path:
+                    try: os.unlink(path)
+                    except OSError: pass
+
+def _run_cli_delegate_process(run_cmd, cwd, env, timeout, prompt_value=None, wait=True):
+    if sys.platform == "darwin":
+        return _run_cli_delegate_in_terminal(run_cmd, cwd, timeout, prompt_value=prompt_value, wait=wait)
+    proc = subprocess.run(
+        run_cmd,
+        cwd=cwd,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=int(timeout or 600),
+    )
+    return proc.returncode, proc.stdout or "", proc.stderr or ""
+
+def delegate_cli_task(target, prompt, cwd, timeout=600, mode="default", extra_args=None, dry_run=False, wait=True):
+    """Run a task through another local LLM CLI and return structured output."""
+    prompt = (prompt or "").strip()
+    if not prompt:
+        return {"status": "error", "msg": "prompt is required"}
+    cwd = os.path.abspath(cwd or os.getcwd())
+    if not os.path.isdir(cwd):
+        return {"status": "error", "msg": f"cwd does not exist: {cwd}"}
+    full_prompt = CLI_DELEGATE_SYSTEM_PROMPT + "\n\n### Task\n" + prompt
+    cmd, err = _build_cli_delegate_command(target, full_prompt, mode=mode, extra_args=extra_args)
+    if err:
+        return {"status": "error", "msg": err}
+    safe_cmd = [cmd[0], *("<prompt>" if arg == full_prompt else arg for arg in cmd[1:])]
+    if dry_run:
+        return {"status": "success", "dry_run": True, "target": target, "cwd": cwd, "command": safe_cmd}
+    env = os.environ.copy()
+    env.setdefault("TERM", "xterm-256color")
+    try:
+        exit_code, stdout_part, stderr_part = _run_cli_delegate_process(
+            cmd, cwd, env, timeout, prompt_value=full_prompt, wait=wait
+        )
+    except subprocess.TimeoutExpired as e:
+        out = (e.stdout or "") + (e.stderr or "")
+        return {
+            "status": "error",
+            "target": target,
+            "cwd": cwd,
+            "exit_code": None,
+            "msg": f"CLI delegate timed out after {timeout}s",
+            "stdout": smart_format(out, max_str_len=12000, omit_str="\n\n[omitted long output]\n\n"),
+        }
+    except Exception as e:
+        return {"status": "error", "target": target, "cwd": cwd, "msg": str(e)}
+    stdout = (stdout_part or "") + (("\n[stderr]\n" + stderr_part) if stderr_part else "")
+    return {
+        "status": "success" if exit_code == 0 else "error",
+        "target": target,
+        "cwd": cwd,
+        "exit_code": exit_code,
+        "stdout": smart_format(stdout, max_str_len=20000, omit_str="\n\n[omitted long output]\n\n"),
+    }
+
+def check_cli_task(output_file, status_file=None, prompt_file=None, cleanup=False, max_chars=20000):
+    """Read an async CLI delegate result created by delegate_cli_task(wait=False)."""
+    output_file = os.path.abspath(output_file or "")
+    status_file = os.path.abspath(status_file or "") if status_file else ""
+    prompt_file = os.path.abspath(prompt_file or "") if prompt_file else ""
+    if not output_file:
+        return {"status": "error", "msg": "output_file is required"}
+    output = ""
+    if os.path.exists(output_file):
+        try:
+            output = open(output_file, encoding="utf-8", errors="replace").read()
+        except Exception as e:
+            return {"status": "error", "msg": f"failed to read output_file: {e}"}
+    status_exists = bool(status_file and os.path.exists(status_file))
+    if not status_exists:
+        return {
+            "status": "running",
+            "exit_code": None,
+            "output_file": output_file,
+            "status_file": status_file,
+            "stdout": smart_format(_strip_ansi(output), max_str_len=max_chars, omit_str="\n\n[omitted long output]\n\n"),
+        }
+    try:
+        raw_status = open(status_file, encoding="utf-8", errors="replace").read().strip()
+        exit_code = int(raw_status or "1")
+    except Exception:
+        exit_code = 1
+    result = {
+        "status": "success" if exit_code == 0 else "error",
+        "exit_code": exit_code,
+        "output_file": output_file,
+        "status_file": status_file,
+        "stdout": smart_format(_strip_ansi(output), max_str_len=max_chars, omit_str="\n\n[omitted long output]\n\n"),
+    }
+    if cleanup:
+        removed = []
+        for path in (output_file, status_file, prompt_file):
+            if path and os.path.exists(path):
+                try:
+                    os.unlink(path)
+                    removed.append(path)
+                except OSError:
+                    pass
+        result["removed"] = removed
+    return result
 
 import simphtml
 driver = None
@@ -305,6 +526,56 @@ class GenericAgentHandler(BaseHandler):
         result = ask_user(question, candidates)
         yield f"Waiting for your answer ...\n"
         return StepOutcome(result, next_prompt="", should_exit=True)
+
+    def do_delegate_cli_task(self, args, response):
+        '''把一个独立任务委托给本机其它 LLM CLI（gemini/qwen/claude/codex）执行。'''
+        target = args.get("target", "gemini")
+        prompt = args.get("prompt", "")
+        mode = args.get("mode", "default")
+        timeout = args.get("timeout", 600)
+        dry_run = bool(args.get("dry_run", False))
+        wait = bool(args.get("wait", False))
+        extra_args = args.get("extra_args", []) or []
+        cwd = self._get_abs_path(args.get("cwd", "./"))
+        yield f"[Action] Delegating task to {target} CLI in {cwd}\n"
+        result = delegate_cli_task(
+            target=target,
+            prompt=prompt,
+            cwd=cwd,
+            timeout=timeout,
+            mode=mode,
+            extra_args=extra_args,
+            dry_run=dry_run,
+            wait=wait,
+        )
+        icon = "✅" if result.get("status") == "success" else "❌"
+        stdout = result.get("stdout") or result.get("msg") or ""
+        yield f"[Status] {icon} delegate_cli_task target={target} mode={mode}\n{smart_format(str(stdout), max_str_len=1200)}\n"
+        next_prompt = self._get_anchor_prompt(skip=args.get('_index', 0) > 0)
+        if result.get("status") != "success":
+            next_prompt += "\n[SYSTEM TIPS] CLI委托失败。请换目标CLI、降低权限模式、缩小任务，或回退到本Agent自身工具完成。"
+        return StepOutcome(result, next_prompt=next_prompt)
+
+    def do_check_cli_task(self, args, response):
+        '''读取 delegate_cli_task(wait=false) 返回的异步 CLI 任务结果。'''
+        output_file = args.get("output_file", "")
+        status_file = args.get("status_file", "")
+        prompt_file = args.get("prompt_file", "")
+        cleanup = bool(args.get("cleanup", False))
+        max_chars = int(args.get("max_chars", 20000) or 20000)
+        yield f"[Action] Checking delegated CLI task: {output_file}\n"
+        result = check_cli_task(
+            output_file=output_file,
+            status_file=status_file,
+            prompt_file=prompt_file,
+            cleanup=cleanup,
+            max_chars=max_chars,
+        )
+        icon = {"success": "✅", "running": "⏳"}.get(result.get("status"), "❌")
+        stdout = result.get("stdout") or result.get("msg") or ""
+        yield f"[Status] {icon} check_cli_task status={result.get('status')}\n{smart_format(str(stdout), max_str_len=1200)}\n"
+        next_prompt = self._get_anchor_prompt(skip=args.get('_index', 0) > 0)
+        return StepOutcome(result, next_prompt=next_prompt)
     
     def do_web_scan(self, args, response):
         '''获取当前页面内容和标签页列表。也可用于切换标签页。

--- a/tests/test_cli_delegation.py
+++ b/tests/test_cli_delegation.py
@@ -1,0 +1,102 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from ga import check_cli_task, delegate_cli_task
+
+
+class TestCliDelegation(unittest.TestCase):
+    def test_dry_run_builds_gemini_command_without_prompt_leak(self):
+        with patch("ga.shutil.which", return_value="/usr/local/bin/gemini"):
+            result = delegate_cli_task(
+                target="gemini",
+                prompt="check this repo",
+                cwd=tempfile.gettempdir(),
+                mode="read_only",
+                dry_run=True,
+            )
+
+        self.assertEqual(result["status"], "success")
+        self.assertTrue(result["dry_run"])
+        self.assertEqual(result["command"][0], "/usr/local/bin/gemini")
+        self.assertIn("-p", result["command"])
+        self.assertIn("<prompt>", result["command"])
+        self.assertIn("--approval-mode", result["command"])
+        self.assertIn("plan", result["command"])
+        self.assertNotIn("check this repo", " ".join(result["command"]))
+
+    def test_missing_cli_returns_error(self):
+        with patch("ga.shutil.which", return_value=None):
+            result = delegate_cli_task(
+                target="gemini",
+                prompt="hello",
+                cwd=tempfile.gettempdir(),
+            )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("CLI not found", result["msg"])
+
+    def test_runs_qwen_with_structured_result(self):
+        with patch("ga.shutil.which", return_value="/usr/local/bin/qwen"), \
+             patch("ga._run_cli_delegate_process", return_value=(0, "done", "")) as run:
+            result = delegate_cli_task(
+                target="qwen",
+                prompt="summarize",
+                cwd=tempfile.gettempdir(),
+                mode="auto_edit",
+                timeout=12,
+                wait=False,
+            )
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["stdout"], "done")
+        args, kwargs = run.call_args
+        self.assertEqual(args[3], 12)
+        self.assertFalse(kwargs["wait"])
+        self.assertEqual(args[1], os.path.abspath(tempfile.gettempdir()))
+        self.assertEqual(args[0][0], "/usr/local/bin/qwen")
+        self.assertIn("--bare", args[0])
+        self.assertIn("--approval-mode", args[0])
+        self.assertIn("auto-edit", args[0])
+
+    def test_check_cli_task_running_when_status_missing(self):
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as out:
+            out.write("partial")
+            output_path = out.name
+        try:
+            result = check_cli_task(output_path, output_path + ".status")
+        finally:
+            os.unlink(output_path)
+
+        self.assertEqual(result["status"], "running")
+        self.assertEqual(result["stdout"], "partial")
+
+    def test_check_cli_task_completed_and_cleanup(self):
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as out:
+            out.write("done")
+            output_path = out.name
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as status:
+            status.write("0")
+            status_path = status.name
+
+        result = check_cli_task(output_path, status_path, cleanup=True)
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["exit_code"], 0)
+        self.assertEqual(result["stdout"], "done")
+        self.assertFalse(os.path.exists(output_path))
+        self.assertFalse(os.path.exists(status_path))
+
+    def test_tool_schemas_include_cli_delegation(self):
+        for path in ("assets/tools_schema.json", "assets/tools_schema_cn.json"):
+            with open(path, encoding="utf-8") as f:
+                schema = json.load(f)
+            names = [item["function"]["name"] for item in schema]
+            self.assertIn("delegate_cli_task", names)
+            self.assertIn("check_cli_task", names)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds two GenericAgent tools for delegating independent work to external local LLM CLIs:

- `delegate_cli_task`: launches a task through `gemini`, `qwen`, `claude`, or `codex`
- `check_cli_task`: checks async delegate output/status files and optionally cleans them up

The delegate wrapper supports permission modes (`read_only`, `auto_edit`, `yolo`), dry-run command inspection, working-directory selection, timeout control, and prompt wrapping with a small delegated-agent system instruction.

## Why

GenericAgent already has strong local tools, but some workflows benefit from calling another locally installed CLI for a second opinion, parallel investigation, or fallback execution. Exposing this as a normal GA tool keeps the workflow inside the existing tool loop instead of requiring the user to leave the agent session.

## Validation

Passed:

```bash
python -m json.tool assets/tools_schema.json >/dev/null
python -m json.tool assets/tools_schema_cn.json >/dev/null
python -m py_compile ga.py agent_loop.py agentmain.py
/Users/tingchim2pro/Desktop/GenericAgent/.venv/bin/python -m pytest tests/test_cli_delegation.py -q
```

Result:

```text
6 passed in 0.08s
```

Also ran the full local suite:

```bash
/Users/tingchim2pro/Desktop/GenericAgent/.venv/bin/python -m pytest tests -q
```

Current result was `22 passed, 3 skipped, 6 failed`. The failures are existing MiniMax/llmcore expectations unrelated to the new CLI delegation path (`temperature` request fields, `compress_history_tags` content/prompt shape, `<think>` extraction, and `LLMSession.raw_ask(model=...)`).
