### PR TITLE
fix(fsapp): show truncated tail instead of silent "..." fallback

### DIFF
--- a/frontends/fsapp.py
+++ b/frontends/fsapp.py
@@ -34,10 +34,13 @@ MEDIA_DIR = os.path.join(TEMP_DIR, "feishu_media")
 os.makedirs(MEDIA_DIR, exist_ok=True)
 
 
+_TRUNC_TAIL = 300  # 截断兜底时保留原文尾部字符数
+
+
 def _clean(text):
     for pat in _TAG_PATS:
-        text = re.sub(pat, "", text, flags=re.DOTALL)
-    return re.sub(r"\n{3,}", "\n\n", text).strip() or "..."
+        text = re.sub(pat, "", text or "", flags=re.DOTALL)
+    return re.sub(r"\n{3,}", "\n\n", text).strip()
 
 
 def _extract_files(text):
@@ -49,7 +52,11 @@ def _strip_files(text):
 
 
 def _display_text(text):
-    return _strip_files(_clean(text)) or "..."
+    cleaned = _strip_files(_clean(text))
+    if cleaned:
+        return cleaned
+    tail = (text or "").strip()[-_TRUNC_TAIL:]
+    return "⚠️ 模型输出被截断或为空" + (f"\n…{tail}" if tail else "")
 
 
 def _to_allowed_set(value):


### PR DESCRIPTION
## Problem

When the model output ends up containing **only** fully-stripped tags (e.g. token budget exhausted inside `<thinking>...</thinking>` with no body emitted), `_clean()` returned the literal string `"..."` and the user only saw `"..."` in Feishu — losing all context about what the model was doing.

The same `or "..."` fallback in `_display_text()` masked the issue further.

## Fix

- `_clean()`: drop the `or "..."` fallback, return empty string instead.
- `_display_text()`: when cleaned result is empty, surface a warning **plus the last 300 chars of the raw output**, so the user can still see what the model was working on right before the truncation.
- Add `_TRUNC_TAIL = 300` constant.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Normal output | text | text (unchanged) |
| Only closed `<thinking>...</thinking>`, no body | `...` | `⚠️ 模型输出被截断或为空
…<thinking>...</thinking>` |
| Truncated mid `<thinking>` (no closing tag) | half thinking shown | half thinking shown (unchanged) |
| Empty content | `...` | `⚠️ 模型输出被截断或为空` |
| Raw > 300 chars after stripping all tags | `...` | warning + last 300 chars |

## Diff size

`1 file changed, 10 insertions(+), 3 deletions(-)` — net ~6 logical lines.
