### PR TITLE
fix(stapp): defend autonomous_enabled init against fragment-only reruns

### DIFF
--- a/frontends/stapp.py
+++ b/frontends/stapp.py
@@ -32,10 +32,11 @@ agent = init()
 
 st.title("🖥️ Cowork")
 
-if 'autonomous_enabled' not in st.session_state: st.session_state.autonomous_enabled = False
+st.session_state.setdefault('autonomous_enabled', False)
 
 @st.fragment
 def render_sidebar():
+    st.session_state.setdefault('autonomous_enabled', False)
     llm_options = agent.list_llms()
     current_idx = agent.llm_no
     llm_labels = {idx: f"{idx}: {(name or '').strip()}" for idx, name, _ in llm_options}


### PR DESCRIPTION
Closes #197.

## Problem

\`render_sidebar()\` is decorated \`@st.fragment\` and triggers \`st.rerun(scope=\"fragment\")\` on backup-link change (line 45). Fragment-scoped reruns re-execute only the fragment body — the module-level guard at line 35 (\`if 'autonomous_enabled' not in st.session_state: ...\`) never runs in that path. After any session-state-clearing event (Streamlit menu \"Clear cache\" + immediate sidebar interaction), the very next read at line 84 raises:

\`\`\`
AttributeError: st.session_state has no attribute \"autonomous_enabled\".
Did you forget to initialize it?
\`\`\`

— exactly the symptom in #197.

## Fix

Idempotent \`setdefault\` at the top of the fragment body. Module-level init switched to the same idiom for consistency.

\`\`\`diff
- if 'autonomous_enabled' not in st.session_state: st.session_state.autonomous_enabled = False
+ st.session_state.setdefault('autonomous_enabled', False)

  @st.fragment
  def render_sidebar():
+     st.session_state.setdefault('autonomous_enabled', False)
\`\`\`

Net +1 line. No behaviour change on full reruns. \`setdefault\` is idempotent — if the user has already toggled autonomy on, the value is preserved.

## Verification

Pre-fix the bug path raises the exact user-facing error; post-fix the same path returns cleanly and preserves the user's chosen state across fragment-only reruns:

\`\`\`
PRE-FIX repro OK: st.session_state has no attribute \"autonomous_enabled\". Did you forget to initialize it?
POST-FIX: returned 'stopped', no exception
POST-FIX with already-True: autonomous_enabled = True (preserved)
\`\`\`

\`python -m py_compile frontends/stapp.py\` clean.

## Checklist

- [x] Issue linked (#197)
- [x] Net line count: +1 (minimal — single defensive line in the affected fragment, plus an equivalent-cost rewrite of the existing init)
- [x] No new dependencies
- [x] No comments added (per CONTRIBUTING.md)
- [x] One concern, one PR