### PR TITLE
fix(dingtalkapp): exponential reconnect backoff and token fetch retry

### DIFF
--- a/frontends/dingtalkapp.py
+++ b/frontends/dingtalkapp.py
@@ -36,14 +36,19 @@ class DingTalkApp(AgentChatMixin):
             resp.raise_for_status()
             return resp.json()
 
-        try:
-            data = await asyncio.to_thread(_fetch)
-            self.access_token = data.get("accessToken")
-            self.token_expiry = time.time() + int(data.get("expireIn", 7200)) - 60
-            return self.access_token
-        except Exception as e:
-            print(f"[DingTalk] token error: {e}")
-            return None
+        last_err = None
+        for attempt in range(2):
+            try:
+                data = await asyncio.to_thread(_fetch)
+                self.access_token = data.get("accessToken")
+                self.token_expiry = time.time() + int(data.get("expireIn", 7200)) - 60
+                return self.access_token
+            except Exception as e:
+                last_err = e
+                if attempt == 0:
+                    await asyncio.sleep(1)
+        print(f"[DingTalk] token error after retry: {last_err}")
+        return None
 
     async def _send_batch_message(self, chat_id, msg_key, msg_param):
         token = await self._get_access_token()
@@ -102,13 +107,19 @@ class DingTalkApp(AgentChatMixin):
         self.client = DingTalkStreamClient(Credential(CLIENT_ID, CLIENT_SECRET))
         self.client.register_callback_handler(ChatbotMessage.TOPIC, _DingTalkHandler(self))
         print("[DingTalk] bot starting...")
+        delay, max_delay = 5, 300
         while True:
+            started_at = time.monotonic()
             try:
                 await self.client.start()
             except Exception as e:
                 print(f"[DingTalk] stream error: {e}")
-            print("[DingTalk] reconnect in 5s...")
-            await asyncio.sleep(5)
+            # any session that lived >=60s is treated as healthy -> reset backoff
+            if time.monotonic() - started_at >= 60:
+                delay = 5
+            print(f"[DingTalk] reconnect in {delay}s...")
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, max_delay)
 
 
 class _DingTalkHandler(CallbackHandler):


### PR DESCRIPTION
## What
- Reconnect: replace fixed 5s sleep with exponential backoff (5, 10, 20, ..., 300s); reset to 5s when a session lived ≥60s.
- Access token fetch: retry once after 1s before returning None.

## Why

**Reconnect.** The current loop sleeps a constant 5s on every `stream error`. During a sustained DingTalk outage or a misconfigured credential, this hammers the platform with one reconnect every 5s and floods `dingtalkapp.log`. Backoff lets pressure relax under prolonged failure. The ≥60s "healthy session" check guards against a long-lived bot drifting up to a 5-min delay just because one reconnect happened after weeks of uptime. `time.monotonic()` is used so a system clock jump can't fool the window check.

**Access token retry.** `_get_access_token` is called inline before every `_send_batch_message`. A single transient network error on the OAuth endpoint currently makes the call return `None`, and `_send_batch_message` silently drops the user's reply. One retry after 1s absorbs the common case (DNS hiccup, TCP reset). Worst-case path is `20s timeout + 1s + 20s timeout = 41s`, still inside the user-perceptible budget.

## Solved
- Sustained DingTalk-side outages no longer flood the log or burn the reconnect budget.
- A single transient blip on the OAuth endpoint no longer silently drops the user's next reply.

## Out of scope
Concurrent token fetches racing past the cache check are not deduplicated. That's a separate concern; the bug this PR addresses is single-call resilience.