### PR TITLE
fix: use HTTPS for skill_search API endpoint

### DIFF
--- a/memory/skill_search/SKILL.md
+++ b/memory/skill_search/SKILL.md
@@ -60,5 +60,5 @@ python -m skill_search --env
 
 | 项 | 默认值 | 说明 |
 |---|---|---|
-| API地址 | `http://www.fudankw.cn:58787` | 环境变量 `SKILL_SEARCH_API` 可覆盖 |
+| API地址 | `https://www.fudankw.cn:58787` | 环境变量 `SKILL_SEARCH_API` 可覆盖 |
 | API密钥 | 无(可选) | 环境变量 `SKILL_SEARCH_KEY` |

--- a/memory/skill_search/skill_search/engine.py
+++ b/memory/skill_search/skill_search/engine.py
@@ -111,7 +111,7 @@ def detect_environment():
 
 # ── API 配置与调用 ────────────────────────────────────────
 
-DEFAULT_API_URL = "http://www.fudankw.cn:58787"
+DEFAULT_API_URL = "https://www.fudankw.cn:58787"
 
 def _get_api_url():
     return os.environ.get("SKILL_SEARCH_API", DEFAULT_API_URL)


### PR DESCRIPTION
## Summary

Changed the default `skill_search` API URL from plaintext HTTP to HTTPS, ensuring environment data (OS, shell, runtimes, tools, model info) is transmitted encrypted.

Closes #204

## Changes

- `memory/skill_search/skill_search/engine.py`: Changed `DEFAULT_API_URL` from `http://` to `https://`
- `memory/skill_search/SKILL.md`: Updated documentation to reflect the HTTPS URL

## Details

The `skill_search` module sends detected environment information (OS type, installed runtimes, available tools) to the API endpoint on every query. Using plaintext HTTP exposes this data to network interception. This fix ensures all API communication uses HTTPS by default.

Users who need to override the URL can still set the `SKILL_SEARCH_API` environment variable.
