### PR TITLE
fix: cap consecutive empty LLM response retries to prevent infinite loop

### DIFF
--- a/ga.py
+++ b/ga.py
@@ -266,6 +266,7 @@ class GenericAgentHandler(BaseHandler):
         self.history_info = last_history if last_history else []
         self.code_stop_signal = []
         self._done_hooks = []
+        self._blank_streak = 0
 
     def _get_abs_path(self, path):
         if not path: return ""
@@ -445,8 +446,13 @@ class GenericAgentHandler(BaseHandler):
         content = getattr(response, 'content', '') or ""
         thinking = getattr(response, 'thinking', '') or ""
         if not response or (not content.strip() and not thinking.strip()):
+            self._blank_streak += 1
+            if self._blank_streak >= 3:
+                yield "[Error] LLM returned empty response 3 times consecutively. Aborting.\n"
+                return StepOutcome({}, next_prompt=None)
             yield "[Warn] LLM returned an empty response. Retrying...\n"
             return StepOutcome({}, next_prompt="[System] Blank response, regenerate and tooluse")
+        self._blank_streak = 0
         if len(content) > 50 and ('[!!! 流异常中断' in content[-100:] or '!!!Error:' in content[-100:]):
             return StepOutcome({}, next_prompt="[System] Incomplete response. Regenerate and tooluse.")
         if 'max_tokens !!!]' in content[-100:]:


### PR DESCRIPTION
## Summary

Added a consecutive empty response counter to prevent the agent from entering an infinite retry loop when the LLM consistently returns empty content.

Closes #201

## Changes

- `ga.py`: Added `_blank_streak` counter to `GenericAgentHandler.__init__`
- `ga.py`: Modified `do_no_tool()` to track consecutive blank responses and abort after 3 failures

## Details

Previously, when the LLM returned an empty response, `do_no_tool` would yield a warning and retry indefinitely (up to the `max_turns=40` outer loop limit). This caused excessive API calls, cost waste, and log flooding with "LLM returned an empty response. Retrying..." messages.

The fix introduces a `_blank_streak` counter:
- Increments on each consecutive empty response
- Resets to 0 on any non-empty response
- After 3 consecutive empty responses, returns `next_prompt=None` which signals the agent loop to exit gracefully
