### PR TITLE
fix: add missing body to __main__ block in vision_api template

### DIFF
--- a/memory/vision_api.template.py
+++ b/memory/vision_api.template.py
@@ -111,3 +111,4 @@ def _call_openai_compat(b64, prompt, timeout, *, apibase, apikey, model, proxy=N
     return resp.json()['choices'][0]['message']['content']
 
 if __name__ == '__main__':
+    pass


### PR DESCRIPTION
## Summary

Fixed `IndentationError` in `memory/vision_api.template.py` where the `if __name__ == '__main__':` block had an empty body.

## Changes

- `memory/vision_api.template.py`: Added `pass` statement after `if __name__ == '__main__':`

## Details

The file failed `py_compile` with `IndentationError: expected an indented block after 'if' statement`. While this is a template file, any tool attempting to import or lint it would crash. Added a minimal `pass` to satisfy the syntax requirement.
