### PR TITLE
Update README with virtual environment setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ If you prefer a modern Python workflow, GenericAgent also provides a minimal `py
 ```bash
 git clone https://github.com/lsdefine/GenericAgent.git
 cd GenericAgent
+uv venv
 uv pip install -e ".[ui]"        # Core + GUI dependencies
 cp mykey_template.py mykey.py
 python launch.pyw


### PR DESCRIPTION
Added instructions for setting up a virtual environment and installing dependencies.

error: No virtual environment found; run `uv venv` to create an environment, or pass `--system` to install into a non-virtual environment
This pull request makes a minor improvement to the setup instructions in the `README.md` file by adding the `uv venv` command. This clarifies that users should create a virtual environment before installing dependencies.