### PR TITLE
fix: cap consecutive empty LLM response retries to prevent infinite loop

### DIFF
--- a/ga.py
+++ b/ga.py
@@ -267,6 +267,7 @@ class GenericAgentHandler(BaseHandler):
         self.history_info = last_history if last_history else []
         self.code_stop_signal = []
         self._done_hooks = []
+        self._consecutive_empty_retries = 0
 
     def _get_abs_path(self, path):
         if not path: return ""
@@ -446,8 +447,14 @@ class GenericAgentHandler(BaseHandler):
         content = getattr(response, 'content', '') or ""
         thinking = getattr(response, 'thinking', '') or ""
         if not response or (not content.strip() and not thinking.strip()):
-            yield "[Warn] LLM returned an empty response. Retrying...\n"
+            self._consecutive_empty_retries += 1
+            if self._consecutive_empty_retries > 3:
+                self._consecutive_empty_retries = 0
+                yield "[Error] LLM returned empty responses 3 consecutive times. Stopping.\n"
+                return StepOutcome({}, next_prompt=None)
+            yield f"[Warn] LLM returned an empty response. Retrying ({self._consecutive_empty_retries}/3)...\n"
             return StepOutcome({}, next_prompt="[System] Blank response, regenerate and tooluse")
+        self._consecutive_empty_retries = 0
         if len(content) > 50 and ('[!!! 流异常中断' in content[-100:] or '!!!Error:' in content[-100:]):
             return StepOutcome({}, next_prompt="[System] Incomplete response. Regenerate and tooluse.")
         if 'max_tokens !!!]' in content[-100:]:


### PR DESCRIPTION
Closes #201

## Summary

Issue #201 reports that the agent enters an infinite retry loop when the LLM returns empty responses, continuously printing `[Warn] LLM returned an empty response. Retrying...` without any upper bound.

## Root Cause

`do_no_tool()` in `ga.py` returns a `StepOutcome` with a retry prompt whenever the LLM response is empty. The agent loop (`agent_runner_loop`) then re-invokes the LLM, which can produce another empty response, creating an unbounded cycle until `max_turns` (40) is exhausted.

## Fix

- Added a consecutive empty response counter (`_consecutive_empty_retries`) to `GenericAgentHandler`
- After 3 consecutive empty responses, the loop breaks by returning `StepOutcome({}, next_prompt=None)` instead of a retry prompt
- The counter resets on any non-empty response
- Retry messages now show progress: `Retrying (1/3)...`, `Retrying (2/3)...`, etc.

## Changes

- `ga.py` — `__init__`: added `_consecutive_empty_retries = 0`
- `ga.py` — `do_no_tool()`: capped retries at 3, added counter reset on valid response

## Verification

```
✓ python3 -m py_compile ga.py — no syntax errors
✓ ruff check ga.py — no new lint issues (existing project-level warnings unchanged)
✓ 8 lines added, 1 removed — surgical change, no collateral modification
```
