### PR TITLE
fix: add Linux CJK font paths for desktop pet bubble text rendering

### DIFF
--- a/frontends/desktop_pet_v2.pyw
+++ b/frontends/desktop_pet_v2.pyw
@@ -82,6 +82,11 @@ def _load_default_font(size):
         'C:/Windows/Fonts/msyh.ttc',
         'C:/Windows/Fonts/simhei.ttf',
         'C:/Windows/Fonts/arial.ttf',
+        '/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc',
+        '/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc',
+        '/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc',
+        '/usr/share/fonts/truetype/droid/DroidSansFallbackFull.ttf',
+        '/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc',
     ]
     for font_path in font_candidates:
         if os.path.exists(font_path):


### PR DESCRIPTION
Closes #68

## Summary

Issue #68 reports that on Debian/Linux, the desktop pet's speech bubble shows garbled text (乱码) because `_load_default_font()` only contains macOS and Windows font paths, falling back to `ImageFont.load_default()` which cannot render CJK characters.

## Fix

Added common Linux CJK font paths to the `_load_default_font()` candidate list:

- `/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc`
- `/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc`
- `/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc`
- `/usr/share/fonts/truetype/droid/DroidSansFallbackFull.ttf`
- `/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc`

These cover the most common Linux distributions (Ubuntu, Debian, Fedora, Arch) with their default CJK font packages installed.

## Changes

- `frontends/desktop_pet_v2.pyw` — `_load_default_font()`: added 5 Linux font paths

## Verification

```
✓ python3 -m py_compile frontends/desktop_pet_v2.pyw — no syntax errors
✓ 5 lines added, 0 removed — minimal change, no side effects
```
