### PR TITLE
fix: mutable default list in code_run stop_signal parameter

### DIFF
--- a/ga.py
+++ b/ga.py
@@ -9,14 +9,14 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from agent_loop import BaseHandler, StepOutcome, json_default
 script_dir = os.path.dirname(os.path.abspath(__file__))
 
-def code_run(code, code_type="python", timeout=60, cwd=None, code_cwd=None, stop_signal=[]):
+def code_run(code, code_type="python", timeout=60, cwd=None, code_cwd=None, stop_signal=None):
     """代码执行器
     python: 运行复杂的 .py 脚本（文件模式）
     powershell/bash: 运行单行指令（命令模式）
     优先使用python，仅在必要系统操作时使用powershell"""
     preview = (code[:60].replace('\n', ' ') + '...') if len(code) > 60 else code.strip()
     yield f"[Action] Running {code_type} in {os.path.basename(cwd)}: {preview}\n"
-    cwd = cwd or os.path.join(script_dir, 'temp'); tmp_path = None
+    stop_signal = stop_signal or []; cwd = cwd or os.path.join(script_dir, 'temp'); tmp_path = None
     if code_type in ["python", "py"]:
         tmp_file = tempfile.NamedTemporaryFile(suffix=".ai.py", delete=False, mode='w', encoding='utf-8', dir=code_cwd)
         cr_header = os.path.join(script_dir, 'assets', 'code_run_header.py')


### PR DESCRIPTION
## Summary

Fix a common Python pitfall where `stop_signal=[]` is used as a mutable default argument in the `code_run()` function signature.

## Problem

In `ga.py:12`, `code_run()` has `stop_signal=[]` as a default parameter. In Python, mutable default arguments are shared across all calls, which means if one call mutates the list, subsequent calls will see the modified default. This is a well-known Python anti-pattern.

## Fix

- Changed default from `stop_signal=[]` to `stop_signal=None`
- Added `stop_signal = stop_signal or []` at the start of the function body
- Behavior is identical for callers (still accepts a list), but the default is now safely immutable

## Testing

- `python3 -m py_compile ga.py` passes
- No functional change — callers either pass an explicit list or get a fresh empty list
