### PR TITLE
fix: add missing body to if __name__ block in vision_api template

### DIFF
--- a/memory/vision_api.template.py
+++ b/memory/vision_api.template.py
@@ -111,3 +111,4 @@ def _call_openai_compat(b64, prompt, timeout, *, apibase, apikey, model, proxy=N
     return resp.json()['choices'][0]['message']['content']
 
 if __name__ == '__main__':
+    pass


### PR DESCRIPTION
## Summary

Fix an `IndentationError` in `memory/vision_api.template.py` that causes a crash when the template is copied and customized.

## Problem

Line 113 has `if __name__ == '__main__':` with no indented block following it, resulting in:

```
IndentationError: expected an indented block after 'if' statement
```

Users copy this template to `vision_api.py` and fill in the `***` placeholders. The missing body in the `if __name__` block makes the copied file syntactically invalid.

## Fix

Added `pass` as the body of the `if __name__ == '__main__'` block. This makes the template syntactically valid without changing any behavior.

## Testing

- `python3 -m py_compile memory/vision_api.template.py` passes
