### PR TITLE
fix: add timeout to TMWebDriver remote requests

### DIFF
--- a/TMWebDriver.py
+++ b/TMWebDriver.py
@@ -242,8 +242,8 @@ class TMWebDriver:
         if newtabs: rr['newTabs'] = newtabs
         return rr
     
-    def _remote_cmd(self, cmd):
-        try: return requests.post(self.remote, headers={"Content-Type": "application/json"}, json=cmd).json()
+    def _remote_cmd(self, cmd, timeout=30):
+        try: return requests.post(self.remote, headers={"Content-Type": "application/json"}, json=cmd, timeout=timeout).json()
         except (ConnectionError, requests.exceptions.ConnectionError):
             raise ConnectionError("TMWebDriver master未运行，看tmwebdriver_sop启动master")
 


### PR DESCRIPTION
## Summary

Add a `timeout` parameter to `TMWebDriver._remote_cmd()` to prevent indefinite hanging on unresponsive servers.

## Problem

`requests.post()` in `_remote_cmd()` has no `timeout` parameter. If the remote TMWebDriver master is unresponsive, the call hangs indefinitely, blocking the entire agent.

## Fix

- Added `timeout=30` as a default parameter to `_remote_cmd()`
- Passed `timeout` to `requests.post()` call
- 30-second default is generous for local server commands
- No change to existing callers (default is backward-compatible)

## Testing

- `python3 -m py_compile TMWebDriver.py` passes
- Higher-level `wait_result` method already has its own timeout logic for long-running scripts
