### PR TITLE
feat: display QR code in terminal (WSL compatible)

### DIFF
--- a/frontends/wechatapp.py
+++ b/frontends/wechatapp.py
@@ -1,4 +1,4 @@
-import os, sys, re, threading, queue, time, socket, json, struct, base64, uuid, webbrowser, hashlib, math
+import os, sys, re, threading, queue, time, socket, json, struct, base64, uuid, hashlib, math
 from pathlib import Path
 from urllib.parse import quote
 import requests, qrcode
@@ -61,8 +61,10 @@ class WxBotClient:
         qr_id, url = d['qrcode'], d.get('qrcode_img_content', '')
         print(f'[QR登录] ID: {qr_id}')
         if url:
-            img = self._tf.parent / 'wx_qr.png'
-            qrcode.make(url).save(str(img)); webbrowser.open(str(img))
+            qr = qrcode.QRCode(border=1)
+            qr.add_data(url)
+            qr.make(fit=True)
+            qr.print_ascii(invert=True)  # 直接在终端显示，兼容WSL
         last = ''
         while True:
             time.sleep(poll_interval)


### PR DESCRIPTION
## 改动说明
将微信登录二维码的显示方式从「生成 `wx_qr.png` 并调用 `webbrowser.open()`」改为「使用 `qrcode.print_ascii()` 直接输出到终端」。

## 改动详情

| 项目 | 改动前 | 改动后 |
|------|--------|--------|
| 显示方式 | 生成 `wx_qr.png` 并调用 `webbrowser.open()` | 使用 `qrcode.print_ascii()` 直接输出到终端 |
| 依赖 | 需要图形界面或浏览器 | 纯终端，无额外依赖 |
| WSL兼容 | ❌ WSL下浏览器调用可能失败 | ✅ 完全兼容 |

## 代码变更

```python
# Before
img = self._tf.parent / 'wx_qr.png'
qrcode.make(url).save(str(img))
webbrowser.open(str(img))

# After
qr = qrcode.QRCode(border=1)
qr.add_data(url)
qr.make(fit=True)
qr.print_ascii(invert=True)  # 直接在终端显示，兼容WSL
```

影响范围
仅修改 frontends/wechatapp.py
移除 webbrowser 模块导入
登录流程无变化，仅二维码展示方式改变
不仅仅是为了兼容WSL,，同时不需要增加一步浏览器打开二维码图片的步骤，直接将二维码渲染在终端直接扫描即可

测试
- WSL环境下终端正常显示二维码
- 二维码可正常扫描登录