### PR TITLE
 优化微信二维码登录展示方式：支持终端二维码显示与图片打开

### DIFF
--- a/frontends/wechatapp.py
+++ b/frontends/wechatapp.py
@@ -62,8 +62,12 @@ class WxBotClient:
         print(f'[QR登录] ID: {qr_id}')
         if url:
             img = self._tf.parent / 'wx_qr.png'
-            qrcode.make(url).save(str(img)); webbrowser.open(str(img))
-        last = ''
+            qr = qrcode.QRCode(border=1)
+            qr.add_data(url)
+            qr.make(fit=True)
+            qr.print_ascii(invert=True)
+            qr.make_image().save(str(img))
+            webbrowser.open(str(img))       
         while True:
             time.sleep(poll_interval)
             try: s = requests.get(f'{API}/ilink/bot/get_qrcode_status', params={'qrcode': qr_id}, headers={'User-Agent': UA}, timeout=60).json()


### PR DESCRIPTION
#修改背景

原有 `wechatapp.py` 中微信登录二维码的展示方式只会将二维码保存为图片，并调用系统默认程序打开：

```python
img = self._tf.parent / 'wx_qr.png'
qrcode.make(url).save(str(img))
webbrowser.open(str(img))

这种方式在 Windows 桌面环境下通常可以正常使用，但在以下场景中体验不佳：

WSL 环境中可能无法正常弹出图片查看器
SSH / 远程终端环境中无法直接打开 GUI 图片
用户需要手动找到二维码图片再扫码
登录流程依赖图形界面，不够通用

因此本次修改在保留原有图片保存和打开逻辑的基础上，增加了终端二维码显示能力。
同时兼顾原有功能，并且兼容特殊情况