### PR TITLE
feat: file_write auto-resume on truncation

### DIFF
--- a/ga.py
+++ b/ga.py
@@ -371,31 +371,100 @@ class GenericAgentHandler(BaseHandler):
         path = self._get_abs_path(args.get("path", ""))
         mode = args.get("mode", "overwrite")  # overwrite/append/prepend
         action_str = {"prepend": "Prepending to", "append": "Appending to"}.get(mode, "Overwriting")
-        yield f"[Action] {action_str} file: {os.path.basename(path)}\n"
 
+        # --- Truncation-aware content extraction ---
         def extract_robust_content(text):
+            """Extract file content, tolerating truncated (unclosed) <file_content> tags."""
+            # 1. Normal closed tag
             tags = re.findall(r"<file_content[^>]*>(.*?)</file_content>", text, re.DOTALL)
-            if tags: return tags[-1].strip()
+            if tags: return tags[-1].strip(), False
+            # 2. Unclosed <file_content> — likely truncated
+            m = re.search(r"<file_content[^>]*>([\s\S]*)", text)
+            if m:
+                raw = m.group(1)
+                # Strip trailing truncation markers appended by llmcore
+                raw = re.sub(r'\s*\[!!! [^\]]*!!!\]\s*$', '', raw)
+                raw = re.sub(r'\s*!!!Error:[^\n]*$', '', raw)
+                return raw.rstrip(), True
+            # 3. Fallback: code block
             blocks = re.findall(r"```[^\n]*\n([\s\S]*?)```", text)
-            if blocks: return blocks[-1].strip()
-            return None
-        
-        blocks = extract_robust_content(response.content)
-        if not blocks:
+            if blocks: return blocks[-1].strip(), False
+            return None, False
+
+        # Check if this is a continuation of a previously truncated write
+        pending = self.working.get('_file_write_resume')
+        is_continuation = pending and pending.get('path') == path
+
+        if is_continuation:
+            mode = "append"  # force append for continuation
+            action_str = "Resuming write to"
+            yield f"[Action] {action_str} file: {os.path.basename(path)} (continuation #{pending.get('round', 1)})\n"
+        else:
+            yield f"[Action] {action_str} file: {os.path.basename(path)}\n"
+
+        content, was_truncated = extract_robust_content(response.content)
+        if not content:
             yield f"[Status] ❌ 失败: 未在回复中找到<file_content>代码块内容\n"
+            self.working.pop('_file_write_resume', None)
             return StepOutcome({"status": "error", "msg": "No content found. Put content inside <file_content>...</file_content> tags in your reply body before call file_write."}, next_prompt="\n")
+
         try:
-            new_content = expand_file_refs(blocks, base_dir=self.cwd)
-            if mode == "prepend":
+            new_content = expand_file_refs(content, base_dir=self.cwd)
+
+            # Overlap dedup for continuation: remove repeated prefix
+            if is_continuation and pending.get('tail'):
+                tail = pending['tail']
+                # Find longest overlap between stored tail and new content start
+                overlap_len = 0
+                check_len = min(len(tail), len(new_content), 200)
+                for k in range(check_len, 0, -1):
+                    if new_content[:k] == tail[-k:]:
+                        overlap_len = k; break
+                if overlap_len > 0:
+                    new_content = new_content[overlap_len:]
+                    yield f"[Info] Dedup: removed {overlap_len} overlapping chars\n"
+
+            # Write
+            if is_continuation:
+                with open(path, 'a', encoding="utf-8") as f: f.write(new_content)
+            elif mode == "prepend":
                 old = open(path, 'r', encoding="utf-8").read() if os.path.exists(path) else ""
                 open(path, 'w', encoding="utf-8").write(new_content + old)
             else:
                 with open(path, 'a' if mode == "append" else 'w', encoding="utf-8") as f: f.write(new_content)
-            yield f"[Status] ✅ {mode.capitalize()} 成功 ({len(new_content)} bytes)\n"
-            next_prompt = self._get_anchor_prompt(skip=args.get('_index', 0) > 0)
-            return StepOutcome({"status": "success", 'writed_bytes': len(new_content)}, next_prompt=next_prompt)
+
+            total_bytes = pending.get('total_bytes', 0) + len(new_content) if is_continuation else len(new_content)
+
+            if was_truncated:
+                round_no = (pending.get('round', 0) if is_continuation else 0) + 1
+                if round_no >= 8:
+                    yield f"[Status] ⚠️ 已续写 {round_no} 轮仍未完成，停止续写 (已写入 {total_bytes} bytes)\n"
+                    self.working.pop('_file_write_resume', None)
+                    return StepOutcome({"status": "partial", "writed_bytes": total_bytes, "msg": "Max continuation rounds reached"}, next_prompt="\n")
+
+                # Store tail for overlap dedup
+                tail_anchor = new_content[-80:] if len(new_content) >= 80 else new_content
+                self.working['_file_write_resume'] = {'path': path, 'round': round_no, 'total_bytes': total_bytes, 'tail': tail_anchor}
+                yield f"[Status] ⏳ 输出被截断，已写入 {len(new_content)} bytes (累计 {total_bytes})，自动请求续写...\n"
+                resume_prompt = (
+                    f"[System] file_write 输出因长度截断，已将已收到的内容写入 {path} ({total_bytes} bytes)。\n"
+                    f"请**立即**继续输出剩余文件内容。要求：\n"
+                    f"1. 从上次中断处继续（最后80字符为: `{tail_anchor[-60:]}`）\n"
+                    f"2. 内容放在 <file_content>...</file_content> 标签内\n"
+                    f"3. 再次调用 file_write 工具（path=\"{path}\"）\n"
+                    f"4. 禁止重复已写入内容，禁止输出任何解释文字，只输出续写内容和工具调用"
+                )
+                return StepOutcome({"status": "truncated_continuing", "writed_bytes": total_bytes, "round": round_no}, next_prompt=resume_prompt)
+            else:
+                # Completed successfully (or final continuation chunk)
+                self.working.pop('_file_write_resume', None)
+                rounds_info = f", {pending['round']+1} rounds" if is_continuation else ""
+                yield f"[Status] ✅ {('Overwrite' if not is_continuation else 'Write')} 成功 ({total_bytes} bytes{rounds_info})\n"
+                next_prompt = self._get_anchor_prompt(skip=args.get('_index', 0) > 0)
+                return StepOutcome({"status": "success", 'writed_bytes': total_bytes}, next_prompt=next_prompt)
         except Exception as e:
             yield f"[Status] ❌ 写入异常: {str(e)}\n"
+            self.working.pop('_file_write_resume', None)
             return StepOutcome({"status": "error", "msg": str(e)}, next_prompt="\n")
         
     def do_file_read(self, args, response):

--- a/tests/test_file_write_resume.py
+++ b/tests/test_file_write_resume.py
@@ -1,0 +1,139 @@
+
+"""Unit test for do_file_write auto-resume on truncation.
+Mocks Response object + truncation markers, exercises 3 scenarios:
+1) Normal complete write
+2) First truncation -> partial write + resume state set
+3) Continuation with overlap -> dedup + finish
+"""
+import sys, os, tempfile, shutil
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Stub heavy imports before loading ga
+class _Stub:
+    def __getattr__(self, k): return _Stub()
+    def __call__(self, *a, **kw): return _Stub()
+sys.modules.setdefault('simphtml', _Stub())
+
+import ga
+from agent_loop import StepOutcome
+
+# --- Mock Response ---
+class MockResponse:
+    def __init__(self, content): self.content = content; self.thinking = ""
+
+# --- Mock Handler (skip __init__, set only what do_file_write needs) ---
+class FakeHandler(ga.GenericAgentHandler):
+    def __init__(self, cwd):
+        self.cwd = cwd
+        self.working = {}
+    def _get_abs_path(self, p):
+        return p if os.path.isabs(p) else os.path.join(self.cwd, p)
+    def _get_anchor_prompt(self, skip=False): return ""
+
+def run_tool(handler, args, response):
+    """Drain generator, capture yields and final StepOutcome."""
+    gen = handler.do_file_write(args, response)
+    yields = []
+    try:
+        while True: yields.append(next(gen))
+    except StopIteration as e:
+        return yields, e.value
+
+def header(t): print(f"\n{'='*60}\n  {t}\n{'='*60}")
+
+tmp = tempfile.mkdtemp()
+try:
+    h = FakeHandler(tmp)
+
+    # ============ TEST 1: Normal complete write ============
+    header("TEST 1: Normal complete write (closed tag)")
+    resp = MockResponse("Sure, here's the file:\n<file_content>line1\nline2\nline3</file_content>\nDone.")
+    yields, outcome = run_tool(h, {"path": "a.txt", "mode": "overwrite"}, resp)
+    print("YIELDS:"); [print(" ", y.rstrip()) for y in yields]
+    print("OUTCOME:", outcome.data)
+    p = os.path.join(tmp, "a.txt")
+    actual = open(p, encoding='utf-8').read()
+    assert actual == "line1\nline2\nline3", f"got {actual!r}"
+    assert outcome.data['status'] == 'success'
+    assert h.working.get('_file_write_resume') is None
+    print("✅ PASS: file written correctly, no resume state")
+
+    # ============ TEST 2: First truncation ============
+    header("TEST 2: First truncation (no closing tag + truncation marker)")
+    h.working = {}
+    truncated = (
+        "Writing the file:\n<file_content>"
+        "PART_A_LINE_1\nPART_A_LINE_2\nPART_A_LINE_3\nPART_A_LINE_4_TAIL_ANCHOR_HERE_XYZ"
+        "\n\n[!!! max_tokens !!!]"
+    )
+    resp = MockResponse(truncated)
+    yields, outcome = run_tool(h, {"path": "b.txt", "mode": "overwrite"}, resp)
+    print("YIELDS:"); [print(" ", y.rstrip()) for y in yields]
+    print("OUTCOME:", outcome.data)
+    print("NEXT_PROMPT (head 200):", (outcome.next_prompt or "")[:200].replace("\n", " | "))
+    p = os.path.join(tmp, "b.txt")
+    written = open(p, encoding='utf-8').read()
+    print("FILE CONTENT:", repr(written))
+    assert "PART_A_LINE_1" in written
+    assert "PART_A_LINE_4_TAIL_ANCHOR_HERE_XYZ" in written
+    assert "max_tokens" not in written, "truncation marker leaked into file!"
+    assert outcome.data['status'] == 'truncated_continuing'
+    rs = h.working.get('_file_write_resume')
+    assert rs is not None, "resume state not set"
+    assert rs['path'] == p
+    assert rs['round'] == 1
+    assert rs['tail'].endswith("TAIL_ANCHOR_HERE_XYZ"), f"tail={rs['tail']!r}"
+    assert "继续" in (outcome.next_prompt or "")
+    print(f"✅ PASS: wrote {len(written)}B, resume state set (round=1, tail=...{rs['tail'][-30:]!r})")
+
+    # ============ TEST 3: Continuation with overlap (dedup) ============
+    header("TEST 3: Continuation with overlap dedup (final chunk)")
+    # LLM resumes; intentionally repeats last ~25 chars as overlap anchor
+    overlap = rs['tail'][-25:]  # repeat trailing 25 chars
+    continuation_content = overlap + "PART_B_LINE_5\nPART_B_LINE_6\nFINAL"
+    cont_resp = MockResponse(f"<file_content>{continuation_content}</file_content>")
+    yields, outcome = run_tool(h, {"path": "b.txt", "mode": "overwrite"}, cont_resp)
+    print("YIELDS:"); [print(" ", y.rstrip()) for y in yields]
+    print("OUTCOME:", outcome.data)
+    final = open(p, encoding='utf-8').read()
+    print("FINAL FILE:", repr(final))
+    # Must NOT contain the overlap twice
+    assert final.count("TAIL_ANCHOR_HERE_XYZ") == 1, f"overlap not deduped, count={final.count('TAIL_ANCHOR_HERE_XYZ')}"
+    assert final.endswith("PART_B_LINE_5\nPART_B_LINE_6\nFINAL")
+    assert outcome.data['status'] == 'success'
+    assert h.working.get('_file_write_resume') is None, "resume state should be cleared"
+    print("✅ PASS: overlap deduped, file completed, resume state cleared")
+
+    # ============ TEST 4: Continuation that ALSO gets truncated ============
+    header("TEST 4: Continuation again truncated (multi-round)")
+    h.working = {}
+    # Round 1
+    r1 = MockResponse("<file_content>AAAA_BBBB_CCCC_DDDD_EEEE_FFFF_GGGG_HHHH_IIII_JJJJ_KKKK_LLLL_MMMM_NNNN_OOOO_PPPP_QQQQ_RRRR_SSSS_TTTT\n[!!! max_tokens !!!]")
+    _, oc1 = run_tool(h, {"path": "c.txt"}, r1)
+    assert oc1.data['status'] == 'truncated_continuing'
+    assert h.working['_file_write_resume']['round'] == 1
+    # Round 2 (also truncated)
+    tail1 = h.working['_file_write_resume']['tail']
+    r2 = MockResponse(f"<file_content>{tail1[-20:]}_UUUU_VVVV_WWWW\n[!!! max_tokens !!!]")
+    _, oc2 = run_tool(h, {"path": "c.txt"}, r2)
+    assert oc2.data['status'] == 'truncated_continuing'
+    assert h.working['_file_write_resume']['round'] == 2, f"round={h.working['_file_write_resume']['round']}"
+    # Round 3 (complete)
+    tail2 = h.working['_file_write_resume']['tail']
+    r3 = MockResponse(f"<file_content>{tail2[-20:]}_END</file_content>")
+    _, oc3 = run_tool(h, {"path": "c.txt"}, r3)
+    assert oc3.data['status'] == 'success'
+    assert h.working.get('_file_write_resume') is None
+    final_c = open(os.path.join(tmp, "c.txt"), encoding='utf-8').read()
+    print("FINAL c.txt:", final_c)
+    assert final_c.startswith("AAAA_BBBB")
+    assert final_c.endswith("_END")
+    # Each tail should appear once (dedup worked)
+    assert final_c.count("UUUU_VVVV_WWWW") == 1
+    print("✅ PASS: 3-round continuation, all dedup correct")
+
+    print("\n" + "="*60)
+    print("  🎉 ALL 4 TESTS PASSED")
+    print("="*60)
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)


### PR DESCRIPTION
## Problem

When `file_write` is used on large files, the LLM's response can hit `max_tokens` 
and get truncated mid-`<file_content>`. Currently this either:
- writes a corrupted/truncated file silently, or
- fails the tool call, requiring manual splitting (the tool desc even warns 
  "HUGE edits >15KB easily truncated, write half then append").

## Solution

Make `do_file_write` truncation-aware:

1. **Detect truncation**: unclosed `<file_content>` tag + llmcore truncation 
   markers (`max_tokens !!!]` / `[!!! 流异常中断` / `!!!Error:`) at content tail.
2. **Strip markers**, write the partial chunk immediately to disk (overwrite 
   first chunk, append subsequent chunks).
3. **Stash resume state** in `self.working['_file_write_resume']`: path, 
   round count, and last 80 chars as overlap anchor.
4. **Return a continuation prompt** instructing the LLM to keep outputting 
   from the cutoff (with the 80-char tail shown as anchor).
5. **On the next call**, detect resume state, dedup overlap (try 80→1 chars 
   for largest match), append, and either finish or loop again.
6. **Cap at 8 rounds** (~80KB) to prevent runaway loops; report `partial` 
   status if exceeded.

User experience: large file writes "just work" — no manual splitting needed.

## Tests

`tests/test_file_write_resume.py` (standalone, no pytest dep) covers:
1. Normal complete write (closed tag) — no resume
2. First truncation — partial write + resume state set + correct prompt
3. Continuation with overlap — dedup precise, file completed, state cleared
4. Multi-round truncation (3 rounds) — all dedup correct end-to-end

Run: `python tests/test_file_write_resume.py` → `🎉 ALL 4 TESTS PASSED`

## Scope

- Only touches `ga.py:do_file_write` (+81/-12 lines) and adds one test file.
- No API/schema change; tool description simplified (removes the now-obsolete 
  "HUGE edits easily truncated" warning).
- `file_patch` is unchanged.