### PR TITLE
fix: add request timeout and replace assert with proper exception

### DIFF
--- a/TMWebDriver.py
+++ b/TMWebDriver.py
@@ -204,7 +204,8 @@ class TMWebDriver:
                     raise ValueError(f"会话ID {session_id} 未连接")  
 
         tp = session.type
-        assert tp in ['ws', 'http', 'ext_ws'], f"Unsupported session type: {tp}"
+        if tp not in ('ws', 'http', 'ext_ws'):
+            raise ValueError(f"Unsupported session type: {tp}")
         exec_id = str(uuid.uuid4())  
         payload_dict = {'id': exec_id, 'code': code}
         if tp == 'ext_ws': payload_dict['tabId'] = int(session.id)
@@ -243,7 +244,7 @@ class TMWebDriver:
         return rr
     
     def _remote_cmd(self, cmd):
-        try: return requests.post(self.remote, headers={"Content-Type": "application/json"}, json=cmd).json()
+        try: return requests.post(self.remote, headers={"Content-Type": "application/json"}, json=cmd, timeout=30).json()
         except (ConnectionError, requests.exceptions.ConnectionError):
             raise ConnectionError("TMWebDriver master未运行，看tmwebdriver_sop启动master")
 


### PR DESCRIPTION
Two small robustness improvements to `TMWebDriver.py`:

1. **Add `timeout=30` to `requests.post` call** in `_remote_cmd()`
   - The current call has no timeout, which means it can hang indefinitely if the remote master is unresponsive.
   - 30 seconds is a reasonable default for a local/remote command request.

2. **Replace `assert` with `raise ValueError`** for session type validation
   - `assert` statements are stripped when Python runs with `-O` (optimization flag), which would silently skip this important validation.
   - `raise ValueError` ensures the check always runs regardless of runtime flags.