### PR TITLE
fix: ACP bridge streaming overlap and truncation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ reflect/*
 
 # Universal: never track __pycache__ anywhere
 **/__pycache__/
+
+.claude/

--- a/frontends/genericagent_acp_bridge.py
+++ b/frontends/genericagent_acp_bridge.py
@@ -159,6 +159,7 @@ class GenericAgentAcpBridge:
         agent = GeneraticAgent()
         agent.next_llm(self.llm_no)
         agent.verbose = True
+        agent.inc_out = True
         threading.Thread(target=agent.run, daemon=True).start()
         return agent
 
@@ -264,28 +265,47 @@ class GenericAgentAcpBridge:
         threading.Thread(target=run_prompt, daemon=True).start()
 
     def _drain_agent_queue(self, session: SessionState, dq: "queue.Queue[Dict[str, Any]]") -> None:
-        last_sent = ""
+        sent_any = False
         while True:
             item = dq.get()
             if not isinstance(item, dict):
                 continue
-            text = item.get("done") or item.get("next") or ""
-            if isinstance(text, str) and len(text) > len(last_sent):
-                delta = text[len(last_sent):]
-                last_sent = text
-                try:
-                    self.write_message(
-                        make_session_update(
-                            session.session_id,
-                            {
-                                "sessionUpdate": "agent_message_chunk",
-                                "content": make_text_block(delta),
-                            },
+            # With inc_out=True, "next" items are already incremental deltas.
+            if "next" in item and "done" not in item:
+                delta = item["next"]
+                if isinstance(delta, str) and delta:
+                    sent_any = True
+                    try:
+                        self.write_message(
+                            make_session_update(
+                                session.session_id,
+                                {
+                                    "sessionUpdate": "agent_message_chunk",
+                                    "content": make_text_block(delta),
+                                },
+                            )
                         )
-                    )
-                except Exception as e:
-                    eprint(f"[ACP-BRIDGE] ERROR writing update: {e}")
+                    except Exception as e:
+                        eprint(f"[ACP-BRIDGE] ERROR writing update: {e}")
             if "done" in item:
+                # "done" text has post-processing (</summary>\n\n insertion)
+                # that shifts offsets — cannot safely compute a tail delta.
+                # Only use "done" content if nothing was streamed (error case).
+                if not sent_any:
+                    done_text = item["done"]
+                    if isinstance(done_text, str) and done_text:
+                        try:
+                            self.write_message(
+                                make_session_update(
+                                    session.session_id,
+                                    {
+                                        "sessionUpdate": "agent_message_chunk",
+                                        "content": make_text_block(done_text),
+                                    },
+                                )
+                            )
+                        except Exception as e:
+                            eprint(f"[ACP-BRIDGE] ERROR writing done: {e}")
                 break
 
     def handle_session_cancel(self, params: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary

Fix text duplication and truncation issues in the ACP bridge (`frontends/genericagent_acp_bridge.py`) when streaming responses to codeg.

## Problem

The bridge's `_drain_agent_queue` used cumulative text mode (`inc_out=False`) and computed incremental deltas via `text[len(last_sent):]`. This broke because `agentmain.py` post-processes `full_resp` before sending the "done" item:

```python
if '</summary>' in full_resp:
    full_resp = full_resp.replace('</summary>', '</summary>\n\n')
```

This inserts characters **in the middle** of the text after the last "next" was sent. The bridge's offset-based delta calculation then produces:
- **Overlapping content** — the delta starts a few characters back, duplicating text (e.g. "具体任务任务。")
- **Garbage tails** — shifted characters from the end of the post-processed text get appended as spurious content (stray backticks, partial fences)

## Fix

Two changes in `_drain_agent_queue`:

1. **Set `agent.inc_out = True`** — queue items now contain incremental deltas directly (not cumulative text), so the bridge forwards them as-is without any offset math.

2. **Rewrite drain logic** — "next" items are forwarded directly. "done" is only used as content when no streaming occurred (error fallback), otherwise it serves purely as a termination signal. This avoids the post-processing offset problem entirely.

## Also included

- `frontends/` relocation (from prior commits on this branch)
- `.gitignore` addition for `.claude/` directory
- stdout fd non-inheritable fix to prevent child process pollution of ACP channel