### PR TITLE
fix #263: add exception handling for /continue command in stapp

### DIFF
--- a/frontends/stapp.py
+++ b/frontends/stapp.py
@@ -273,20 +273,24 @@ if prompt := st.chat_input("any task?"):
         st.session_state.messages = [{"role": "assistant", "content": reset_conversation(agent), "time": ts}]
         _reset_and_rerun()
     if cmd.startswith("/continue"):
-        m = re.match(r'/continue\s+(\d+)\s*$', cmd.strip())
-        sessions = list_sessions(exclude_pid=os.getpid()) if m else []
-        idx = int(m.group(1)) - 1 if m else -1
-        # Resolve target path BEFORE handle (which snapshots current log, shifting indices).
-        target = sessions[idx][0] if 0 <= idx < len(sessions) else None
-        result = handle_frontend_command(agent, cmd)
-        history = extract_ui_messages(target) if target and result.startswith('✅') else None
-        tail = [{"role": "assistant", "content": result, "time": ts}]
-        if history:
-            st.session_state.messages = history + tail
-        else:
-            st.session_state.messages = list(st.session_state.messages) + \
-                [{"role": "user", "content": cmd, "time": ts}] + tail
-        _reset_and_rerun()
+        try:
+            m = re.match(r'/continue\s+(\d+)\s*$', cmd.strip())
+            sessions = list_sessions(exclude_pid=os.getpid()) if m else []
+            idx = int(m.group(1)) - 1 if m else -1
+            # Resolve target path BEFORE handle (which snapshots current log, shifting indices).
+            target = sessions[idx][0] if 0 <= idx < len(sessions) else None
+            result = handle_frontend_command(agent, cmd)
+            history = extract_ui_messages(target) if target and result.startswith('✅') else None
+            tail = [{"role": "assistant", "content": result, "time": ts}]
+            if history:
+                st.session_state.messages = history + tail
+            else:
+                st.session_state.messages = list(st.session_state.messages) + \
+                    [{"role": "user", "content": cmd, "time": ts}] + tail
+            _reset_and_rerun()
+        except Exception as e:
+            st.error(f"恢复会话失败: {e}")
+            st.rerun()
     if cmd.startswith("/btw"):
         answer = btw_handle_frontend(agent, cmd)  # sync; bypasses put_task → main agent.run() untouched
         st.session_state.messages = list(st.session_state.messages) + [


### PR DESCRIPTION
## 问题描述

Issue #263：`/continue` 指令恢复会话时，如果 `handle_frontend_command` 或 `extract_ui_messages` 抛出异常（例如会话文件损坏、后端状态异常等），整个 Streamlit 应用会直接崩溃，用户只能重启。

## 修复方案

在 `frontends/stapp.py` 的 `/continue` 命令处理流程外层包裹 `try/except` 块：

- 捕获所有 `Exception` 异常
- 通过 `st.error()` 显示友好的中文错误提示「恢复会话失败: {异常信息}」
- 调用 `st.rerun()` 重新渲染界面，而非直接崩溃

此改动仅增加容错逻辑，不改变正常流程行为。

## 验证

- 语法校验：`python3 -m py_compile frontends/stapp.py` ✓
- Lint 检查：`ruff check frontends/stapp.py` ✓（仅有文件头部预存风格问题，与本次修改无关）
- 改动量：+18 行 / -14 行，精准覆盖 `/continue` 分支

## 关联

修复 #263