### PR TITLE
fix: correct GenericAgent typo, improve error handling, expand English docs

### DIFF
--- a/agentmain.py
+++ b/agentmain.py
@@ -39,7 +39,7 @@ def get_system_prompt():
     prompt += get_global_memory()
     return prompt
 
-class GeneraticAgent:
+class GenericAgent:
     def __init__(self):
         os.makedirs(os.path.join(script_dir, 'temp'), exist_ok=True)
         self.lock = threading.Lock()
@@ -55,7 +55,7 @@ class GeneraticAgent:
         mykeys, changed = reload_mykeys()
         if not changed and hasattr(self, 'llmclients'): return
         try: oldhistory = self.llmclient.backend.history
-        except: oldhistory = None
+        except Exception: oldhistory = None
         llm_sessions = []
         for k, cfg in mykeys.items():
             if not any(x in k for x in ['api', 'config', 'cookie']): continue
@@ -65,7 +65,7 @@ class GeneraticAgent:
                 elif 'claude' in k: llm_sessions += [ToolClient(ClaudeSession(cfg=cfg))]
                 elif 'oai' in k: llm_sessions += [ToolClient(LLMSession(cfg=cfg))]
                 elif 'mixin' in k: llm_sessions += [{'mixin_cfg': cfg}]
-            except: pass
+            except Exception as e: print(f'[WARN] Failed to init session for key "{k}": {e}')
         for i, s in enumerate(llm_sessions):
             if isinstance(s, dict) and 'mixin_cfg' in s:
                 try:
@@ -83,7 +83,7 @@ class GeneraticAgent:
         lastc = self.llmclient
         self.llmclient = self.llmclients[self.llm_no]
         try: self.llmclient.backend.history = lastc.backend.history
-        except: raise Exception('[ERROR] BAD Mixin config: Check your mykey.py')
+        except Exception: raise Exception('[ERROR] BAD Mixin config: Check your mykey.py')
         self.llmclient.last_tools = ''
         name = self.get_llm_name(model=True)
         if 'glm' in name or 'minimax' in name or 'kimi' in name: load_tool_schema('_cn')
@@ -192,7 +192,7 @@ if __name__ == '__main__':
             stderr=open(os.path.join(d, 'stderr.log'), 'w', encoding='utf-8'))
         print(p.pid); sys.exit(0)
 
-    agent = GeneraticAgent()
+    agent = GenericAgent()
     agent.next_llm(args.llm_no)
     agent.verbose = args.verbose
     threading.Thread(target=agent.run, daemon=True).start()

--- a/frontends/chatapp_common.py
+++ b/frontends/chatapp_common.py
@@ -331,6 +331,6 @@ class AgentChatMixin:
             self.user_tasks.pop(chat_id, None)
 
 
-from agentmain import GeneraticAgent as _GA
+from agentmain import GenericAgent as _GA
 from continue_cmd import handle_frontend_command as _handle_continue_frontend, install as _install_continue, reset_conversation as _reset_conversation
 _install_continue(_GA)

--- a/frontends/dcapp.py
+++ b/frontends/dcapp.py
@@ -7,7 +7,7 @@ import asyncio, os, re, sys, threading, time
 from collections import OrderedDict
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from agentmain import GeneraticAgent
+from agentmain import GenericAgent
 from chatapp_common import (
     AgentChatMixin, build_done_text, ensure_single_instance, extract_files,
     public_access, redirect_log, require_runtime, split_text, strip_files, clean_reply,
@@ -20,7 +20,7 @@ except Exception:
     print("Please install discord.py to use Discord: pip install discord.py")
     sys.exit(1)
 
-agent = GeneraticAgent(); agent.verbose = False
+agent = GenericAgent(); agent.verbose = False
 BOT_TOKEN = str(mykeys.get("discord_bot_token", "") or "").strip()
 ALLOWED = {str(x).strip() for x in mykeys.get("discord_allowed_users", []) if str(x).strip()}
 USER_TASKS = {}

--- a/frontends/dingtalkapp.py
+++ b/frontends/dingtalkapp.py
@@ -2,7 +2,7 @@ import asyncio, json, os, sys, threading, time
 import requests
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from agentmain import GeneraticAgent
+from agentmain import GenericAgent
 from chatapp_common import AgentChatMixin, ensure_single_instance, public_access, redirect_log, require_runtime, split_text
 from llmcore import mykeys
 
@@ -13,7 +13,7 @@ except Exception:
     print("Please install dingtalk-stream to use DingTalk: pip install dingtalk-stream")
     sys.exit(1)
 
-agent = GeneraticAgent(); agent.verbose = False
+agent = GenericAgent(); agent.verbose = False
 CLIENT_ID = str(mykeys.get("dingtalk_client_id", "") or "").strip()
 CLIENT_SECRET = str(mykeys.get("dingtalk_client_secret", "") or "").strip()
 ALLOWED = {str(x).strip() for x in mykeys.get("dingtalk_allowed_users", []) if str(x).strip()}

--- a/frontends/fsapp.py
+++ b/frontends/fsapp.py
@@ -3,7 +3,7 @@ import glob, json, os, queue as Q, re, sys, threading, time
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, PROJECT_ROOT)
 os.chdir(PROJECT_ROOT)
-from agentmain import GeneraticAgent
+from agentmain import GenericAgent
 from frontends.chatapp_common import format_restore
 from frontends.continue_cmd import handle_frontend_command as handle_continue_frontend, reset_conversation
 from llmcore import mykeys
@@ -235,7 +235,7 @@ ALLOWED_USERS = _to_allowed_set(mykeys.get("fs_allowed_users", []))
 PUBLIC_ACCESS = not ALLOWED_USERS or "*" in ALLOWED_USERS
 AGENT_TIMEOUT_SEC = 900
 
-agent = GeneraticAgent()
+agent = GenericAgent()
 threading.Thread(target=agent.run, daemon=True).start()
 client, user_tasks = None, {}
 

--- a/frontends/genericagent_acp_bridge.py
+++ b/frontends/genericagent_acp_bridge.py
@@ -47,7 +47,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
-from agentmain import GeneraticAgent
+from agentmain import GenericAgent
 
 
 JSONRPC_VERSION = "2.0"
@@ -130,7 +130,7 @@ def jsonrpc_result(req_id: Any, result: Any) -> Dict[str, Any]:
 class SessionState:
     session_id: str
     cwd: str
-    agent: GeneraticAgent
+    agent: GenericAgent
     current_prompt_id: Any = None
     prompt_lock: threading.Lock = field(default_factory=threading.Lock)
 
@@ -155,8 +155,8 @@ class GenericAgentAcpBridge:
         except Exception as e:
             eprint(f"[ACP-BRIDGE] WRITE FAILED: {type(e).__name__}: {e}")
 
-    def new_agent(self) -> GeneraticAgent:
-        agent = GeneraticAgent()
+    def new_agent(self) -> GenericAgent:
+        agent = GenericAgent()
         agent.next_llm(self.llm_no)
         agent.verbose = True
         agent.inc_out = True

--- a/frontends/qqapp.py
+++ b/frontends/qqapp.py
@@ -2,7 +2,7 @@ import asyncio, os, sys, threading, time
 from collections import deque
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from agentmain import GeneraticAgent
+from agentmain import GenericAgent
 from chatapp_common import AgentChatMixin, ensure_single_instance, public_access, redirect_log, require_runtime, split_text
 from llmcore import mykeys
 
@@ -13,7 +13,7 @@ except Exception:
     print("Please install qq-botpy to use QQ module: pip install qq-botpy")
     sys.exit(1)
 
-agent = GeneraticAgent(); agent.verbose = False
+agent = GenericAgent(); agent.verbose = False
 APP_ID = str(mykeys.get("qq_app_id", "") or "").strip()
 APP_SECRET = str(mykeys.get("qq_app_secret", "") or "").strip()
 ALLOWED = {str(x).strip() for x in mykeys.get("qq_allowed_users", []) if str(x).strip()}

--- a/frontends/qtapp.py
+++ b/frontends/qtapp.py
@@ -28,7 +28,7 @@ from PySide6.QtGui import (
 )
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from agentmain import GeneraticAgent
+from agentmain import GenericAgent
 from chatapp_common import FILE_HINT, HELP_TEXT, clean_reply, build_done_text, format_restore
 
 
@@ -2424,7 +2424,7 @@ def main():
     app.setFont(font)
 
     # ── Agent initialisation ──────────────────────────────
-    agent = GeneraticAgent()
+    agent = GenericAgent()
     if agent.llmclient is None:
         QMessageBox.critical(
             None,

--- a/frontends/stapp.py
+++ b/frontends/stapp.py
@@ -13,8 +13,8 @@ sys.path.append(os.path.abspath(script_dir))
 
 import streamlit as st
 import time, json, re, threading, queue
-from agentmain import GeneraticAgent
-import chatapp_common  # activate /continue command (monkey patches GeneraticAgent)
+from agentmain import GenericAgent
+import chatapp_common  # activate /continue command (monkey patches GenericAgent)
 from continue_cmd import handle_frontend_command, reset_conversation, list_sessions, extract_ui_messages
 
 st.set_page_config(page_title="Cowork", layout="wide")
@@ -37,7 +37,7 @@ def T(key): return I18N.get(LANG, I18N['zh']).get(key, key)
 
 @st.cache_resource
 def init():
-    agent = GeneraticAgent()
+    agent = GenericAgent()
     if agent.llmclient is None:
         st.error("⚠️ Please set mykey.py!")
         st.stop()

--- a/frontends/stapp2.py
+++ b/frontends/stapp2.py
@@ -16,7 +16,7 @@ except (ImportError, AttributeError):
     from streamlit.components.v1 import html as _embed_html  # ≤1.55
 import time, json, re, threading, queue
 from datetime import datetime
-from agentmain import GeneraticAgent
+from agentmain import GenericAgent
 
 st.set_page_config(page_title="Cowork", layout="wide")
 
@@ -799,7 +799,7 @@ ANTHROPIC_SELECTBOX_SCRIPT = """
 
 @st.cache_resource
 def init():
-    agent = GeneraticAgent()
+    agent = GenericAgent()
     if agent.llmclient is None:
         st.error("⚠️ 未配置任何可用的 LLM 接口，请在 mykey.py 中添加 sider_cookie 或 oai_apikey+oai_apibase 等信息后重启。")
         st.stop()

--- a/frontends/tgapp.py
+++ b/frontends/tgapp.py
@@ -1,7 +1,7 @@
 import os, sys, re, threading, asyncio, queue as Q, time, random, uuid
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 _TEMP_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'temp')
-from agentmain import GeneraticAgent
+from agentmain import GenericAgent
 try:
     from telegram import BotCommand, InlineKeyboardButton, InlineKeyboardMarkup
     from telegram.constants import ChatType, MessageLimit, ParseMode
@@ -27,7 +27,7 @@ from chatapp_common import (
 from continue_cmd import handle_frontend_command, reset_conversation
 from llmcore import mykeys
 
-agent = GeneraticAgent()
+agent = GenericAgent()
 agent.verbose = False
 agent.inc_out = True
 ALLOWED = set(mykeys.get('tg_allowed_users', []))

--- a/frontends/wechatapp.py
+++ b/frontends/wechatapp.py
@@ -5,7 +5,7 @@ import requests, qrcode
 from Crypto.Cipher import AES
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 _TEMP_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'temp')
-from agentmain import GeneraticAgent
+from agentmain import GenericAgent
 
 # ── WxBotClient (inline from wx_bot_client.py) ──
 for _k in ('HTTPS_PROXY', 'https_proxy'):
@@ -253,7 +253,7 @@ def _dl_media(items):
             break  # one media per item
     return paths
 
-agent = GeneraticAgent()
+agent = GenericAgent()
 agent.verbose = False
 
 _TAG_PATS = [r'<' + t + r'>.*?</' + t + r'>' for t in ('thinking', 'tool_use')]

--- a/frontends/wecomapp.py
+++ b/frontends/wecomapp.py
@@ -16,7 +16,7 @@ class TurnContext(TypedDict, total=False):
 TurnHookFn = Callable[[TurnContext], None]
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from agentmain import GeneraticAgent
+from agentmain import GenericAgent
 from chatapp_common import (AgentChatMixin, FILE_HINT, build_done_text, clean_reply,
                             ensure_single_instance, extract_files, public_access,
                             redirect_log, require_runtime, split_text, strip_files)
@@ -335,7 +335,7 @@ class WeComApp(AgentChatMixin):
 
 # ── Main ────────────────────────────────────────────────────────────
 if __name__ == "__main__":
-    agent = GeneraticAgent(); agent.verbose = False
+    agent = GenericAgent(); agent.verbose = False
     _LOCK = ensure_single_instance(PORT, "WeCom")
     require_runtime(agent, "WeCom", wecom_bot_id=BOT_ID, wecom_secret=SECRET)
     redirect_log(__file__, "wecomapp.log", "WeCom", ALLOWED)

--- a/ga.py
+++ b/ga.py
@@ -285,7 +285,7 @@ class GenericAgentHandler(BaseHandler):
             code = self._extract_code_block(response, code_type)
             if not code: return StepOutcome("[Error] Code missing. Must use reply code block or 'script' arg.", next_prompt="\n")
         try: timeout = int(args.get("timeout", 60))
-        except: timeout = 60
+        except (ValueError, TypeError): timeout = 60
         raw_path = os.path.join(self.cwd, args.get("cwd", './'))
         cwd = os.path.normpath(os.path.abspath(raw_path))
         code_cwd = os.path.normpath(self.cwd)

--- a/mykey_template_en.py
+++ b/mykey_template_en.py
@@ -2,75 +2,402 @@
 #  GenericAgent — mykey.py configuration template (copy to mykey.py and fill in)
 # ══════════════════════════════════════════════════════════════════════════════
 #
-#  Quick start:
-#    1. Copy this file to mykey.py
-#    2. Uncomment one of the configs below and fill in your apikey
-#    3. Run `python agentmain.py` or `python launch.pyw`
+#  ┌─────────────────────────────────────────────────────────────────────────┐
+#  │ Quick start: 3 steps                                                     │
+#  │  1. Copy this file to mykey.py                                           │
+#  │  2. Fill in your apikey in the recommended configs below                 │
+#  │  3. Run `python agentmain.py` or `python launch.pyw`                     │
+#  └─────────────────────────────────────────────────────────────────────────┘
 #
-#  GA auto-detects any variable whose name contains 'api'/'config'/'cookie'
+#  ────────── Session type quick reference ──────────
+#
+#  agentmain.py scans variables whose names contain 'api' / 'config' / 'cookie'
 #  and picks the session class by keyword:
-#      name contains 'native' + 'claude'  → NativeClaudeSession  (Anthropic API)
-#      name contains 'native' + 'oai'     → NativeOAISession     (OpenAI API)
-#      name contains 'mixin'              → MixinSession         (failover)
 #
-#  Native = tools go in the API's native `tool` field (function calling), same
-#  way Claude Code and Codex do it. Recommended for GPT / Claude / Gemini.
+#      Variable keyword                       → Session class          → Tool protocol
+#      ─────────────────────────────────────────────────────────────────────────
+#      Contains 'native' + 'claude'          → NativeClaudeSession    → API native tool field
+#      Contains 'native' + 'oai'            → NativeOAISession       → API native tool field
+#      Contains 'claude' (no 'native')      → ClaudeSession          → text-protocol tools (deprecated)
+#      Contains 'oai' (no 'native')         → LLMSession             → text-protocol tools (deprecated)
+#      Contains 'mixin'                     → MixinSession           → multi-session failover
+#                                                                       NativeClaudeSession and
+#                                                                       NativeOAISession can be mixed
 #
-#  Tip: runtime overrides via `/session.<attr>=<val>` in the REPL, e.g.
+#  Priority is top-down: native_claude_xxx always becomes NativeClaudeSession.
+#  If a variable named oai_claude_xxx still matches 'claude' first, it goes to
+#  ClaudeSession. Name your variables to reflect what you intend.
+#
+#  ────────── Native vs non-Native ──────────
+#
+#  "Native" = tools are sent in the API's native `tool` field (function calling).
+#  This is how Claude Code / Codex do it — models overtrained on the tool field
+#  may ignore tool descriptions in any other format. Use Native to emulate CC.
+#
+#  "Non-Native" = tool descriptions are embedded in the text field (text protocol).
+#  More compatible, but weaker for models overtrained on the native tool field
+#  (e.g. Claude Opus/Sonnet). Deprecated — prefer Native for new setups.
+#
+#  → Recommendation: always use native_claude_config / native_oai_config first.
+#
+#  ────────── Prompt cache ──────────
+#
+#  NativeClaudeSession always sends the prompt-caching-scope beta header.
+#  LLMSession / NativeOAISession auto-add cache_control: ephemeral to the last
+#  two user messages when the model name contains 'claude'/'anthropic'.
+#  prompt_cache defaults to True. Only set it to False if your upstream relay
+#  rejects requests with cache_control fields.
+#
+# ══════════════════════════════════════════════════════════════════════════════
+#  apibase auto-append rules:
+#      'http://host:2001'                      → appends /v1/chat/completions
+#      'http://host:2001/v1'                   → appends /chat/completions
+#      'http://host:2001/v1/chat/completions'  → used as-is
+#  NativeClaudeSession additionally appends ?beta=true for the Anthropic beta.
+#
+# ══════════════════════════════════════════════════════════════════════════════
+#  Runtime overrides: in the GA REPL, type
 #      /session.reasoning_effort=high
 #      /session.thinking_type=adaptive
+#      /session.thinking_budget_tokens=32768
 #      /session.temperature=0.3
+#      /session.max_tokens=16384
+#  These setattr on the current session's backend, taking effect immediately
+#  until you switch models or restart.
+#  reasoning_effort values:  none / minimal / low / medium / high / xhigh
+#  thinking_type values:     adaptive / enabled / disabled
 #
+# ══════════════════════════════════════════════════════════════════════════════
+#  Complete field reference (BaseSession.__init__ order)
+# ─── Auth / routing ─────────────────────────────────────────────────────────
+#   apikey          Required. sk-ant-* prefix → x-api-key header; everything
+#                   else (sk-*, cr_*, amp_*…) → Authorization: Bearer.
+#                   Auto-detected by NativeClaudeSession.
+#   apibase         Required. See auto-append rules above.
+#   model           Required. Suffix '[1m]' triggers the context-1m-2025-08-07
+#                   beta (stripped from the payload before sending).
+#   name            Optional. Display name; also the credential key referenced
+#                   by mixin_config['llm_nos']. Defaults to model if omitted.
+#   proxy           Optional. Per-session HTTP proxy, e.g. 'http://127.0.0.1:2082'.
+#                   If not set, the global proxy (if any) is used.
+# ─── Capacity / timeouts ────────────────────────────────────────────────────
+#   context_win     Default 24000 (NativeClaudeSession: 28000). History trim
+#                   threshold — not a hard context limit.
+#   max_retries     Default 1. Number of auto-retries for 429/408/5xx in
+#                   the streaming client.
+#   connect_timeout Connection timeout in seconds, default 5.
+#   read_timeout    Stream read timeout in seconds, default 30.
+# ─── Reasoning / thinking ──────────────────────────────────────────────────
+#   reasoning_effort  OpenAI o-series or Responses API reasoning budget.
+#                     For Claude: mapped to output_config.effort (xhigh → max).
+#   thinking_type     Claude native thinking blocks:
+#                     'adaptive'  (CC default) → model decides budget
+#                     'enabled'                → requires thinking_budget_tokens
+#                     'disabled'               → no thinking field sent
+#   thinking_budget_tokens  Only effective when thinking_type='enabled'.
+#                     Reference: low≈4096, medium≈10240, high≈32768
+# ─── Sampling ──────────────────────────────────────────────────────────────
+#   temperature     Default 1.0. Kimi/Moonshot forced to 1.0;
+#                   MiniMax clamped to (0, 1].
+#   max_tokens      Default 8192.
+# ─── Transport ─────────────────────────────────────────────────────────────
+#   stream          Default True. NativeClaudeSession uses SSE when True,
+#                   single JSON response when False. Set False if your relay
+#                   drops SSE connections mid-stream.
+#   api_mode        'chat_completions' (default) or 'responses'.
+#                   Only effective for LLMSession / NativeOAISession.
+# ─── NativeClaudeSession exclusive ──────────────────────────────────────────
+#   fake_cc_system_prompt
+#                   Default False. CRITICAL: set to True for ALL third-party
+#                   relays/proxies that mirror Claude Code protocol (CC switch,
+#                   anyrouter, claude-relay-service, etc.). Not needed for the
+#                   genuine Anthropic endpoint (sk-ant- keys).
+#   user_agent      Default 'claude-cli/2.1.113 (external, cli)'.
+#                   Override with any version string. Some relays (tabcode,
+#                   anyrouter) whitelist by UA; pin an older version here if
+#                   CC upgrades and your relay starts rejecting requests.
 # ══════════════════════════════════════════════════════════════════════════════
 
 
-# ── 1. NativeClaudeSession — Anthropic direct ────────────────────────────────
-#  Official Anthropic endpoint. apikey starting with 'sk-ant-' is auto-sent
-#  as x-api-key; any other prefix uses Authorization: Bearer.
-#  Model suffix '[1m]' triggers the 1M-context beta (stripped before sending).
-native_claude_config = {
-    'name': 'claude',                         # display name & mixin reference
-    'apikey': 'sk-ant-<your-anthropic-key>',
-    'apibase': 'https://api.anthropic.com',
-    'model': 'claude-opus-4-7[1m]',           # or 'claude-sonnet-4-6'
-    'thinking_type': 'adaptive',              # 'adaptive' | 'enabled' | 'disabled'
-    # 'thinking_budget_tokens': 32768,        # required if thinking_type='enabled'
-    # 'max_retries': 3,
-    # 'read_timeout': 180,
+# ╔═══════════════════════════════════════════════════════════════════════════╗
+# ║                  ★ Recommended setup (start here) ★                      ║
+# ╚═══════════════════════════════════════════════════════════════════════════╝
+#
+#  We recommend mixin failover + multiple native sessions.
+#  Fill in your apikey/apibase below and you're ready to go.
+
+
+# ── Mixin failover (most recommended) ──────────────────────────────────────
+#  llm_nos entries must match the 'name' field of the sessions they reference
+#  (or use integer indices). Constraint: all referenced sessions must all be
+#  Native or all non-Native; mixing Native with non-Native is not supported.
+mixin_config = {
+    'llm_nos': ['gpt-native'],   # priority order; mix Claude and GPT
+    # 'llm_nos': ['cc-relay-1', 'cc-relay-2', 'gpt-native'],  # priority order
+    'max_retries': 10,           # int; total retry budget across rotation
+    'base_delay': 0.5,           # float seconds; exponential backoff start
+    # 'spring_back': 300,        # int seconds; delay before falling back to first node
 }
 
 
-# ── 2. NativeOAISession — OpenAI direct ──────────────────────────────────────
-#  Standard OpenAI chat/completions endpoint. Also works for any OpenAI-
-#  compatible provider that supports native function-calling tool fields.
+# ══════════════════════════════════════════════════════════════════════════════
+#  1. NativeClaudeSession — Anthropic native protocol + native tools (preferred)
+# ══════════════════════════════════════════════════════════════════════════════
+#
+#  Most users connect through a CC-switch-adapted Claude relay (not Anthropic
+#  direct). These relays forward Claude Code protocol upstream and require
+#  fake_cc_system_prompt=True. This is the most common community setup.
+
+# ── 1a. CC switch relay (most common) ───────────────────────────────────────
+#  These relays forward Claude Code protocol upstream. apikey formats vary
+#  (sk-user-*, sk-*, cr_*, etc.) — all use Bearer auth. Must set
+#  fake_cc_system_prompt=True.
+# native_claude_config0 = {
+#     'name': 'cc-relay-1',                        # display name & mixin reference
+#     'apikey': 'sk-user-<your-relay-key>',        # non-sk-ant- prefix → Bearer auth
+#     'apibase': 'https://<your-cc-switch-host>/claude/office',   # CC switch endpoint
+#     'model': 'claude-opus-4-7',                  # or claude-sonnet-4-6
+#     'fake_cc_system_prompt': True,               # REQUIRED for CC relay
+#     'thinking_type': 'adaptive',
+# }
+
+# native_claude_config1 = {
+#     'name': 'cc-relay-2',                        # display name & mixin reference
+#     'apikey': 'sk-<your-second-relay-key>',
+#     'apibase': 'https://<your-second-host>',
+#     'model': 'claude-opus-4-7[1m]',              # [1m] triggers 1M-context beta
+#     'fake_cc_system_prompt': True,
+#     'thinking_type': 'adaptive',
+#     'max_retries': 3,
+#     'read_timeout': 300,                         # 1M-context responses may be slower
+#     'stream': False,                             # set False if relay drops SSE
+#     # 'user_agent': 'claude-cli/2.1.113 (external, cli)',
+# }
+
+# ── 1b. Anthropic official direct ───────────────────────────────────────────
+#  Official endpoint. apikey starting with sk-ant- → auto x-api-key header.
+#  Genuine Anthropic endpoint does NOT need fake_cc_system_prompt.
+# native_claude_config_anthropic = {
+#     'name': 'anthropic-direct',              # display name & mixin reference
+#     'apikey': 'sk-ant-<your-anthropic-key>', # sk-ant- prefix → x-api-key header
+#     'apibase': 'https://api.anthropic.com',  # NativeClaudeSession auto-appends ?beta=true
+#     'model': 'claude-opus-4-7[1m]',          # [1m] triggers 1M-context beta
+#     'thinking_type': 'adaptive',             # 'adaptive' | 'enabled' | 'disabled'
+#     # 'thinking_type': 'enabled',
+#     # 'thinking_budget_tokens': 32768,       # required if thinking_type='enabled'
+#     # 'reasoning_effort': 'high',            # none|minimal|low|medium|high|xhigh
+#     'temperature': 1,
+#     'max_tokens': 32768,
+#     # 'context_win': 800000,
+#     # 'stream': True,                        # False → single JSON (when SSE is broken)
+#     # 'max_retries': 3,
+#     # 'connect_timeout': 10,
+#     # 'read_timeout': 180,
+#     # 'fake_cc_system_prompt': False,        # not needed for real Anthropic
+# }
+
+# ── 1c. CRS relay (Claude Max) ──────────────────────────────────────────────
+#  CRS requires fake_cc_system_prompt=True
+# native_claude_config_crs = {
+#     'name': 'crs-claude-max',                # display name
+#     'apikey': 'cr_<your-crs-key>',           # cr_ prefix → Bearer auth (64 hex chars)
+#     'apibase': 'https://<your-crs-host>/api',# CRS Anthropic-compatible path
+#     'model': 'claude-opus-4-7[1m]',          # [1m] triggers 1M beta
+#     'fake_cc_system_prompt': True,           # REQUIRED; CRS validates CC system prompt
+#     'thinking_type': 'adaptive',
+#     # 'reasoning_effort': 'high',
+#     'max_tokens': 32768,
+#     'max_retries': 3,
+#     'read_timeout': 180,
+# }
+
+# ── 1d. CRS Gemini Ultra (Antigravity channel) ──────────────────────────────
+#  CRS wraps Google Antigravity (Gemini Ultra) as an Anthropic-style interface.
+#  ⚠ This channel does NOT support SSE streaming — must set stream=False.
+# native_claude_config_crs_gemini = {
+#     'name': 'crs-gemini-ultra',              # display name
+#     'apikey': 'cr_<your-crs-gemini-key>',    # cr_ prefix → Bearer
+#     'apibase': 'https://<your-crs-gemini-host>/antigravity/api',
+#     'model': 'claude-opus-4-7-thinking',     # or 'claude-opus-4-7[1m]' or 'claude-opus-4-7'
+#     'stream': False,                         # Antigravity does not support SSE
+#     'max_tokens': 32768,
+#     'max_retries': 3,
+#     'read_timeout': 180,
+# }
+
+# ── 1e. Zhipu GLM-5.1 (Anthropic-compatible protocol) ──────────────────────
+#  Zhipu provides an Anthropic-compatible endpoint at /api/anthropic.
+#  Variable name must contain 'native' + 'claude'. apikey is Zhipu format (xxx.yyy).
+# native_claude_glm_config = {
+#     'name': 'glm-5.1',                               # display name
+#     'apikey': '<your-zhipu-apikey>',                 # e.g. f0f1b798xxxx.F8SSbzxxxx; non-sk-ant → Bearer
+#     'apibase': 'https://open.bigmodel.cn/api/anthropic',  # Zhipu Anthropic-compatible endpoint
+#     'model': 'glm-5.1',
+#     'max_retries': 3,
+#     'connect_timeout': 10,
+#     'read_timeout': 180,
+#     # 'fake_cc_system_prompt': False,                # Zhipu does not validate CC fingerprint
+# }
+
+# ── 1f. MiniMax Anthropic path (recommended — no extra <think> tags) ────────
+#  MiniMax offers both OAI and Anthropic-compatible endpoints (same key):
+#    - /v1             → chat/completions (LLMSession)
+#    - /anthropic      → Anthropic Messages (NativeClaudeSession)
+#  Anthropic path is cleaner; OAI path may return <think> tags (M2.7 built-in
+#  thinking). Temperature auto-clamped to (0, 1]. Supports M2.7 / M2.5, 204K ctx.
+# native_claude_config_minimax = {
+#     'name': 'minimax-anthropic',                   # display name
+#     'apikey': 'sk-<your-minimax-key>',             # same key as OAI path
+#     'apibase': 'https://api.minimaxi.com/anthropic',  # Anthropic Messages endpoint
+#     'model': 'MiniMax-M2.7',
+#     'max_retries': 3,
+#     # 'fake_cc_system_prompt': False,              # MiniMax does not validate CC fingerprint
+# }
+
+# ── 1g. Kimi for Coding (Anthropic-compatible CC relay) ────────────────────
+#  Kimi's official /coding path for Claude Code / Codex, using Anthropic protocol.
+#  Different from the Moonshot OAI path (section 2b): model uses 'kimi-for-coding'.
+#  Official requirement: must relay CC system prompt → fake_cc_system_prompt=True.
+#  Docs: https://www.kimi.com/code/docs/third-party-tools/other-coding-agents.html
+# native_claude_config_kimi = {
+#     'name': 'kimi-coding',                   # display name & mixin reference
+#     'apikey': 'sk-kimi-<your-kimi-coding-key>',  # Bearer auth
+#     'apibase': 'https://api.kimi.com/coding',# Anthropic-compatible endpoint
+#     'model': 'kimi-for-coding',              # official coding model id
+#     'fake_cc_system_prompt': True,           # REQUIRED; official hard requirement
+#     'thinking_type': 'adaptive',
+# }
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  2. NativeOAISession — OpenAI protocol + native tools
+# ══════════════════════════════════════════════════════════════════════════════
+#  Variable name must contain 'native' + 'oai'. Uses OpenAI chat/completions or
+#  responses endpoints with native function-calling tool fields (matching the
+#  Claude Code / Codex approach). Suitable for GPT/o-series, Gemini, or any
+#  OAI-compatible provider with native tool support.
+
 native_oai_config = {
-    'name': 'gpt',                            # display name & mixin reference
-    'apikey': 'sk-<your-openai-key>',
-    'apibase': 'https://api.openai.com/v1',
-    'model': 'gpt-5.4',                       # or 'o4', 'gpt-5.3-codex', etc.
-    'api_mode': 'chat_completions',           # or 'responses' for /v1/responses
-    # 'reasoning_effort': 'high',             # none|minimal|low|medium|high|xhigh
-    # 'max_retries': 3,
-    # 'read_timeout': 120,
+    'name': 'gpt-native',                           # display name & mixin reference
+    'apikey': 'sk-<your-openai-key>',                # Bearer auth
+    'apibase': 'https://api.openai.com/v1',          # auto-appends /chat/completions
+    'model': 'gpt-5.4',                              # gpt-5 / o-series
+    'api_mode': 'chat_completions',                  # 'chat_completions' (default) | 'responses'
+    # 'reasoning_effort': 'high',                    # none|minimal|low|medium|high|xhigh
+    'max_retries': 3,
+    'connect_timeout': 10,
+    'read_timeout': 120,
+    # 'temperature': 1.0,
+    # 'max_tokens': 8192,
+    # 'proxy': 'http://127.0.0.1:2082',
+    # 'context_win': 16000,
 }
 
-
-# ── 3. Mixin failover (optional) ─────────────────────────────────────────────
-#  List sessions by 'name'; if one fails, the next is tried automatically.
-#  Constraint: all referenced sessions must be Native (mixing Native Claude
-#  and Native OAI is fine; mixing Native with non-Native is not).
-# mixin_config = {
-#     'llm_nos': ['claude', 'gpt'],
-#     'max_retries': 5,
-#     'base_delay': 0.5,
+# ── Responses API variant ───────────────────────────────────────────────────
+#  Targets OpenAI /v1/responses. reasoning_effort is written as
+#  payload.reasoning.effort in responses mode; /session.reasoning_effort=high
+#  overrides it at runtime.
+# native_oai_config_responses = {
+#     'name': 'gpt-responses',                       # display name
+#     'apikey': 'sk-<your-openai-key>',
+#     'apibase': 'https://api.openai.com/v1',        # auto-appends /responses (api_mode=responses)
+#     'model': 'gpt-5.4',
+#     'api_mode': 'responses',
+#     'reasoning_effort': 'high',
+#     'max_retries': 2,
+#     'read_timeout': 120,
 # }
 
 
-# ── 4. Global HTTP proxy (optional) ──────────────────────────────────────────
-#  Applies to every session that doesn't set its own 'proxy' field.
-# proxy = 'http://127.0.0.1:7890'
+# ══════════════════════════════════════════════════════════════════════════════
+#  3. Legacy non-Native sessions (LLMSession / ClaudeSession) — deprecated
+# ══════════════════════════════════════════════════════════════════════════════
+#  ⚠ May be removed in a future version. New users should use Native configs.
+#  Non-Native embeds tool descriptions in the text field — more compatible but
+#  weaker for models overtrained on native tool fields.
+#  Variable name containing 'oai' (no 'native') → LLMSession
+#  Variable name containing 'claude' (no 'native') → ClaudeSession
+#
+# oai_config = {
+#     'name': 'my-oai-proxy',
+#     'apikey': 'sk-<your-proxy-key>',
+#     'apibase': 'http://<your-proxy-host>:2001',      # auto-appends /v1/chat/completions
+#     'model': 'gpt-5.4',                              # or claude-opus-4-7, gemini-3-flash, etc.
+#     'api_mode': 'chat_completions',
+#     # 'reasoning_effort': 'high',
+#     'max_retries': 3,
+#     'connect_timeout': 10,
+#     'read_timeout': 120,
+# }
 
 
-# ── 5. Chat platform integrations (optional) ─────────────────────────────────
-# tg_bot_token = '...'
-# tg_allowed_users = [123456789]
+# ══════════════════════════════════════════════════════════════════════════════
+#  4. Other Native-compatible providers
+# ══════════════════════════════════════════════════════════════════════════════
+
+# ── 4a. MiniMax OAI path (/v1 chat/completions) ────────────────────────────
+#  OAI path may return <think> tags (M2.7 built-in thinking). Anthropic path
+#  (1f) is cleaner. Temperature auto-clamped to (0, 1]. Supports M2.7/M2.5, 204K ctx.
+# oai_config_minimax = {
+#     'name': 'minimax-oai',
+#     'apikey': 'sk-<your-minimax-key>',               # e.g. sk-cp-xxxxxxxxx; Bearer auth
+#     'apibase': 'https://api.minimaxi.com/v1',        # OAI-compatible endpoint
+#     'model': 'MiniMax-M2.7',                         # name contains 'minimax' → temp clamped to (0.01, 1.0]
+#     'context_win': 50000,
+# }
+
+# ── 4b. Kimi / Moonshot (OAI-compatible) ───────────────────────────────────
+#  Note: Kimi/Moonshot temperature is forced to 1.0 by llmcore.py regardless
+#  of what you set here.
+# oai_config_kimi = {
+#     'name': 'kimi-k2',
+#     'apikey': 'sk-<your-moonshot-key>',            # Bearer auth
+#     'apibase': 'https://api.moonshot.cn/v1',       # Moonshot OAI endpoint
+#     'model': 'kimi-k2-turbo-preview',              # name contains 'kimi'/'moonshot' → temp forced 1.0
+#     # 'temperature': 0.3,                          # ← ignored; llmcore overrides to 1.0
+# }
+
+# ── 4c. OpenRouter (OAI protocol multi-model relay) ─────────────────────────
+#  OpenRouter is the most general multi-model OAI relay: https://openrouter.ai/api/v1
+#  Use provider/model format for the model field (e.g. anthropic/claude-opus-4-7).
+# oai_config_openrouter = {
+#     'name': 'openrouter-claude',                   # display name & mixin reference
+#     'apikey': 'sk-or-<your-openrouter-key>',       # OpenRouter key format: sk-or-xxx; Bearer auth
+#     'apibase': 'https://openrouter.ai/api/v1',     # auto-appends /chat/completions
+#     'model': 'anthropic/claude-opus-4-7',          # provider/model format
+#     'max_retries': 3,
+#     'connect_timeout': 10,
+#     'read_timeout': 120,
+# }
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  Global HTTP proxy (shared by all sessions that don't set their own 'proxy')
+# ══════════════════════════════════════════════════════════════════════════════
+# proxy = 'http://127.0.0.1:2082'
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  Chat platform integrations (optional; unset entries won't start adapters)
+# ══════════════════════════════════════════════════════════════════════════════
+# tg_bot_token = '84102K2gYZ...'
+# tg_allowed_users = [6806...]
+# qq_app_id = '123456789'
+# qq_app_secret = 'xxxxxxxxxxxxxxxx'
+# qq_allowed_users = ['your_user_openid']           # omit or ['*'] to allow all QQ users
+# fs_app_id = 'cli_xxxxxxxxxxxxxxxx'
+# fs_app_secret = 'xxxxxxxxxxxxxxxx'
+# fs_allowed_users = ['ou_xxxxxxxxxxxxxxxx']        # omit or ['*'] to allow all Feishu users
+# wecom_bot_id = 'your_bot_id'
+# wecom_secret = 'your_bot_secret'
+# wecom_allowed_users = ['your_user_id']            # omit or ['*'] to allow all WeCom users
+# wecom_welcome_message = 'Hello, I am online.'
+# dingtalk_client_id = 'your_app_key'
+# dingtalk_client_secret = 'your_app_secret'
+# dingtalk_allowed_users = ['your_staff_id']        # omit or ['*'] to allow all DingTalk users
+
+# Optional: Langfuse tracing. No impact when not set.
+# langfuse_config = {
+#     'public_key': 'pk-lf-...',
+#     'secret_key': 'sk-lf-...',
+#     'host': 'https://cloud.langfuse.com',   # or self-hosted address
+# }


### PR DESCRIPTION
Three small, targeted fixes that follow the contributing guidelines:

## 1. Fix class name typo: GeneraticAgent → GenericAgent

The class name was consistently misspelled across 14 files (agentmain.py + 13 frontends). Since the project is called GenericAgent, the internal class should match. Pure rename, zero behavioral change.

## 2. Replace bare except clauses with specific exceptions

- agentmain.py: bare except: pass that silently swallowed session init failures now logs a warning with the key name and error
- agentmain.py: bare except: in next_llm changed to except Exception: to avoid catching KeyboardInterrupt/SystemExit
- ga.py: bare except: in do_code_run changed to except (ValueError, TypeError): since only int conversion can fail there

## 3. Expand English mykey template (77 to ~370 lines)

The Chinese mykey_template.py has comprehensive documentation including session type reference, native vs non-native explanation, apibase rules, complete field reference, and provider-specific examples. The English version was ~77 lines with minimal guidance. This brings parity with the Chinese template so international users can configure GA correctly without needing to read Chinese.

All changes are compact, self-documenting, and have minimal change radius.