### PR TITLE
fix(qqapp): exponential reconnect backoff

### DIFF
--- a/frontends/qqapp.py
+++ b/frontends/qqapp.py
@@ -103,14 +103,19 @@ class QQApp(AgentChatMixin):
 
     async def start(self):
         self.client = _make_bot_class(self)()
+        delay, max_delay = 5, 300
         while True:
+            started_at = time.monotonic()
             try:
                 print(f"[QQ] bot starting... {time.strftime('%m-%d %H:%M')}")
                 await self.client.start(appid=APP_ID, secret=APP_SECRET)
             except Exception as e:
                 print(f"[QQ] bot error: {e}")
-            print("[QQ] reconnect in 5s...")
-            await asyncio.sleep(5)
+            if time.monotonic() - started_at >= 60:
+                delay = 5
+            print(f"[QQ] reconnect in {delay}s...")
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, max_delay)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What
Replace the fixed 5s reconnect sleep with exponential backoff: 5 → 10 → 20 → … → 300s, resetting to 5s when a session lived ≥60s.

## Why
A misconfigured credential or sustained QQ platform outage causes the current loop to retry every 5s indefinitely, flooding `qqapp.log` and hammering the platform auth endpoint. Backoff lets pressure relax while still recovering quickly from a one-off blip.

`dcapp.py` (added in the same codebase) already uses this exact pattern — this PR brings `qqapp.py` in line with it.

## Solved
- Sustained failures no longer flood the log or burn the reconnect budget.
- Transient blips (session lived ≥60s before dropping) still recover with a 5s delay.