### PR TITLE
Fix grammar: 'an skill' → 'a skill' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@
 
 Its design philosophy: **don't preload skills — evolve them.**
 
-Every time GenericAgent solves a new task, it automatically crystallizes the execution path into an skill for direct reuse later. The longer you use it, the more skills accumulate — forming a skill tree that belongs entirely to you, grown from 3K lines of seed code.
+Every time GenericAgent solves a new task, it automatically crystallizes the execution path into a skill for direct reuse later. The longer you use it, the more skills accumulate — forming a skill tree that belongs entirely to you, grown from 3K lines of seed code.
 
 > **🤖 Self-Bootstrap Proof** — Everything in this repository, from installing Git and running `git init` to every commit message, was completed autonomously by GenericAgent. The author never opened a terminal once.
 
 ## 📋 Core Features
-- **Self-Evolving**: Automatically crystallizes each task into an skill. Capabilities grow with every use, forming your personal skill tree.
+- **Self-Evolving**: Automatically crystallizes each task into a skill. Capabilities grow with every use, forming your personal skill tree.
 - **Minimal Architecture**: ~3K lines of core code. Agent Loop is ~100 lines. No complex dependencies, zero deployment overhead.
 - **Strong Execution**: Injects into a real browser (preserving login sessions). 9 atomic tools take direct control of the system.
 - **High Compatibility**: Supports Claude / Gemini / Kimi / MiniMax and other major models. Cross-platform.


### PR DESCRIPTION
## Summary

Fixed a grammar error in the English section of README.md where `an skill` was used instead of the correct `a skill` (the article `a` is used before consonant sounds).

Two occurrences fixed:
- Line 20: overview paragraph
- Line 25: Core Features bullet point