### PR TITLE
Security: API key exposed in HTTP header without TLS

### DIFF
--- a/reflect/agent_team_worker.py
+++ b/reflect/agent_team_worker.py
@@ -16,6 +16,7 @@ _last_id = _last_done = -1
 def check():
     global _last_id
     if not base_url: return None
+    if not base_url.startswith('https://'): return None
     if _last_done > 0 and time.time() - _last_done < 120: return _prompt()
     try:
         req = request.Request(f"{base_url}/posts?limit=10")


### PR DESCRIPTION
## Problem

reflect/agent_team_worker.py sends board_key directly in X-API-Key header over plain HTTP. The base_url is read from config file without validation, allowing potential man-in-the-middle attacks to intercept credentials.

**Severity**: `high`
**File**: `reflect/agent_team_worker.py`

## Solution

Use HTTPS for API calls. Validate URL scheme before making requests. Consider using environment variables for sensitive keys instead of config files.

## Changes

- `reflect/agent_team_worker.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
