### PR TITLE
fix: filter whitespace-only text blocks to prevent API 400 errors

### DIFF
--- a/llmcore.py
+++ b/llmcore.py
@@ -994,7 +994,8 @@ class NativeToolClient:
         for tid in self._pending_tool_ids:
             if tid not in tr_id_set: tool_result_blocks.append({"type": "tool_result", "tool_use_id": tid, "content": ""})
         self._pending_tool_ids = []
-        merged = {"role": "user", "content": tool_result_blocks + combined_content}
+        # Filter whitespace-only text blocks that cause 400 on strict API proxies
+        merged = {"role": "user", "content": tool_result_blocks + [c for c in combined_content if c.get("text", "").strip()]}
         _write_llm_log('Prompt', json.dumps(merged, ensure_ascii=False, indent=2), self.log_path)
         gen = self.backend.ask(merged)
         try:


### PR DESCRIPTION
## Problem
When the model only outputs tool calls with no meaningful text response, `NativeToolClient.chat()` may produce a user message containing only whitespace text blocks (e.g. `"\n"`) alongside `tool_result` blocks.

This is rejected by strict API proxies/relays with:
```
HTTP 400: "The last user message has empty content. Provide a non-empty user prompt."
```

## Fix
Filter out whitespace-only text blocks before constructing the merged message in `NativeToolClient.chat()` (llmcore.py ~L997).

## Testing
Verified with model response logs showing `{"type":"text","text":"\n"}` being sent, causing 400 errors on proxied Anthropic API channels. After the fix, such empty blocks are filtered out and the request succeeds.