### PR TITLE
fix: disable Streamlit dev shortcuts to prevent Ctrl+C triggering Clear Caches on Windows

### DIFF
--- a/launch.pyw
+++ b/launch.pyw
@@ -18,7 +18,7 @@ def get_screen_width():
 
 def start_streamlit(port):
     global proc
-    cmd = [sys.executable, "-m", "streamlit", "run", os.path.join(frontends_dir, "stapp.py"), "--server.port", str(port), "--server.address", "localhost", "--server.headless", "true"]
+    cmd = [sys.executable, "-m", "streamlit", "run", os.path.join(frontends_dir, "stapp.py"), "--server.port", str(port), "--server.address", "localhost", "--server.headless", "true", "--client.toolbarMode", "viewer"]
     proc = subprocess.Popen(cmd)
     atexit.register(proc.kill)
 


### PR DESCRIPTION
## Problem
On Windows, pressing Ctrl+C in the pywebview window triggers Streamlit's built-in 'C' keyboard shortcut, which pops up a 'Clear caches' confirmation dialog instead of copying text.

## Fix
Add `--client.toolbarMode viewer` to the Streamlit launch command in `launch.pyw`. This disables all dev-mode keyboard shortcuts (including the 'C' = Clear Cache shortcut) without affecting any app functionality.

## Changes
- `launch.pyw` line 21: added `"--client.toolbarMode", "viewer"` to the streamlit startup command