### PR TITLE
修复：清理 TMWebDriver 未使用的导入，修正裸 except 语法

### DIFF
--- a/TMWebDriver.py
+++ b/TMWebDriver.py
@@ -1,9 +1,8 @@
 import json, threading, time, uuid, queue, socket, requests, traceback
-from typing import Dict, Any, Optional, List  
-from simple_websocket_server import WebSocketServer, WebSocket  
-from bs4 import BeautifulSoup  
-import bottle, random
-from bottle import route, template, request, response
+from typing import Any
+from simple_websocket_server import WebSocketServer, WebSocket
+import bottle
+from bottle import request
 
 class Session:
     def __init__(self, session_id, info, client=None):
@@ -69,7 +68,7 @@ class TMWebDriver:
                 try:
                     msg = msgQ.get(timeout=0.2)
                     try: self.acks[json.loads(msg).get('id','')] = True
-                    except: traceback.print_exc()
+                    except Exception: traceback.print_exc()
                     return msg
                 except queue.Empty: continue
             return json.dumps({"id": "", "ret": "next long-poll"})


### PR DESCRIPTION
## 修复内容

清理 TMWebDriver.py 中未使用的模块导入，同时将裸 `except:` 修正为 `except Exception:`，提升代码健壮性。

### 变更详情

**文件**: `TMWebDriver.py`

移除 8 个未使用的导入：
- `Dict`, `Optional`, `List`（typing）
- `BeautifulSoup`（bs4）
- `random`
- `route`, `template`, `response`（bottle）

保留的导入均已在文件中实际使用：`json`, `threading`, `time`, `uuid`, `queue`, `socket`, `requests`, `traceback`, `Any`（typing），`WebSocketServer`, `WebSocket`（simple_websocket_server），`bottle`，`request`（bottle）。

裸 `except:` 修正为 `except Exception:`，避免意外捕获 `KeyboardInterrupt` 和 `SystemExit`，使异常处理语义更清晰。

### 验证结果

- 语法检查：`python3 -m py_compile` ✅ 通过
- Lint 检查：`ruff check --select=F401,E722` ✅ 通过（F401/E722 全部消除）
- 修改行数：5 行新增 / 6 行删除（净减少 1 行）
