### PR TITLE
fix #312: 修复 next_prompt 为 None 时未正确退出导致的死循环

### DIFF
--- a/agent_loop.py
+++ b/agent_loop.py
@@ -90,7 +90,7 @@ def agent_runner_loop(client, system_prompt, user_input, handler, tools_schema, 
                 datastr = json.dumps(outcome.data, ensure_ascii=False, default=json_default) if type(outcome.data) in [dict, list] else str(outcome.data) 
                 tool_results.append({'tool_use_id': tid, 'content': datastr})
             next_prompts.add(outcome.next_prompt)
-        if len(next_prompts) == 0 or exit_reason:
+        if all(p is None or p == '' for p in next_prompts) or exit_reason:
             if len(handler._done_hooks) == 0 or exit_reason.get('result', '') == 'EXITED': break
             next_prompts.add(handler._done_hooks.pop(0))
         next_prompt = handler.turn_end_callback(response, tool_calls, tool_results, turn, '\n'.join(next_prompts), exit_reason)


### PR DESCRIPTION
## Issue #312: 修复 next_prompt 为 None 时未正确退出导致的死循环

### 问题重现

#### 触发场景
1. 当模型输出被截断或为 None 时（通常发生在上下文过大时）
2. 系统会收到模型输出被截断的告警提示
3. `next_prompt` 字段丢失，导致 `next_prompts` 集合中包含 `None` 值

#### 现象
- 框架误判为"还有下一轮提示词"
- 继续执行循环，无法正确退出
- 最终陷入死循环直到达到 `max_turns` 限制

### 原因分析

#### 根本原因
原代码使用 `len(next_prompts) == 0` 判断是否还有下一轮提示词：
```python
if len(next_prompts) == 0 or exit_reason:
```

**问题分析**：
- `next_prompts` 是一个 `set` 类型
- 当模型输出被截断时，`outcome.next_prompt` 为 `None`
- `next_prompts.add(None)` 会将 `None` 值加入集合
- 即使集合中有元素，但如果这些元素都是 `None` 或空字符串 `''`，`len(next_prompts)` 仍然大于 0
- 这导致判断失效，框架误判为"还有下一轮提示词"
- 继续执行循环，最终陷入死循环直到达到 `max_turns` 限制

**触发条件**：
- **上下文过大**：当对话上下文过大时，模型输出可能被截断
- **模型输出为 None**：模型可能返回 `None` 的 `next_prompt`
- **网络问题**：网络不稳定可能导致模型输出不完整

### 修改说明

#### 修改位置
**文件**: `agent_loop.py` (第 93 行)

#### 修复前后对比

**修复前**:
```python
if len(next_prompts) == 0 or exit_reason:
```

**修复后**:
```python
if all(p is None or p == '' for p in next_prompts) or exit_reason:
```

#### 修复说明
使用 `all(p is None or p == '' for p in next_prompts)` 来检查：
1. 当 `next_prompts` 中**所有**元素都是 `None` 或空字符串时，正确退出循环
2. 避免因 `next_prompt` 为 `None` 而无法正确退出的死锁问题
3. 确保在模型输出被截断或为 `None` 时，框架能够正确识别并退出

### 测试建议

#### 测试场景
1. **模型输出被截断的场景**
   - 模拟上下文过大的情况
   - 验证框架能够正确识别并退出

2. **模型输出为 None 的场景**
   - 模拟模型返回 `None` 的 `next_prompt` 的情况
   - 验证框架能够正确识别并退出

3. **正常场景**
   - 验证正常对话流程不受影响
   - 验证循环能够正常继续

#### 验证要点
- 循环能够正确退出，不会陷入死循环
- 框架能够正确处理模型输出被截断或为 `None` 的情况
- 不会出现 `max_turns` 限制导致的异常退出

### 关联 Issue
#312

### 备注
- 此修复主要针对模型输出被截断或为 `None` 时的死循环问题
- 建议同时关注上下文大小管理，避免频繁触发模型输出截断
- 可以考虑在后续版本中增加上下文长度限制或自动截断机制
