### PR TITLE
feat: add /btw side-question subagent

### DIFF
--- a/frontends/btw_cmd.py
+++ b/frontends/btw_cmd.py
@@ -1,0 +1,142 @@
+"""`/btw` 命令：side question — 不打断主 Agent 的临时 subagent 问答。
+
+- 持锁 deepcopy backend.history → 后台线程 backend.raw_ask 单次拉答
+- 主 agent backend.history 零写入；不入 task_queue
+- 答案 → display_queue 'done'（install 路径）或同步 return（frontend 路径）
+
+复用 backend.raw_ask + make_messages，不新建 LLM 实例。
+"""
+from __future__ import annotations
+import copy, os, threading, time
+from typing import Optional
+
+
+_WRAPPER_ZH = """<system-reminder>
+这是用户的临时插问 (side question)。主 agent 仍在后台运行，**不会被打断**。
+
+身份与边界：
+- 你是一个独立的轻量 sub-agent
+- 上下文里能看到主 agent 与用户的完整对话、最近的工具调用与结果
+- 用户在问当前进展或顺便确认某事——基于已有信息**一次性**作答
+- 没有任何工具可用：不要"让我查一下" / "我去试试" / 任何承诺动作
+- 信息不足就坦白说"基于目前对话我不知道"
+
+侧问内容如下：
+</system-reminder>
+
+{question}"""
+
+_WRAPPER_EN = """<system-reminder>
+This is a side question from the user. The main agent is NOT interrupted — it continues in the background.
+
+Identity & boundaries:
+- You are an independent lightweight sub-agent
+- You can see the full conversation between the main agent and the user, plus recent tool calls/results
+- The user is asking about current progress or a quick aside — answer in **one shot** from existing info
+- You have NO tools — never say "let me check" / "I'll try" / any action promise
+- If info is missing, just say "based on the conversation I don't know"
+
+Question:
+</system-reminder>
+
+{question}"""
+
+_TIMEOUT_SEC = 120
+
+
+def _wrapper(): return _WRAPPER_EN if os.environ.get('GA_LANG') == 'en' else _WRAPPER_ZH
+
+
+def _strip_cmd(query):
+    s = (query or '').strip()
+    return s[len('/btw'):].strip() if s.startswith('/btw') else s
+
+
+def _help_text():
+    return ('**/btw 用法**：side question — 临时问主 agent 当前进展，不打断主线\n\n'
+            '`/btw <你的问题>`\n\n'
+            '行为：抓取当前对话上下文 → 单轮纯文本作答（无工具）→ 主 agent 历史不变。')
+
+
+def _snapshot_history(backend):
+    """Lock + deepcopy: defends against concurrent compress_history_tags mutating inner blocks."""
+    with backend.lock:
+        return copy.deepcopy(list(backend.history))
+
+
+def _build_wire(backend, history, sidequest_msg):
+    """history + sidequest → wire-format. Dispatches: BaseSession subclasses → make_messages,
+    Native* → raw pairs (raw_ask runs _fix/_drop/_ensure transforms itself)."""
+    msgs = history + [sidequest_msg]
+    if hasattr(backend, 'make_messages'):
+        return backend.make_messages(msgs)
+    return [{"role": m["role"], "content": list(m.get("content", []))} for m in msgs]
+
+
+def _ask(agent, question, deadline):
+    """One-shot raw_ask against current backend; never mutates backend.history."""
+    backend = agent.llmclient.backend
+    user_msg = {"role": "user",
+                "content": [{"type": "text", "text": _wrapper().format(question=question)}]}
+    wire = _build_wire(backend, _snapshot_history(backend), user_msg)
+    text = ''
+    for chunk in backend.raw_ask(wire):
+        text += chunk
+        if time.time() > deadline:
+            return text + '\n\n⚠️ /btw 超时，仅返回部分回复。'
+    return text
+
+
+def _format(question, body, took):
+    head = f'> 🟡 /btw {question}\n\n'
+    return head + (body.strip() or '*(空回复)*') + f'\n\n*({took:.1f}s)*'
+
+
+def _run(agent, question, deadline):
+    """Catches errors at the boundary so neither caller path needs its own try/except."""
+    try: return _ask(agent, question, deadline)
+    except Exception as e: return f'❌ /btw 失败: {type(e).__name__}: {e}'
+
+
+def handle(agent, query, display_queue) -> Optional[str]:
+    """Slash-cmd entry (server-side, install path). Spawn worker; return None to consume."""
+    question = _strip_cmd(query)
+    if not question or question in ('help', '?', '-h', '--help'):
+        display_queue.put({'done': _help_text(), 'source': 'system'})
+        return None
+    started = time.time()
+    deadline = started + _TIMEOUT_SEC
+
+    def worker():
+        body = _run(agent, question, deadline)
+        display_queue.put({'done': _format(question, body, time.time() - started), 'source': 'system'})
+
+    threading.Thread(target=worker, daemon=True, name='btw-sidequest').start()
+    return None
+
+
+def handle_frontend_command(agent, query) -> str:
+    """Sync entry for frontends wanting a string back (tg/wx/stapp/...)."""
+    question = _strip_cmd(query)
+    if not question or question in ('help', '?', '-h', '--help'):
+        return _help_text()
+    started = time.time()
+    body = _run(agent, question, started + _TIMEOUT_SEC)
+    return _format(question, body, time.time() - started)
+
+
+def install(cls):
+    """Idempotent monkey-patch: intercept /btw before original dispatch."""
+    orig = cls._handle_slash_cmd
+    if getattr(orig, '_btw_patched', False): return
+
+    def patched(self, raw_query, display_queue):
+        s = (raw_query or '').strip()
+        if s == '/btw' or s.startswith('/btw ') or s.startswith('/btw\t'):
+            r = handle(self, raw_query, display_queue)
+            if r is None: return None
+            return r
+        return orig(self, raw_query, display_queue)
+
+    patched._btw_patched = True
+    cls._handle_slash_cmd = patched

--- a/frontends/chatapp_common.py
+++ b/frontends/chatapp_common.py
@@ -8,6 +8,7 @@ HELP_COMMANDS = (
     ("/restore", "恢复上次对话历史"),
     ("/continue", "列出可恢复会话"),
     ("/continue [n]", "恢复第 n 个会话"),
+    ("/btw <q>", "side question — 临时插问主 agent 进展，不打断主线"),
     ("/llm", "查看当前模型列表"),
     ("/llm [n]", "切换到第 n 个模型"),
 )
@@ -300,6 +301,9 @@ class AgentChatMixin:
             return await self.send_text(chat_id, _handle_continue_frontend(self.agent, cmd), **ctx)
         if op == "/new":
             return await self.send_text(chat_id, _reset_conversation(self.agent), **ctx)
+        if op == "/btw":
+            answer = await asyncio.to_thread(_handle_btw_frontend, self.agent, cmd)
+            return await self.send_text(chat_id, answer, **ctx)
         return await self.send_text(chat_id, HELP_TEXT, **ctx)
 
     async def run_agent(self, chat_id, text, **ctx):
@@ -334,3 +338,4 @@ class AgentChatMixin:
 from agentmain import GeneraticAgent as _GA
 from continue_cmd import handle_frontend_command as _handle_continue_frontend, install as _install_continue, reset_conversation as _reset_conversation
 _install_continue(_GA)
+from btw_cmd import handle_frontend_command as _handle_btw_frontend, install as _install_btw; _install_btw(_GA)

--- a/frontends/stapp.py
+++ b/frontends/stapp.py
@@ -16,6 +16,7 @@ import time, json, re, threading, queue
 from agentmain import GeneraticAgent
 import chatapp_common  # activate /continue command (monkey patches GeneraticAgent)
 from continue_cmd import handle_frontend_command, reset_conversation, list_sessions, extract_ui_messages
+from btw_cmd import handle_frontend_command as btw_handle_frontend
 
 st.set_page_config(page_title="Cowork", layout="wide")
 
@@ -139,6 +140,8 @@ def fold_turns(text):
             segments.append({'type': 'fold', 'title': title, 'content': content})
         else: segments.append({'type': 'text', 'content': marker + content})
     return segments
+_SUMMARY_TAG_RE = re.compile(r'<summary>.*?</summary>\s*', re.DOTALL)
+
 def render_segments(segments, suffix=''):
     # 整块重画：调用方用 slot.container() 包裹，保证 DOM 路径稳定、跨 rerun 对齐（消除"灰色重影"）。
     # heartbeat 空转时 segments 不变 → Streamlit 后端 diff 无变化 → 前端零闪烁；
@@ -147,22 +150,63 @@ def render_segments(segments, suffix=''):
         if seg['type'] == 'fold':
             with st.expander(seg['title'], expanded=False): st.markdown(seg['content'])
         else:
-            st.markdown(seg['content'] + suffix)
+            # Strip <summary> meta tags from text segments — folded turns already
+            # promote them to expander titles; for the first/last segments
+            # they'd otherwise leak into the chat as raw text (esp. after /continue
+            # restores a multi-turn body).
+            st.markdown(_SUMMARY_TAG_RE.sub('', seg['content']) + suffix)
 
-def agent_backend_stream(prompt):
-    display_queue = agent.put_task(prompt, source="user")
-    response = ''
-    try:
-        while True:
-            try: item = display_queue.get(timeout=1)
-            except queue.Empty:
-                yield response   # heartbeat: let outer st.markdown() run → Streamlit checks StopException
-                continue
-            if 'next' in item:
-                response = item['next']; yield response
-            if 'done' in item:
-                yield item['done']; break
-    finally: agent.abort()
+def agent_backend_stream(prompt=None):
+    """Drain main task display_queue.
+    - prompt given:  start a fresh task; new dq is kept in session_state.
+    - prompt is None: resume a dq left in session_state by a prior run (e.g. after /btw).
+    Per-chunk progress is mirrored to session_state.partial_response so the rendered
+    bubble survives reruns. No implicit agent.abort() — explicit stop is on the Stop button."""
+    if prompt is not None:
+        st.session_state.display_queue = agent.put_task(prompt, source="user")
+        st.session_state.partial_response = ''
+    dq = st.session_state.get('display_queue')
+    if dq is None: return
+    # Drop a dangling 'LLM Running (Turn N) ...' marker if the captured partial
+    # ended right at a turn boundary with no content yet — otherwise the resume
+    # bubble flashes as a marker-only gray line. The marker reappears with
+    # content on the next chunk (raw_resp is cumulative).
+    response = re.sub(r'\**LLM Running \(Turn \d+\) \.\.\.\**\s*$',
+                      '', st.session_state.get('partial_response', '')).rstrip()
+    while True:
+        try: item = dq.get(timeout=1)
+        except queue.Empty:
+            yield response   # heartbeat: let outer st.markdown() run → Streamlit checks StopException
+            continue
+        if 'next' in item:
+            response = item['next']
+            st.session_state.partial_response = response
+            yield response
+        if 'done' in item:
+            st.session_state.display_queue = None
+            st.session_state.partial_response = ''
+            yield item['done']; break
+
+
+def render_main_stream(prompt=None):
+    """Render the assistant bubble for the main task (new or resumed). Saves final to messages."""
+    with st.chat_message("assistant"):
+        frozen = 0; live = st.empty(); response = ''
+        CURSOR = ' ▌'
+        for response in agent_backend_stream(prompt):
+            segs = fold_turns(response)
+            n_done = max(0, len(segs) - 1)
+            while frozen < n_done:
+                with live.container(): render_segments([segs[frozen]])
+                live = st.empty(); frozen += 1
+            with live.container(): render_segments([segs[-1]], suffix=CURSOR)   # live 区域
+        segs = fold_turns(response)
+        for i in range(frozen, len(segs)):
+            with live.container(): render_segments([segs[i]])
+            if i < len(segs) - 1: live = st.empty()
+    if response:
+        st.session_state.messages.append({"role": "assistant", "content": response})
+        st.session_state.last_reply_time = int(time.time())
 
 if "messages" not in st.session_state: st.session_state.messages = []
 for msg in st.session_state.messages:
@@ -234,26 +278,26 @@ if prompt := st.chat_input("any task?"):
             st.session_state.messages = list(st.session_state.messages) + \
                 [{"role": "user", "content": cmd, "time": ts}] + tail
         _reset_and_rerun()
+    if cmd.startswith("/btw"):
+        answer = btw_handle_frontend(agent, cmd)  # sync; bypasses put_task → main agent.run() untouched
+        st.session_state.messages = list(st.session_state.messages) + [
+            {"role": "user", "content": prompt, "time": ts},
+            {"role": "assistant", "content": answer, "time": ts},
+        ]
+        st.rerun()  # preserve display_queue/partial_response so resume path drains the running main task
+    # Regular prompt: cancel any in-flight task to match original "submit cancels" UX.
+    # (/btw branch above is the only path that intentionally lets the prior task keep streaming.)
+    if st.session_state.get('display_queue') is not None:
+        agent.abort()
+        st.session_state.display_queue = None
+        st.session_state.partial_response = ''
     st.session_state.messages.append({"role": "user", "content": prompt})
     if hasattr(agent, '_pet_req') and not prompt.startswith('/'): agent._pet_req('state=walk')
     with st.chat_message("user"): st.markdown(prompt)
-
-    with st.chat_message("assistant"):
-        frozen = 0; live = st.empty(); response = ''
-        CURSOR = ' ▌'
-        for response in agent_backend_stream(prompt):
-            segs = fold_turns(response)
-            n_done = max(0, len(segs) - 1)
-            while frozen < n_done:
-                with live.container(): render_segments([segs[frozen]])
-                live = st.empty(); frozen += 1
-            with live.container(): render_segments([segs[-1]], suffix=CURSOR)   # live 区域
-        segs = fold_turns(response)
-        for i in range(frozen, len(segs)):
-            with live.container(): render_segments([segs[i]])
-            if i < len(segs) - 1: live = st.empty()
-    st.session_state.messages.append({"role": "assistant", "content": response})
-    st.session_state.last_reply_time = int(time.time())
+    render_main_stream(prompt)
+elif st.session_state.get('display_queue') is not None:
+    # No new prompt but a task is mid-flight (typically a /btw rerun) — resume drain.
+    render_main_stream()
 
 if st.session_state.autonomous_enabled:
     st.markdown(f"""<div id="last-reply-time" style="display:none">{st.session_state.get('last_reply_time', int(time.time()))}</div>""", unsafe_allow_html=True)


### PR DESCRIPTION
## /btw — side question subagent

  让用户在不打断主 Agent 进程的前提下，临时插问当前进展。复用 `backend.raw_ask` + `make_messages`，不新建 LLM 实例，主 Agent 的
  `backend.history` 零写入。

  /btw <你的问题>

  ---

  ### 改动范围（坦诚分组）

  本 PR 触及 3 个文件、共 +223/-32 行，按"必需性"分成三组：

  #### A. /btw 命令本体（核心，无可争议）

  - **`frontends/btw_cmd.py`**（新增 142 行）
    持锁 `deepcopy(backend.history)` → 后台线程 `backend.raw_ask` 单轮 answer → `display_queue.put({'done': ...})`。一次性失败由 `_run` 的
  try/except 收尾，不会冒到 worker 线程外。
  - **`frontends/chatapp_common.py`**（+5 行）
    `HELP_COMMANDS` 注册 / `AgentChatMixin.handle_command` 加 `/btw` 分支 / 模块底部 `install(_GA)`，与 `/continue` 现有模式完全对齐。

  #### B. stapp.py /btw 适配（必需，否则功能不成立）

  stapp 的 `agent_backend_stream` 原本在 `finally: agent.abort()`。每次 Streamlit rerun（包括用户提交 /btw）都会触发上一个生成器的
  `finally`，把还在跑的主任务直接 abort 掉 —— 与 /btw "不打断主 agent" 的语义直接冲突。

  - 删掉 `finally: agent.abort()`（-1 行；Stop 按钮在 line 64 仍然显式 abort，行为不丢）。
  - 普通 prompt 路径补上**显式** `agent.abort()`，保留原来"提交即取消"的 UX。
  - `/btw` 分支：sync 走 `btw_handle_frontend`，绕过 `put_task` / `agent_backend_stream`，直接落 `session_state.messages` 后 `st.rerun()`。

  这一组**不修不行**：单独验证过，缺这一段时 /btw 在 stapp 里会立刻把主任务杀掉。

  #### C. stapp.py UI 一致性（同时引入，可商榷）

  A+B 落地后，遇到两个**原本就存在但被 /btw 暴露**的 stapp 渲染问题：

  1. **主任务流式跟踪丢失**：`agent_backend_stream` 的 `display_queue` 是 local，Streamlit rerun 后引用就没了。/btw
  之后主任务后台还在跑、`done` 也推过去了，但 UI 端再没人 drain → 用户感知"被打断了"。
     - 修法：把 `display_queue` + `partial_response` 升到 `session_state`；新增 `render_main_stream(prompt=None)` 抽出 streaming 渲染；新增
  `elif resume` 分支，rerun 后接力 drain。

  2. **/continue 恢复多轮对话时 `<summary>` 标签作为 raw HTML 露出**：`fold_turns` 只把*中间*轮的 `<summary>` 提取为 expander
  标题，第一段和最后一段的 text segment 没处理。
     - 修法：`render_segments` 里给 text segments 加一道 `_SUMMARY_TAG_RE.sub('', ...)`。

  这两项严格说和 /btw 正交，**也可以拆成独立 PR**。我把它们一并放进来是因为：
  - (1) 没修的话 /btw 在 stapp 里仍会被用户感知为"打断主 agent"，与 PR 的核心承诺有体感落差；
  - (2) 改面都在 stapp.py 同一份文件、同一段流式渲染逻辑，分 PR 反而要拆 hunk，整体更乱。

  **如果 reviewer 倾向分 PR**，我可以把 C 抽成 `refactor(stapp): persist display_queue across reruns` + `fix(stapp): strip <summary> meta tags
   in restored history` 两个独立 PR。

  ---

  ### 设计要点

  - **不新建 LLM 实例**：复用 `agent.llmclient.backend`，零额外 cost。
  - **零核心代码改动**：`agentmain.py` / `llmcore.py` / `ga.py` 完全不动，命令通过 `install(cls)` 单调猴补 `_handle_slash_cmd`，与现有
  `/continue` 一致。
  - **数据安全**：`backend.lock` + `copy.deepcopy` 防 `compress_history_tags` 在中途改 inner block；超时硬上限 120s。
  - **多前端覆盖**：via `install()` → 任何把 chatapp_common import 进来的前端（stapp / qtapp / qq / wecom / dingtalk 等）都自动支持；via
  `AgentChatMixin.handle_command` → 复用 base 的子类（qq / wecom / dingtalk）也免改。

  ### 验证

  - 端到端 import smoke test 全过：`btw_cmd` ↔ `chatapp_common` ↔ `agentmain.GeneraticAgent._handle_slash_cmd` 钩子链路完整、`install()`
  幂等。
  - 手测：stapp 里 `/btw` 主任务空闲 / mid-task / 错误路径（network fail）三种情况；`/continue` 恢复多轮对话；普通对话流不受影响。
  - 不接触 `temp/model_responses/*.txt`，/btw 内容**不进**主 Agent 日志（确认过）。

  ### 文件改动统计

   frontends/btw_cmd.py        | 142 +++++++++++++++++  (新增)
   frontends/chatapp_common.py |   5 +
   frontends/stapp.py          | 108 +++++++++++++++----------------
   3 files changed, 223 insertions(+), 32 deletions(-)