### PR TITLE
fix: make scheduler lock port configurable with automatic fallback

### DIFF
--- a/reflect/scheduler.py
+++ b/reflect/scheduler.py
@@ -3,10 +3,22 @@ from datetime import datetime, timedelta
 
 # 端口锁：防止重复启动，bind失败时agentmain会直接崩溃退出
 # reload时mod.__dict__保留_lock，跳过重复绑定
+# 端口可通过 SCHEDULER_LOCK_PORT 环境变量配置，默认 45762
+# Windows 动态端口范围可能占用 45762，此时自动尝试备选端口
 try: _lock
 except NameError:
     _lock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
-    _lock.bind(('127.0.0.1', 45762)); _lock.listen(1)
+    _lock.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, 1)
+    _base_port = int(os.environ.get('SCHEDULER_LOCK_PORT', 45762))
+    _bound = False
+    for _port in range(_base_port, _base_port + 10):
+        try:
+            _lock.bind(('127.0.0.1', _port)); _lock.listen(1)
+            _bound = True; break
+        except OSError:
+            continue
+    if not _bound:
+        raise RuntimeError(f'scheduler: cannot bind lock port in range {_base_port}-{_base_port+9}')
 
 INTERVAL = 120
 ONCE = False


### PR DESCRIPTION
## Summary

On Windows, the scheduler's hardcoded lock port `45762` can conflict with the system's dynamic port range, causing `WinError 10013` and preventing startup.

## Changes

- Made the lock port configurable via `SCHEDULER_LOCK_PORT` environment variable (default: 45762)
- Added automatic port fallback: if the configured port is occupied, tries up to 10 consecutive ports
- Raises a clear `RuntimeError` if no port in the range can be bound

## Root Cause

`reflect/scheduler.py` hardcoded `45762` for the lock socket. On Windows, if the dynamic port range (configurable via `netsh`) overlaps with this port, the `bind()` call fails with `WinError 10013`.

## Testing

- All 3 existing tests pass (no regression)
- Verified: default port binding works correctly
- Verified: `SCHEDULER_LOCK_PORT` environment variable override works
- Verified: automatic fallback to next available port when the target port is occupied

Closes #331