### PR TITLE
feat(tgapp): add /btw command handling

### DIFF
--- a/frontends/chatapp_common.py
+++ b/frontends/chatapp_common.py
@@ -19,6 +19,7 @@ TELEGRAM_MENU_COMMANDS = (
     ("new", "开启新对话并清空当前上下文"),
     ("restore", "恢复上次对话历史"),
     ("continue", "列出可恢复会话；/continue n 恢复第 n 个"),
+    ("btw", "临时插问主 agent 进展，不打断主线"),
     ("llm", "查看模型列表；/llm n 切换到指定模型"),
 )
 

--- a/frontends/tgapp.py
+++ b/frontends/tgapp.py
@@ -25,6 +25,7 @@ from chatapp_common import (
     split_text,
 )
 from continue_cmd import handle_frontend_command, reset_conversation
+from btw_cmd import handle_frontend_command as handle_btw_frontend_command
 from llmcore import mykeys
 
 agent = GeneraticAgent()
@@ -812,6 +813,14 @@ def _cancel_stream_task(ctx):
 async def _sync_commands(application):
     await application.bot.set_my_commands([BotCommand(command, description) for command, description in TELEGRAM_MENU_COMMANDS])
 
+async def _reply_command_text(message, text):
+    for segment in _markdown_safe_segments(text) or ["..."]:
+        try:
+            await message.reply_text(_to_markdown_v2(segment), parse_mode=ParseMode.MARKDOWN_V2)
+        except Exception as exc:
+            print(f"[TG command markdown fallback] {type(exc).__name__}: {exc}", flush=True)
+            await message.reply_text(segment)
+
 async def handle_msg(update, ctx):
     uid = update.effective_user.id
     if ALLOWED and uid not in ALLOWED:
@@ -908,6 +917,9 @@ async def handle_command(update, ctx):
         return await update.message.reply_text(f"状态: {'🔴 运行中' if agent.is_running else '🟢 空闲'}\nLLM: [{agent.llm_no}] {llm}")
     if op == '/stop': return await cmd_abort(update, ctx)
     if op == '/llm': return await cmd_llm(update, ctx)
+    if op == '/btw':
+        answer = await asyncio.to_thread(handle_btw_frontend_command, agent, cmd)
+        return await _reply_command_text(update.message, answer)
     if op == '/new':
         _cancel_stream_task(ctx)
         return await update.message.reply_text(reset_conversation(agent))


### PR DESCRIPTION
## Context

Telegram `/help` already advertises `/btw`, but Telegram command messages are consumed by `handle_command()` before they can reach the shared slash-command path. This PR wires `/btw` into the Telegram command handler while keeping the change radius limited to Telegram command wiring and shared command metadata. No new dependencies are added.

## Summary

Add Telegram `/btw` slash-command handling by reusing the shared `btw_cmd` frontend path without interrupting active Telegram streams.

## Changes

### `frontends/tgapp.py`

- Import the shared `/btw` frontend handler from `btw_cmd`.
- Add a Telegram `/btw` command branch that runs the shared handler via `asyncio.to_thread(...)` so the bot event loop is not blocked.
- Preserve active `ctx.user_data["stream_task"]` for `/btw`, keeping it as a side question that does not cancel the main response stream.
- Send `/btw` replies through the existing MarkdownV2-safe segmentation path with a plain-text fallback.

### `frontends/chatapp_common.py`

- Add `btw` to `TELEGRAM_MENU_COMMANDS` so Telegram bot command menu sync matches the advertised command surface.