### PR TITLE
feat(oaiapp): 让项目能支持 OpenAI-compatible /v1/chat/completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,52 @@ The default Streamlit desktop UI started by `python launch.pyw`, plus the QQ / T
 - `/continue N` - restore the `N`th recoverable conversation
 
 
+## 🔌 OpenAI-Compatible API
+
+Expose the **whole agent** (not just the underlying LLM) as a single OpenAI-style model via `/v1/chat/completions`. Any OAI-compatible client (NextChat, Open WebUI, LobeChat, raw OpenAI SDK, curl…) can talk to GenericAgent and automatically get the full agent behavior: tool loop, memory, file I/O, browser control. Streaming (SSE) is supported.
+
+#### Configure
+
+In `mykey.py`:
+
+```python
+oai_api_token   = 'sk-local-your-secret-token'   # required, Bearer token
+# oai_api_host  = '127.0.0.1'                    # optional; '0.0.0.0' to expose on LAN
+# oai_api_port  = 18000                          # optional
+# oai_api_timeout = 600                          # optional, seconds per request
+```
+
+#### Run
+
+```bash
+python frontends/oaiapp.py            # standalone
+# or together with the desktop GUI:
+python launch.pyw --api
+```
+
+#### Endpoints
+
+- `POST /v1/chat/completions` — OpenAI Chat Completions, supports `stream: true/false`
+- `GET  /v1/models` — lists all configured backend LLMs (informational)
+
+#### Quick test
+
+```bash
+curl -N http://127.0.0.1:18000/v1/chat/completions \
+  -H "Authorization: Bearer sk-local-your-secret-token" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"any","stream":true,
+       "messages":[{"role":"user","content":"list the current directory"}]}'
+```
+
+#### Notes & Limitations
+
+- **Shared single agent instance** — concurrent HTTP requests are serialized through the agent's task queue. The agent's own history is the conversation source of truth; only the **last** `user` message from `messages[]` is forwarded each call.
+- The `model` field in requests is **ignored**; the currently selected backend (`agent.llm_no`) is used.
+- Multimodal `image_url` parts are noted as placeholders, not yet wired to the agent's image channel.
+- Client disconnects do **not** cancel an in-flight agent loop — it runs to completion server-side.
+
+
 ## 📊 Comparison with Similar Tools
 
 | Feature | GenericAgent | OpenClaw | Claude Code |
@@ -484,6 +530,52 @@ dingtalk_allowed_users = ["your_staff_id"]  # 或 ['*']
 - `/new` - 开启新对话并清空当前上下文
 - `/continue` - 列出可恢复会话快照
 - `/continue N` - 恢复第 `N` 个可恢复会话
+
+
+## 🔌 OpenAI 兼容 API
+
+通过 `/v1/chat/completions` 把**整个智能体**（不是底层裸 LLM）作为一个 OpenAI 风格的"模型"暴露出去。任何兼容 OpenAI 接口的客户端（NextChat、Open WebUI、LobeChat、OpenAI SDK、curl 等）都可以接入 GenericAgent，**自动获得完整智能体行为**：工具循环、分层记忆、文件 IO、浏览器控制等。支持流式（SSE）。
+
+#### 配置
+
+在 `mykey.py` 中：
+
+```python
+oai_api_token   = 'sk-local-your-secret-token'   # 必填，Bearer token
+# oai_api_host  = '127.0.0.1'                    # 可选；'0.0.0.0' 暴露到局域网
+# oai_api_port  = 18000                          # 可选
+# oai_api_timeout = 600                          # 可选，单请求超时秒数
+```
+
+#### 启动
+
+```bash
+python frontends/oaiapp.py            # 独立运行
+# 或与桌面 GUI 一起：
+python launch.pyw --api
+```
+
+#### 端点
+
+- `POST /v1/chat/completions` — OpenAI Chat Completions，支持 `stream: true/false`
+- `GET  /v1/models` — 列出当前配置的全部 LLM 后端（仅信息展示）
+
+#### 快速测试
+
+```bash
+curl -N http://127.0.0.1:18000/v1/chat/completions \
+  -H "Authorization: Bearer sk-local-your-secret-token" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"any","stream":true,
+       "messages":[{"role":"user","content":"列出当前目录"}]}'
+```
+
+#### 说明与限制
+
+- **共享单实例**：所有 HTTP 请求经 agent 任务队列串行化。Agent 自身维护对话历史；每次调用只取 `messages[]` 中**最后一条** `user` 消息转发给 agent。
+- 请求中的 `model` 字段**会被忽略**，使用当前选中的后端（`agent.llm_no`）。
+- 多模态 `image_url` 暂未接入 agent 的 images 通道（仅占位）。
+- 客户端断开**不会**取消正在执行的 agent loop —— 任务会在服务端跑完。
 
 
 ## 📊 与同类产品对比

--- a/frontends/oaiapp.py
+++ b/frontends/oaiapp.py
@@ -1,0 +1,324 @@
+"""OpenAI-compatible /v1/chat/completions endpoint that exposes the GenericAgent
+as a single 'model'. Shared agent instance, streaming supported.
+
+Endpoints:
+    POST /v1/chat/completions   (stream and non-stream)
+    GET  /v1/models
+
+Run standalone:
+    python frontends/oaiapp.py
+Or via launcher:
+    python launch.pyw --api
+
+Required config in mykey.py:
+    oai_api_token = 'sk-your-local-token'
+Optional:
+    oai_api_host    = '127.0.0.1'   # use '0.0.0.0' to expose on LAN
+    oai_api_port    = 18000
+    oai_api_timeout = 600           # seconds, per-request
+"""
+import os, sys, json, time, uuid, threading
+from socketserver import ThreadingMixIn
+from wsgiref.simple_server import make_server, WSGIServer, WSGIRequestHandler
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+try:
+    from bottle import Bottle, request, response, HTTPResponse, debug as bottle_debug
+except ImportError:
+    print("[oaiapp] bottle not installed. Run: pip install bottle")
+    sys.exit(1)
+
+bottle_debug(True)  # show tracebacks on error pages + log to stderr
+import traceback
+
+from agentmain import GeneraticAgent
+from llmcore import mykeys
+
+# ---------- single shared agent (same pattern as tgapp.py) ----------
+agent = GeneraticAgent()
+agent.verbose = False
+# NOTE: do NOT touch agent.inc_out — DeltaTracker below handles both modes.
+
+# ---------- config ----------
+TOKEN       = mykeys.get('oai_api_token')
+HOST        = mykeys.get('oai_api_host', '127.0.0.1')
+PORT        = int(mykeys.get('oai_api_port', 18000))
+REQ_TIMEOUT = int(mykeys.get('oai_api_timeout', 600))
+
+if not TOKEN:
+    print("[oaiapp][WARN] oai_api_token not set in mykey.py — server will refuse all requests.")
+
+app = Bottle()
+
+
+@app.error(500)
+def _err500(err):
+    try:
+        tb = traceback.format_exc()
+        exc = getattr(err, 'exception', None)
+        msg = repr(exc) if exc else (getattr(err, 'body', None) or 'unknown')
+    except Exception as e:
+        tb, msg = f"(handler failure: {e})", "internal error"
+    sys.stderr.write(f"[oaiapp][ERROR 500] {msg}\n{tb}\n"); sys.stderr.flush()
+    print(f"[oaiapp][ERROR 500] {msg}", flush=True)
+    response.content_type = 'application/json'
+    return json.dumps({"error": {"message": str(msg), "type": "server_error", "traceback": tb}}, ensure_ascii=False)
+
+
+# ---------- helpers ----------
+def _oai_err(status, msg, etype="invalid_request_error", code=None):
+    body = {"error": {"message": msg, "type": etype, "code": code}}
+    r = HTTPResponse(status=status, body=json.dumps(body, ensure_ascii=False))
+    r.content_type = 'application/json'
+    return r
+
+
+def _check_auth():
+    if not TOKEN:
+        return _oai_err(503, "oai_api_token not configured on server", "server_error")
+    auth = request.headers.get('Authorization', '') or ''
+    if not auth.startswith('Bearer ') or auth[7:].strip() != TOKEN:
+        return _oai_err(401, "Invalid API key", "authentication_error")
+    return None
+
+
+def _model_name():
+    try:
+        return agent.get_llm_name()
+    except Exception:
+        return "genericagent"
+
+
+def _extract_last_user(messages):
+    """Take only the last user message — agent maintains its own history."""
+    if not isinstance(messages, list) or not messages:
+        return None
+    for m in reversed(messages):
+        if not isinstance(m, dict) or m.get('role') != 'user':
+            continue
+        c = m.get('content', '')
+        if isinstance(c, str):
+            return c
+        if isinstance(c, list):
+            texts = []
+            for part in c:
+                if not isinstance(part, dict):
+                    continue
+                if part.get('type') == 'text':
+                    texts.append(part.get('text', ''))
+                elif part.get('type') == 'image_url':
+                    texts.append('[image attached — not yet wired through]')
+            return '\n'.join(t for t in texts if t)
+        return str(c)
+    return None
+
+
+class DeltaTracker:
+    """Robust delta extractor — works whether 'next' is cumulative or incremental."""
+    def __init__(self):
+        self.emitted = ""
+
+    def feed(self, chunk):
+        if not chunk:
+            return ""
+        if chunk.startswith(self.emitted):     # cumulative form
+            delta = chunk[len(self.emitted):]
+            self.emitted = chunk
+            return delta
+        self.emitted += chunk                  # incremental form
+        return chunk
+
+    def finalize(self, full_text):
+        if not full_text:
+            return ""
+        if full_text.startswith(self.emitted):
+            tail = full_text[len(self.emitted):]
+            self.emitted = full_text
+            return tail
+        return ""
+
+
+def _sse(obj):
+    return f"data: {json.dumps(obj, ensure_ascii=False)}\n\n"
+
+
+def _chunk(chat_id, model, delta_text=None, finish=None, role=None):
+    delta = {}
+    if role is not None:
+        delta['role'] = role
+    if delta_text is not None:
+        delta['content'] = delta_text
+    return {
+        "id": chat_id,
+        "object": "chat.completion.chunk",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+    }
+
+
+# ---------- CORS preflight ----------
+@app.hook('after_request')
+def _cors_after():
+    response.set_header('Access-Control-Allow-Origin', '*')
+    response.set_header('Access-Control-Allow-Headers', 'Authorization, Content-Type')
+    response.set_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+
+
+@app.route('/v1/models', method=['OPTIONS'])
+@app.route('/v1/chat/completions', method=['OPTIONS'])
+def _options():
+    return ''
+
+
+# ---------- endpoints ----------
+@app.route('/v1/models', method='GET')
+def list_models():
+    err = _check_auth()
+    if err:
+        return err
+    try:
+        lst = agent.list_llms()
+    except Exception:
+        lst = [(0, _model_name(), True)]
+    data = [{"id": name, "object": "model", "created": 0, "owned_by": "genericagent"}
+            for (_i, name, _cur) in lst]
+    response.content_type = 'application/json'
+    return json.dumps({"object": "list", "data": data}, ensure_ascii=False)
+
+
+@app.route('/v1/chat/completions', method='POST')
+def chat_completions():
+    try:
+        err = _check_auth()
+        if err:
+            return err
+        try:
+            body = request.json
+            if not isinstance(body, dict):
+                raise ValueError("body must be a JSON object")
+        except Exception as e:
+            return _oai_err(400, f"Invalid request body: {e}")
+
+        query = _extract_last_user(body.get('messages', []))
+        if not query:
+            return _oai_err(400, "No user message found in messages[]")
+
+        stream = bool(body.get('stream', False))
+        model = _model_name()
+        chat_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
+        print(f"[oaiapp] -> task (stream={stream}, len={len(query)}): {query[:80]!r}", flush=True)
+
+        dq = agent.put_task(query, source='oai_api')
+
+        if stream:
+            return _stream_response(dq, chat_id, model)
+        return _blocking_response(dq, chat_id, model)
+    except Exception as e:
+        tb = traceback.format_exc()
+        sys.stderr.write(f"[oaiapp][route exc] {e!r}\n{tb}\n"); sys.stderr.flush()
+        print(f"[oaiapp][route exc] {e!r}", flush=True)
+        return _oai_err(500, f"{type(e).__name__}: {e}", "server_error")
+
+
+def _blocking_response(dq, chat_id, model):
+    tracker = DeltaTracker()
+    final = ""
+    deadline = time.time() + REQ_TIMEOUT
+    try:
+        while True:
+            remaining = max(1, int(deadline - time.time()))
+            item = dq.get(timeout=remaining)
+            if 'next' in item:
+                tracker.feed(item['next'])
+            if 'done' in item:
+                final = item.get('done', '') or ''
+                tracker.finalize(final)
+                break
+        final = final or tracker.emitted
+    except Exception as e:
+        return _oai_err(504, f"Agent timeout/error: {e}", "server_error")
+
+    response.content_type = 'application/json'
+    return json.dumps({
+        "id": chat_id,
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": final},
+            "finish_reason": "stop",
+        }],
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    }, ensure_ascii=False)
+
+
+def _stream_response(dq, chat_id, model):
+    response.content_type = 'text/event-stream; charset=utf-8'
+    response.set_header('Cache-Control', 'no-cache')
+    response.set_header('X-Accel-Buffering', 'no')
+    # NOTE: do NOT set 'Connection' — it's hop-by-hop, WSGI servers reject it (wsgiref AssertionError).
+
+    def gen():
+        tracker = DeltaTracker()
+        try:
+            yield _sse(_chunk(chat_id, model, role='assistant'))
+            deadline = time.time() + REQ_TIMEOUT
+            while True:
+                remaining = max(1, int(deadline - time.time()))
+                item = dq.get(timeout=remaining)
+                if 'next' in item:
+                    delta = tracker.feed(item['next'])
+                    if delta:
+                        yield _sse(_chunk(chat_id, model, delta_text=delta))
+                if 'done' in item:
+                    tail = tracker.finalize(item.get('done', '') or '')
+                    if tail:
+                        yield _sse(_chunk(chat_id, model, delta_text=tail))
+                    yield _sse(_chunk(chat_id, model, finish='stop'))
+                    yield "data: [DONE]\n\n"
+                    return
+        except Exception as e:
+            tb = traceback.format_exc()
+            sys.stderr.write(f"[oaiapp][stream exc] {e!r}\n{tb}\n"); sys.stderr.flush()
+            print(f"[oaiapp][stream exc] {e!r}", flush=True)
+            yield _sse(_chunk(chat_id, model, delta_text=f"\n\n[stream error: {type(e).__name__}: {e}]", finish='stop'))
+            yield "data: [DONE]\n\n"
+
+    return gen()
+
+
+# ---------- threaded WSGI server ----------
+class ThreadingWSGIServer(ThreadingMixIn, WSGIServer):
+    daemon_threads = True
+
+
+class QuietHandler(WSGIRequestHandler):
+    def log_message(self, fmt, *args):
+        print(f"[oaiapp] {self.address_string()} - {fmt % args}")
+
+
+def main():
+    # background agent worker (same as agentmain.py __main__)
+    threading.Thread(target=agent.run, daemon=True).start()
+    try:
+        agent.next_llm(0)
+    except Exception as e:
+        print(f"[oaiapp][WARN] next_llm(0) failed: {e}")
+
+    srv = make_server(HOST, PORT, app, server_class=ThreadingWSGIServer, handler_class=QuietHandler)
+    tok_disp = '<configured>' if TOKEN else '<MISSING — set oai_api_token in mykey.py>'
+    print(f"[oaiapp] OpenAI-compatible API listening on http://{HOST}:{PORT}")
+    print(f"[oaiapp]   POST /v1/chat/completions    GET /v1/models")
+    print(f"[oaiapp]   auth: Bearer {tok_disp}")
+    print(f"[oaiapp]   model exposed: {_model_name()}")
+    try:
+        srv.serve_forever()
+    except KeyboardInterrupt:
+        print("\n[oaiapp] shutting down")
+
+
+if __name__ == '__main__':
+    main()

--- a/launch.pyw
+++ b/launch.pyw
@@ -89,6 +89,7 @@ if __name__ == '__main__':
     parser.add_argument('--wecom', action='store_true', help='启动 WeCom Bot');
     parser.add_argument('--dingtalk', '--dt', dest='dingtalk', action='store_true', help='启动 DingTalk Bot');
     parser.add_argument('--sched', action='store_true', help='启动计划任务调度器')
+    parser.add_argument('--api', action='store_true', help='启动 OpenAI 兼容 API (/v1/chat/completions)')
     parser.add_argument('--llm_no', type=int, default=0, help='LLM编号')
     args = parser.parse_args()
     port = str(find_free_port()) if args.port == '0' else args.port
@@ -131,6 +132,12 @@ if __name__ == '__main__':
         print('[Launch] DingTalk Bot started')
     else: print('[Launch] DingTalk Bot not enabled (use --dingtalk to start)')
     
+    if args.api:
+        apiproc = subprocess.Popen([sys.executable, os.path.join(frontends_dir, "oaiapp.py")], creationflags=subprocess.CREATE_NO_WINDOW if os.name=='nt' else 0)
+        atexit.register(apiproc.kill)
+        print('[Launch] OpenAI-compatible API started')
+    else: print('[Launch] OpenAI-compatible API not enabled (use --api to start)')
+
     if args.sched:
         scheduler_proc = subprocess.Popen([sys.executable, os.path.join(script_dir, "agentmain.py"), "--reflect", os.path.join(script_dir, "reflect", "scheduler.py"), "--llm_no", str(args.llm_no)], creationflags=subprocess.CREATE_NO_WINDOW if os.name=='nt' else 0)
         atexit.register(scheduler_proc.kill)

--- a/mykey_template.py
+++ b/mykey_template.py
@@ -417,6 +417,14 @@ native_oai_config = {
 # dingtalk_client_secret = 'your_app_secret'
 # dingtalk_allowed_users = ['your_staff_id']        # 留空或 ['*'] 表示允许所有钉钉用户
 
+# ══════════════════════════════════════════════════════════════════════════════
+#  OpenAI 兼容 API 接口（让外部应用通过 /v1/chat/completions 访问本智能体）
+# ══════════════════════════════════════════════════════════════════════════════
+# oai_api_token   = 'sk-local-your-secret-token'    # 必填：Bearer token
+# oai_api_host    = '127.0.0.1'                     # 可选；'0.0.0.0' 暴露到局域网
+# oai_api_port    = 18000                           # 可选
+# oai_api_timeout = 600                             # 可选，单请求超时秒数
+
 # 可选：Langfuse 追踪。不设此项则不 import langfuse，零影响
 # langfuse_config = {
 #     'public_key': 'pk-lf-...',


### PR DESCRIPTION
## Summary

- 新增 `frontends/oaiapp.py`：把**整个智能体**（带工具循环、分层记忆等完整行为）作为一个 OpenAI 风格"模型"暴露出去，任何兼容 OpenAI 接口的客户端（NextChat / Open WebUI / LobeChat / OpenAI SDK / curl 等）即可接入。
- 支持流式（SSE）与非流式两种模式；零新增依赖（复用已有的 `bottle` + 标准库 `wsgiref` 多线程服务器）。
- `launch.pyw` 增加 `--api` 启动开关；`mykey_template.py` 增加配置示例段；`README.md` 中英双语补充文档。

## Endpoints

- `POST /v1/chat/completions` — Chat Completions，支持 `stream: true/false`
- `GET  /v1/models` — 列出当前配置的全部 LLM 后端

## Configuration (`mykey.py`)

```python
oai_api_token   = 'sk-local-your-secret-token'   # 必填，Bearer token
# oai_api_host  = '127.0.0.1'                    # 可选；'0.0.0.0' 暴露到局域网
# oai_api_port  = 18000                          # 可选
# oai_api_timeout = 600                          # 可选，单请求超时秒数
