### PR TITLE
refactor(langfuse/chatapp):

### DIFF
--- a/frontends/chatapp_common.py
+++ b/frontends/chatapp_common.py
@@ -1,5 +1,10 @@
 import ast, asyncio, glob, json, os, queue as Q, re, socket, sys, time
 
+# 确保能导入上级目录的模块（如 agentmain）
+_parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _parent_dir not in sys.path:
+    sys.path.insert(0, _parent_dir)
+
 HELP_COMMANDS = (
     ("/help", "显示帮助"),
     ("/status", "查看状态"),

--- a/plugins/langfuse_tracing.py
+++ b/plugins/langfuse_tracing.py
@@ -20,7 +20,7 @@ if _lf:
     _tls = threading.local()
 
     _orig_log = llmcore._write_llm_log
-    def _patched_log(label, content):
+    def _patched_log(label, content, log_path=None):
         try:
             if label == 'Prompt':
                 _tls.gen = _lf.start_observation(name='llm.chat', as_type='generation', input=content[:20000])
@@ -29,7 +29,7 @@ if _lf:
                 _tls.gen.update(output=content[:20000], usage_details=getattr(_tls, 'usage', None))
                 _tls.gen.end(); _tls.gen = None
         except Exception: pass
-        return _orig_log(label, content)
+        return _orig_log(label, content, log_path)
     llmcore._write_llm_log = _patched_log
 
     def _extract_usage(buf):


### PR DESCRIPTION
- Fix 1: _patched_log function signature mismatch
  - Location: plugins-langfuse_tracing.py
  - Problem: monkey-patch function only accepts 2 parameters, but the original function has 3 parameters (including the default parameter log_path)
  - Fix: add log_path=None parameter and pass it to the original function

- Fix 2: Agentmain module import failed
  - Location: frontends-chatapp_common.py
  - Problem: Modules in the frontends directory cannot be imported into the agentmain of the upper directory
  - Fix: Add the parent directory to sys.path at the beginning of the file