### PR TITLE
fix(tui): keep v2 output scrolled during stream updates

### DIFF
--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -1211,6 +1211,7 @@ class GenericAgentTUI(App[None]):
         if found and found._body_widget is not None:
             try:
                 found._body_widget.update(self._build_assistant_body(found))
+                self.query_one("#messages", VerticalScroll).scroll_end(animate=False)
             except Exception:
                 self._refresh_messages()
         else:


### PR DESCRIPTION
When an assistant message already has a mounted body widget, streaming updates only refreshed the widget content. Scroll the messages container after those in-place updates so both streaming chunks and final responses remain visible at the bottom.