### PR TITLE
Feat/v2 keybindings

### DIFF
--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -525,25 +525,20 @@ def render_topbar(session_name: str, status: str, model: str, tasks_running: int
 
 def render_bottombar(quit_armed: bool = False) -> Table:
     t = Table.grid(expand=True)
-    t.add_column(ratio=2, justify="left")
-    t.add_column(ratio=1, justify="right")
+    t.add_column(justify="left")
     left = Text()
     if quit_armed:
         left.append("再按 Ctrl+C 退出", style=f"bold {C_GREEN}")
     else:
         pairs = [("Enter", "发送"), ("Ctrl+N", "新会话"),
-                 ("Ctrl+B", "侧栏"), ("Ctrl+C", "停止/退出")]
+                 ("Ctrl+B", "侧栏"), ("Ctrl+C", "停止/退出"),
+                 ("/", "命令面板"), ("Ctrl+/", "快捷键帮助")]
         for i, (k, d) in enumerate(pairs):
             if i: left.append("    ")
-            left.append(k, style=C_FG)
+            left.append(k, style=C_GREEN if k in ("/", "Ctrl+/") else C_FG)
             left.append(" ")
             left.append(d, style=C_MUTED)
-    right = Text()
-    right.append("Ctrl+?", style=C_GREEN)
-    right.append(" 帮助  ", style=C_MUTED)
-    right.append("/", style=C_GREEN)
-    right.append(" 命令面板", style=C_MUTED)
-    t.add_row(left, right)
+    t.add_row(left)
     return t
 
 
@@ -730,9 +725,10 @@ class GenericAgentTUI(App[None]):
         Binding("ctrl+o",     "toggle_fold",   "Fold",  show=False),
         Binding("ctrl+up",    "prev_session",  "Prev",  show=False, priority=True),
         Binding("ctrl+down",  "next_session",  "Next",  show=False, priority=True),
-        # Ctrl+? = Ctrl+Shift+/ — Textual 在不同终端会以 ctrl+? 或 ctrl+question_mark 上报；都绑上以兜底
-        Binding("ctrl+question_mark", "show_help", "Help", show=False),
-        Binding("ctrl+?",     "show_help",      "Help",  show=False),
+        # Ctrl+/ — 终端常报为 ctrl+slash 或 legacy ctrl+_（=ASCII 0x1F），都绑上以兜底
+        Binding("ctrl+slash", "show_help", "Help", show=False),
+        Binding("ctrl+/",     "show_help", "Help", show=False),
+        Binding("ctrl+underscore", "show_help", "Help", show=False),
         Binding("escape",     "escape",        "Close", show=False),
         Binding("tab",        "complete_command", "Complete", show=False, priority=True),
     ]
@@ -1018,14 +1014,14 @@ class GenericAgentTUI(App[None]):
             ("/",                       "唤起命令面板"),
             ("Tab",                     "命令面板可见时补全"),
             ("Esc",                     "取消选择 / 关闭面板 / 关闭帮助"),
-            ("Ctrl+?",                  "显示 / 隐藏本帮助"),
+            ("Ctrl+/",                  "显示 / 隐藏本帮助"),
         ]
         t = Text()
-        t.append("快捷键\n\n", style=f"bold {C_GREEN}")
+        t.append("快捷键帮助\n\n", style=f"bold {C_GREEN}")
         for k, d in rows:
             t.append(f"  {k:<22}", style=C_FG)
             t.append(f"{d}\n", style=C_MUTED)
-        t.append("\n按 Esc 或 Ctrl+? 关闭", style=C_DIM)
+        t.append("\n按 Esc 或 Ctrl+/ 关闭", style=C_DIM)
         return t
 
     def action_complete_command(self) -> None:

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -735,7 +735,8 @@ class GenericAgentTUI(App[None]):
         self._ids = count(1)
         self._suppress_palette_open = False   # 选中 option 后抑制下一次 on_input_changed 重开 palette
         self.fold_mode: bool = True           # 折叠已完成的 turn，Ctrl+F 切
-        self._last_width: int = -1            # 轮询时检测变化用（Windows 窗口吸附/全屏不发 resize 时的兜底）
+        self._last_size: tuple[int, int] = (-1, -1)  # 同尺寸去重 + tick 兜底（Windows 窗口吸附不发 resize）
+        self._resize_timer = None             # 拖拽 resize 80ms 防抖，避免每帧全量重挂载
 
     def compose(self) -> ComposeResult:
         yield Static("", id="topbar")
@@ -773,9 +774,9 @@ class GenericAgentTUI(App[None]):
     def _tick(self) -> None:
         """0.5s 轮询：刷顶栏时间 + 兜底检测尺寸变化（Windows 窗口吸附/全屏不发 resize）。"""
         self._refresh_topbar()
-        w = self.size.width
-        if w != self._last_width:
-            self._last_width = w
+        size = (self.size.width, self.size.height)
+        if size != self._last_size:
+            self._last_size = size
             self._apply_responsive_layout()
 
     def _patch_auto_scroll_for_selection(self) -> None:
@@ -935,9 +936,21 @@ class GenericAgentTUI(App[None]):
 
     # ---------------- input + palette ----------------
     def on_resize(self, event) -> None:
-        self._apply_responsive_layout()
+        # 终端常对一次拖拽连发多个 resize；同尺寸短路避免重复重挂载。
+        size = (self.size.width, self.size.height)
+        if size == self._last_size:
+            return
+        self._last_size = size
+        # 输入框高度自适应即时跑（对延迟敏感）；布局重挂载走 80ms 防抖。
         try: self._resize_input(self.query_one("#input", InputArea))
         except Exception: pass
+        if self._resize_timer is not None:
+            self._resize_timer.stop()
+        self._resize_timer = self.set_timer(0.08, self._flush_resize)
+
+    def _flush_resize(self) -> None:
+        self._resize_timer = None
+        self._apply_responsive_layout()
 
     def _apply_responsive_layout(self) -> None:
         """按终端宽度调侧栏宽 + 主区横向 padding。<70 列隐藏侧栏，宽屏按比例放大。"""
@@ -947,7 +960,7 @@ class GenericAgentTUI(App[None]):
         except Exception:
             return
         w = self.size.width
-        self._last_width = w
+        self._last_size = (w, self.size.height)
         # 自动隐藏走 -narrow 类，跟用户手动 Ctrl+B 切的 -hidden 互不干扰
         if w < 70:
             sidebar.add_class("-narrow")
@@ -955,7 +968,8 @@ class GenericAgentTUI(App[None]):
             sidebar.remove_class("-narrow")
             sidebar.styles.width = max(30, min(50, w // 5))
         main.styles.padding = (1, 2) if w < 90 else (1, 6)
-        self._remount_current_session()  # 宽度变了 → markdown 要按新宽重渲
+        # padding 改完 layout 是异步重算；推迟到下一帧再读 #messages.content_region 取新宽
+        self.call_after_refresh(self._remount_current_session)
 
     def _remount_current_session(self) -> None:
         if self.current_id is None or not self.is_mounted:

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -33,6 +33,7 @@ try:
     from textual.binding import Binding
     from textual.containers import Horizontal, Vertical, VerticalScroll
     from textual.message import Message
+    from textual.screen import ModalScreen
     from textual.widgets import OptionList, Static, TextArea
     from textual.widgets.option_list import Option
 except ModuleNotFoundError as exc:
@@ -611,6 +612,37 @@ def render_sidebar(sessions: dict[int, AgentSession], current_id: Optional[int])
 
 # ---------- App ----------
 
+
+class HelpScreen(ModalScreen):
+    """快捷键帮助 modal — push 上来覆盖主屏幕，Esc / Ctrl+/ 关闭，不影响下层输入框位置。"""
+    CSS = """
+    HelpScreen { align: center middle; }
+    HelpScreen > Static {
+        width: auto;
+        max-width: 80;
+        height: auto;
+        max-height: 80%;
+        background: #21262d;
+        border: solid #30363d;
+        padding: 1 2;
+        color: #c9d1d9;
+    }
+    """
+    BINDINGS = [
+        Binding("escape", "dismiss", "Close", show=False),
+        Binding("ctrl+slash", "dismiss", "Close", show=False),
+        Binding("ctrl+/", "dismiss", "Close", show=False),
+        Binding("ctrl+underscore", "dismiss", "Close", show=False),
+    ]
+
+    def __init__(self, content) -> None:
+        super().__init__()
+        self._content = content
+
+    def compose(self) -> ComposeResult:
+        yield Static(self._content)
+
+
 class GenericAgentTUI(App[None]):
 
     CSS = """
@@ -704,18 +736,6 @@ class GenericAgentTUI(App[None]):
         scrollbar-size: 0 0;
     }
     #input:focus { border: none; }
-
-    #help {
-        display: none;
-        width: 1fr;
-        height: auto;
-        max-height: 80%;
-        background: #0d1117;
-        border: solid #21262d;
-        padding: 1 2;
-        margin: 0 6;
-    }
-    #help.-visible { display: block; }
     """
 
     BINDINGS = [
@@ -745,7 +765,6 @@ class GenericAgentTUI(App[None]):
         self._resize_timer = None             # 拖拽 resize 80ms 防抖，避免每帧全量重挂载
         self._quit_armed: bool = False        # Ctrl+C 双击退出：第一次按设 True，2s 内再按则真正退出
         self._quit_timer = None               # 配合 _quit_armed 的兜底清除定时器
-        self._help_open: bool = False         # 帮助 overlay 是否打开
 
     def compose(self) -> ComposeResult:
         yield Static("", id="topbar")
@@ -763,7 +782,6 @@ class GenericAgentTUI(App[None]):
                     highlight_cursor_line=False,
                     placeholder="输入指令或问题... (Enter 发送, Ctrl+J 换行, / 唤起命令面板)",
                 )
-        yield Static("", id="help")
         yield Static(render_bottombar(), id="bottombar")
 
     def on_mount(self) -> None:
@@ -887,16 +905,20 @@ class GenericAgentTUI(App[None]):
         self._refresh_all()
 
     def action_handle_ctrl_c(self) -> None:
-        """Ctrl+C 跨场景统一入口：跑任务时中断；输入框有内容时清空；否则 arm-then-quit。
-        与 CC 双击退出协议对齐，避免误触 + 与系统 SIGINT 直觉一致。"""
-        # 1) 任务在跑 → 中断
+        """Ctrl+C 跨场景统一入口：跑任务时中断；否则首次清空输入框 + 武装退出，
+        2s 内再按退出。与 CC 双击退出协议对齐，输入框非空时不会一键退出。"""
+        # 1) 任务在跑 → 中断（不武装退出，避免误关）
         try: sess = self.current
         except Exception: sess = None
         if sess is not None and sess.status == "running":
             self._cmd_stop([])
             self._disarm_quit()
             return
-        # 2) 输入框非空 → 清空（让用户从草稿中断恢复，避免误退出）
+        # 2) 已武装 → 真正退出
+        if self._quit_armed:
+            self.exit()
+            return
+        # 3) 首次按：输入框有内容则清空，无论空满都武装并提示
         try:
             inp = self.query_one("#input", InputArea)
         except Exception:
@@ -905,13 +927,6 @@ class GenericAgentTUI(App[None]):
             inp.reset()
             try: self._resize_input(inp)
             except Exception: pass
-            self._disarm_quit()
-            return
-        # 3) armed → 退出
-        if self._quit_armed:
-            self.exit()
-            return
-        # 4) 首次按 → 武装并提示
         self._quit_armed = True
         self._refresh_bottombar()
         if self._quit_timer is not None:
@@ -951,7 +966,8 @@ class GenericAgentTUI(App[None]):
         self.notify(f"Fold: {'on' if self.fold_mode else 'off'}", timeout=1)
 
     def action_escape(self) -> None:
-        """Esc 统一入口：choice → palette → help，按优先级 short-circuit。"""
+        """Esc 统一入口：choice → palette → 兜底解除 quit 武装。
+        HelpScreen 自己绑了 Esc 拦截，到这里时它已经被 pop 掉。"""
         # 1) 还有未选定的 choice → 取消
         choice = self._active_choice()
         if choice is not None:
@@ -966,38 +982,15 @@ class GenericAgentTUI(App[None]):
             self._hide_palette()
             self.query_one("#input", InputArea).focus()
             return
-        # 3) 帮助 overlay 打开 → 关闭
-        if self._help_open:
-            self._close_help()
-            return
-        # 4) armed → 解除（on_key 兜底通常已处理；这里仅显式情形）
+        # 3) armed → 解除（on_key 兜底通常已处理；这里仅显式情形）
         self._disarm_quit()
 
     def action_show_help(self) -> None:
-        if self._help_open:
-            self._close_help()
+        # 已经在 HelpScreen 上 → 关掉；否则 push 一个新的（ModalScreen 不影响下层布局，输入框不动）
+        if isinstance(self.screen, HelpScreen):
+            self.pop_screen()
         else:
-            self._open_help()
-
-    def _open_help(self) -> None:
-        try:
-            help_widget = self.query_one("#help", Static)
-        except Exception:
-            return
-        help_widget.update(self._render_help())
-        help_widget.add_class("-visible")
-        self._help_open = True
-
-    def _close_help(self) -> None:
-        try:
-            help_widget = self.query_one("#help", Static)
-        except Exception:
-            self._help_open = False
-            return
-        help_widget.remove_class("-visible")
-        self._help_open = False
-        try: self.query_one("#input", InputArea).focus()
-        except Exception: pass
+            self.push_screen(HelpScreen(self._render_help()))
 
     def _render_help(self) -> Text:
         rows = [
@@ -1216,25 +1209,19 @@ class GenericAgentTUI(App[None]):
         return None
 
     def _cancel_choice(self, msg: ChatMessage) -> None:
-        """← / Esc 取消选择：塌缩成"已取消"行，与 _collapse_choice 对称。"""
-        msg.selected_label = "（已取消）"
-        msg.content = "（已取消）"
-        container = self.query_one("#messages", VerticalScroll)
-        body = Text()
-        body.append("✗ ", style=C_DIM)
-        body.append("已取消", style=C_MUTED)
-        new_widget = SelectableStatic(body, classes="msg")
-        anchor = msg._hint_widget or msg._body_widget
-        if anchor is not None:
-            container.mount(new_widget, after=anchor)
-        else:
-            container.mount(new_widget)
-        if msg._hint_widget is not None:
-            msg._hint_widget.remove()
-            msg._hint_widget = None
-        if msg._body_widget is not None:
-            msg._body_widget.remove()
-        msg._body_widget = new_widget
+        """Esc 取消选择：直接移除整个 choice 消息（role / hint / body 三个 widget），
+        不留"已取消"痕迹。session.messages 同步删掉，下次 _refresh 不会重新挂载。"""
+        for w in (msg._role_widget, msg._hint_widget, msg._body_widget):
+            if w is not None:
+                try: w.remove()
+                except Exception: pass
+        msg._role_widget = None
+        msg._hint_widget = None
+        msg._body_widget = None
+        try:
+            self.current.messages.remove(msg)
+        except (ValueError, RuntimeError):
+            pass
         try:
             self.query_one("#input", InputArea).focus()
         except Exception:

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -197,15 +197,15 @@ class ChoiceList(OptionList):
     """OptionList 子类，记住所属 ChatMessage，便于选中后回填。"""
     BINDINGS = [*OptionList.BINDINGS,
                 Binding("right", "select", "Select", show=False),
-                Binding("left", "leave", "Leave", show=False)]
+                Binding("escape", "cancel", "Cancel", show=False)]
 
     def __init__(self, msg: "ChatMessage", **kwargs):
         super().__init__(**kwargs)
         self.msg = msg
 
-    def action_leave(self) -> None:
+    def action_cancel(self) -> None:
         try:
-            self.app.query_one("#input", InputArea).focus()
+            self.app._cancel_choice(self.msg)
         except Exception:
             pass
 
@@ -272,12 +272,10 @@ class InputArea(TextArea):
 
     BINDINGS = [
         Binding("ctrl+j",      "newline", "Newline", show=False),
-        Binding("alt+enter",   "newline", "Newline", show=False),
         Binding("ctrl+enter",  "newline", "Newline", show=False),
         Binding("shift+enter", "newline", "Newline", show=False),
         # Ctrl+V 优先尝试系统图片剪贴板；无图片时再走 Textual 文本剪贴板。
         Binding("ctrl+v",      "paste", "Paste", show=False),
-        Binding("ctrl+c",      "copy_or_clear", "CopyOrClear", show=False),
         # Ctrl+U: Unix 终端约定的 "kill line"，此处复用为整框清空（无选区时）。
         # 跨平台一致：Windows ConPTY / macOS Terminal / Linux 各家终端均原生支持 Ctrl+U 键码。
         Binding("ctrl+u",      "clear_input", "ClearInput", show=False),
@@ -285,16 +283,6 @@ class InputArea(TextArea):
 
     def action_noop(self) -> None:
         pass
-
-    def action_copy_or_clear(self) -> None:
-        # Textual/terminal copy remains active when there is an actual selection.
-        if self.selection.start != self.selection.end:
-            self.action_copy(); return
-        self.reset()
-        try:
-            self.app._resize_input(self)
-        except Exception:
-            pass
 
     def action_clear_input(self) -> None:
         """Ctrl+U: 一键清空整个输入框（无视选区/光标位置），跨平台终端通用。
@@ -478,7 +466,7 @@ class InputArea(TextArea):
                 choice.action_cursor_down(); event.stop(); event.prevent_default(); return
             if event.key in ("enter", "right") and choice.highlighted is not None:
                 choice.action_select(); event.stop(); event.prevent_default(); return
-            if event.key in ("left", "escape"):
+            if event.key == "escape":
                 self.app._cancel_choice(choice.msg); event.stop(); event.prevent_default(); return
         # 3) 输入历史：只在首行首列 / 尾行尾列时接管 ↑/↓。既保留原有光标移动，又允许在行内任意位置浏览历史（不强制先跳到行首/行尾）。
         if event.key == "up" and self.cursor_location == (0, 0):
@@ -501,7 +489,8 @@ class InputArea(TextArea):
 
 
 # ---------- 顶部栏 ----------
-def render_topbar(session_name: str, status: str, model: str, tasks_running: int) -> Table:
+def render_topbar(session_name: str, status: str, model: str, tasks_running: int,
+                  fold_mode: bool = True) -> Table:
     t = Table.grid(expand=True)
     t.add_column(ratio=1, justify="left")
     t.add_column(ratio=1, justify="center")
@@ -516,6 +505,9 @@ def render_topbar(session_name: str, status: str, model: str, tasks_running: int
     dot_color = C_GREEN if status == "running" else C_DIM
     left.append("● ", style=dot_color)
     left.append(status, style=C_MUTED)
+    if fold_mode:
+        left.append("    ")
+        left.append("▾ fold", style=C_DIM)
 
     mid = Text()
     mid.append("model: ", style=C_MUTED)
@@ -531,20 +523,24 @@ def render_topbar(session_name: str, status: str, model: str, tasks_running: int
     return t
 
 
-def render_bottombar() -> Table:
+def render_bottombar(quit_armed: bool = False) -> Table:
     t = Table.grid(expand=True)
     t.add_column(ratio=2, justify="left")
     t.add_column(ratio=1, justify="right")
     left = Text()
-    pairs = [("Enter", "发送"), ("↑/↓", "选择"),
-             ("Ctrl+N", "新会话"), ("Ctrl+B", "侧栏"),
-             ("Ctrl+F", "折叠"), ("Ctrl+S", "停止")]
-    for i, (k, d) in enumerate(pairs):
-        if i: left.append("    ")
-        left.append(k, style=C_FG)
-        left.append(" ")
-        left.append(d, style=C_MUTED)
+    if quit_armed:
+        left.append("再按 Ctrl+C 退出", style=f"bold {C_GREEN}")
+    else:
+        pairs = [("Enter", "发送"), ("Ctrl+N", "新会话"),
+                 ("Ctrl+B", "侧栏"), ("Ctrl+C", "停止/退出")]
+        for i, (k, d) in enumerate(pairs):
+            if i: left.append("    ")
+            left.append(k, style=C_FG)
+            left.append(" ")
+            left.append(d, style=C_MUTED)
     right = Text()
+    right.append("Ctrl+?", style=C_GREEN)
+    right.append(" 帮助  ", style=C_MUTED)
     right.append("/", style=C_GREEN)
     right.append(" 命令面板", style=C_MUTED)
     t.add_row(left, right)
@@ -713,17 +709,31 @@ class GenericAgentTUI(App[None]):
         scrollbar-size: 0 0;
     }
     #input:focus { border: none; }
+
+    #help {
+        display: none;
+        width: 1fr;
+        height: auto;
+        max-height: 80%;
+        background: #0d1117;
+        border: solid #21262d;
+        padding: 1 2;
+        margin: 0 6;
+    }
+    #help.-visible { display: block; }
     """
 
     BINDINGS = [
+        Binding("ctrl+c",     "handle_ctrl_c", "Stop/Quit", show=False, priority=True),
         Binding("ctrl+n",     "new_session",   "New",   show=False),
         Binding("ctrl+b",     "toggle_sidebar","Sidebar", show=False),
-        Binding("ctrl+s",     "stop_current",  "Stop",  show=False),
-        Binding("ctrl+f",     "toggle_fold",   "Fold",  show=False),
-        Binding("ctrl+q",     "quit",          "Quit",  show=False),
-        Binding("ctrl+left",  "prev_session",  "Prev",  show=False, priority=True),
-        Binding("ctrl+right", "next_session",  "Next",  show=False, priority=True),
-        Binding("escape",     "close_palette", "Close", show=False),
+        Binding("ctrl+o",     "toggle_fold",   "Fold",  show=False),
+        Binding("ctrl+up",    "prev_session",  "Prev",  show=False, priority=True),
+        Binding("ctrl+down",  "next_session",  "Next",  show=False, priority=True),
+        # Ctrl+? = Ctrl+Shift+/ — Textual 在不同终端会以 ctrl+? 或 ctrl+question_mark 上报；都绑上以兜底
+        Binding("ctrl+question_mark", "show_help", "Help", show=False),
+        Binding("ctrl+?",     "show_help",      "Help",  show=False),
+        Binding("escape",     "escape",        "Close", show=False),
         Binding("tab",        "complete_command", "Complete", show=False, priority=True),
     ]
 
@@ -734,9 +744,12 @@ class GenericAgentTUI(App[None]):
         self.current_id: Optional[int] = None
         self._ids = count(1)
         self._suppress_palette_open = False   # 选中 option 后抑制下一次 on_input_changed 重开 palette
-        self.fold_mode: bool = True           # 折叠已完成的 turn，Ctrl+F 切
+        self.fold_mode: bool = True           # 折叠已完成的 turn，Ctrl+O 切
         self._last_size: tuple[int, int] = (-1, -1)  # 同尺寸去重 + tick 兜底（Windows 窗口吸附不发 resize）
         self._resize_timer = None             # 拖拽 resize 80ms 防抖，避免每帧全量重挂载
+        self._quit_armed: bool = False        # Ctrl+C 双击退出：第一次按设 True，2s 内再按则真正退出
+        self._quit_timer = None               # 配合 _quit_armed 的兜底清除定时器
+        self._help_open: bool = False         # 帮助 overlay 是否打开
 
     def compose(self) -> ComposeResult:
         yield Static("", id="topbar")
@@ -754,6 +767,7 @@ class GenericAgentTUI(App[None]):
                     highlight_cursor_line=False,
                     placeholder="输入指令或问题... (Enter 发送, Ctrl+J 换行, / 唤起命令面板)",
                 )
+        yield Static("", id="help")
         yield Static(render_bottombar(), id="bottombar")
 
     def on_mount(self) -> None:
@@ -876,8 +890,54 @@ class GenericAgentTUI(App[None]):
         self.current_id = ids[(i + 1) % len(ids)]
         self._refresh_all()
 
-    def action_stop_current(self) -> None:
-        self._cmd_stop([])
+    def action_handle_ctrl_c(self) -> None:
+        """Ctrl+C 跨场景统一入口：跑任务时中断；输入框有内容时清空；否则 arm-then-quit。
+        与 CC 双击退出协议对齐，避免误触 + 与系统 SIGINT 直觉一致。"""
+        # 1) 任务在跑 → 中断
+        try: sess = self.current
+        except Exception: sess = None
+        if sess is not None and sess.status == "running":
+            self._cmd_stop([])
+            self._disarm_quit()
+            return
+        # 2) 输入框非空 → 清空（让用户从草稿中断恢复，避免误退出）
+        try:
+            inp = self.query_one("#input", InputArea)
+        except Exception:
+            inp = None
+        if inp is not None and inp.text:
+            inp.reset()
+            try: self._resize_input(inp)
+            except Exception: pass
+            self._disarm_quit()
+            return
+        # 3) armed → 退出
+        if self._quit_armed:
+            self.exit()
+            return
+        # 4) 首次按 → 武装并提示
+        self._quit_armed = True
+        self._refresh_bottombar()
+        if self._quit_timer is not None:
+            try: self._quit_timer.stop()
+            except Exception: pass
+        self._quit_timer = self.set_timer(2.0, self._disarm_quit)
+
+    def _disarm_quit(self) -> None:
+        if not self._quit_armed and self._quit_timer is None:
+            return
+        self._quit_armed = False
+        if self._quit_timer is not None:
+            try: self._quit_timer.stop()
+            except Exception: pass
+            self._quit_timer = None
+        try: self._refresh_bottombar()
+        except Exception: pass
+
+    def on_key(self, event: events.Key) -> None:
+        """非 Ctrl+C 的任何键都解除退出武装状态，避免错按后僵在 armed。"""
+        if self._quit_armed and event.key != "ctrl+c":
+            self._disarm_quit()
 
     def action_toggle_sidebar(self) -> None:
         self.query_one("#sidebar", Static).toggle_class("-hidden")
@@ -891,11 +951,82 @@ class GenericAgentTUI(App[None]):
                     m._cached_body = None
                     m._cache_key = ()
         self._remount_current_session()
+        self._refresh_topbar()
         self.notify(f"Fold: {'on' if self.fold_mode else 'off'}", timeout=1)
 
-    def action_close_palette(self) -> None:
-        self._hide_palette()
-        self.query_one("#input", InputArea).focus()
+    def action_escape(self) -> None:
+        """Esc 统一入口：choice → palette → help，按优先级 short-circuit。"""
+        # 1) 还有未选定的 choice → 取消
+        choice = self._active_choice()
+        if choice is not None:
+            self._cancel_choice(choice.msg)
+            return
+        # 2) 命令面板可见 → 关闭
+        try:
+            palette = self.query_one("#palette", OptionList)
+        except Exception:
+            palette = None
+        if palette is not None and palette.has_class("-visible"):
+            self._hide_palette()
+            self.query_one("#input", InputArea).focus()
+            return
+        # 3) 帮助 overlay 打开 → 关闭
+        if self._help_open:
+            self._close_help()
+            return
+        # 4) armed → 解除（on_key 兜底通常已处理；这里仅显式情形）
+        self._disarm_quit()
+
+    def action_show_help(self) -> None:
+        if self._help_open:
+            self._close_help()
+        else:
+            self._open_help()
+
+    def _open_help(self) -> None:
+        try:
+            help_widget = self.query_one("#help", Static)
+        except Exception:
+            return
+        help_widget.update(self._render_help())
+        help_widget.add_class("-visible")
+        self._help_open = True
+
+    def _close_help(self) -> None:
+        try:
+            help_widget = self.query_one("#help", Static)
+        except Exception:
+            self._help_open = False
+            return
+        help_widget.remove_class("-visible")
+        self._help_open = False
+        try: self.query_one("#input", InputArea).focus()
+        except Exception: pass
+
+    def _render_help(self) -> Text:
+        rows = [
+            ("Enter",                   "发送"),
+            ("Ctrl+J / Ctrl+Enter",     "换行（Shift+Enter 同义）"),
+            ("Ctrl+C",                  "停止任务 / 空闲时连按两次退出"),
+            ("Ctrl+N",                  "新建会话"),
+            ("Ctrl+B",                  "切换侧栏"),
+            ("Ctrl+↑ / Ctrl+↓",         "切换会话"),
+            ("Ctrl+O",                  "折叠 / 展开已完成的轮次"),
+            ("Ctrl+U",                  "清空输入框"),
+            ("Ctrl+V",                  "粘贴（图片优先）"),
+            ("↑ / ↓",                   "输入框：浏览发送历史 / 面板内：移动"),
+            ("/",                       "唤起命令面板"),
+            ("Tab",                     "命令面板可见时补全"),
+            ("Esc",                     "取消选择 / 关闭面板 / 关闭帮助"),
+            ("Ctrl+?",                  "显示 / 隐藏本帮助"),
+        ]
+        t = Text()
+        t.append("快捷键\n\n", style=f"bold {C_GREEN}")
+        for k, d in rows:
+            t.append(f"  {k:<22}", style=C_FG)
+            t.append(f"{d}\n", style=C_MUTED)
+        t.append("\n按 Esc 或 Ctrl+? 关闭", style=C_DIM)
+        return t
 
     def action_complete_command(self) -> None:
         """Tab：命令面板可见时补全到当前高亮命令；否则什么都不做。"""
@@ -1535,7 +1666,15 @@ class GenericAgentTUI(App[None]):
         try: model = s.agent.get_llm_name(model=True)
         except Exception: model = "?"
         tasks_running = sum(1 for x in self.sessions.values() if x.status == "running")
-        self.query_one("#topbar", Static).update(render_topbar(s.name, s.status, model, tasks_running))
+        self.query_one("#topbar", Static).update(
+            render_topbar(s.name, s.status, model, tasks_running, fold_mode=self.fold_mode))
+
+    def _refresh_bottombar(self):
+        if not self.is_mounted: return
+        try:
+            self.query_one("#bottombar", Static).update(render_bottombar(quit_armed=self._quit_armed))
+        except Exception:
+            pass
 
     def _refresh_sidebar(self):
         if not self.is_mounted: return

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -288,7 +288,6 @@ class InputArea(TextArea):
     def action_clear_input(self) -> None:
         """Ctrl+U: 一键清空整个输入框（无视选区/光标位置），跨平台终端通用。
 
-        与 action_copy_or_clear 的区别：本动作无条件清空，不抢复制行为；
         相当于 readline 的 unix-line-discard，所有主流终端原生透传该键码。
         """
         self.reset()
@@ -457,7 +456,7 @@ class InputArea(TextArea):
             fn = routes.get(event.key)
             if fn:
                 fn(); event.stop(); event.prevent_default(); return
-        # 2) 内嵌 ChoiceList 路由 (ccstatusline 风格)：↑↓ 移动 / → 或 Enter 确认 / ← 或 Esc 取消。
+        # 2) 内嵌 ChoiceList 路由 (ccstatusline 风格)：↑↓ 移动 / → 或 Enter 确认 / Esc 取消。
         #    不依赖焦点转移：只要存在未选定的 ChoiceList，方向键就被借走。
         choice = getattr(self.app, "_active_choice", lambda: None)()
         if choice is not None:
@@ -907,6 +906,16 @@ class GenericAgentTUI(App[None]):
     def action_handle_ctrl_c(self) -> None:
         """Ctrl+C 跨场景统一入口：跑任务时中断；否则首次清空输入框 + 武装退出，
         2s 内再按退出。与 CC 双击退出协议对齐，输入框非空时不会一键退出。"""
+        # 0) 有选区 → 保持终端/TUI 复制语义，不触发 stop / clear / quit。
+        try:
+            selected_text = self.screen.get_selected_text()
+        except Exception:
+            selected_text = None
+        if selected_text:
+            try: self.copy_to_clipboard(selected_text)
+            except Exception: pass
+            self._disarm_quit()
+            return
         # 1) 任务在跑 → 中断（不武装退出，避免误关）
         try: sess = self.current
         except Exception: sess = None
@@ -1411,7 +1420,7 @@ class GenericAgentTUI(App[None]):
             choices.append((f"{mark}[{i}] {name}", i))
         msg = ChatMessage(
             role="system",
-            content="选择模型 (↑/↓ 移动，→/Enter 确认，← 返回输入框)",
+            content="选择模型 (↑/↓ 移动，→/Enter 确认，Esc 取消)",
             kind="choice",
             choices=choices,
             on_select=lambda v: self._do_switch_llm(v),
@@ -1488,7 +1497,7 @@ class GenericAgentTUI(App[None]):
             ]
             msg = ChatMessage(
                 role="system",
-                content="选择导出方式 (↑/↓ 移动，→/Enter 确认，← 返回输入框)",
+                content="选择导出方式 (↑/↓ 移动，→/Enter 确认，Esc 取消)",
                 kind="choice",
                 choices=choices,
                 on_select=lambda v: self._do_export(v),


### PR DESCRIPTION
  ## Summary

  - Reworks `tuiapp_v2` shortcuts around a small Claude/Codex-inspired default set:
    - `Ctrl+C`: stop running task; otherwise clear input + arm quit; press again within 2s to exit
    - `Ctrl+O`: fold / unfold completed tool-call turns
    - `Ctrl+Up` / `Ctrl+Down`: switch sessions
    - `Ctrl+/`: centered shortcut-help modal
    - `Esc`: one-step cancel for choice prompts / close palette / close help
  - Adds a centered shortcut-help modal and simplifies the bottom hint bar to the most important keys.
  - Debounces resize reflow and defers message remount to the next frame so wrapped message content follows terminal width changes more reliably.

  ## Breaking / behavior changes users may need to adapt to

  - `Ctrl+S` no longer stops tasks; use `Ctrl+C`.
  - `Ctrl+Q` no longer exits; press `Ctrl+C` twice while idle / after clearing input.
  - `Ctrl+F` no longer toggles fold; use `Ctrl+O`.
  - `Ctrl+Left` / `Ctrl+Right` no longer switch sessions; use `Ctrl+Up` / `Ctrl+Down`.
  - Choice prompts no longer use left-arrow return/cancel; use `Esc` to cancel and `Right` / `Enter` to confirm.
  - Newline remains cross-terminal: `Ctrl+J`, `Ctrl+Enter`, and `Shift+Enter` all work; `Alt+Enter` is removed.

  ## Notes

  - `Ctrl+C` preserves copy semantics: if text is selected, it copies the selection and does not stop / clear / quit.
  - `Ctrl+/` is bound with terminal fallbacks (`ctrl+slash`, `ctrl+/`, `ctrl+underscore`) for compatibility.
  - This branch was rebased onto current `upstream/main` and includes #361 and #362; no cherry-pick conflicts remained.