### PR TITLE
feat(stapp2): 在交互界面中新增文件上传功能，截图粘贴功能

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,189 @@
+# 变更说明：stapp2 二次开发功能整合
+
+## Pull Request 说明
+
+**目标分支：** `master`  
+**源分支：** `master`（当前本地 2 commits ahead of `origin/master`）  
+**涉及提交：**
+- `2cf9c1f` feat(ui): 对齐 Origin stapp.py 外观风格，保留上传/粘贴功能
+- `b05eabc` fix: upload row layout in narrow webview + launch.pyw robustness
+
+**改动文件：**
+- `frontends/stapp2.py`（主前端，+97 / -634 行）
+- `launch.pyw`（桌面启动器，+17 / -2 行）
+
+**合并前检查：**
+- [ ] `streamlit run frontends/stapp2.py` 正常启动，页面显示"🖥️ Cowork"标题
+- [ ] 侧边栏展开后出现"强行停止任务 / 重新注入工具 / 🐱 桌面宠物 / 自主行动"区
+- [ ] 右上角汉堡菜单可见（System / Light / Dark 可切换）
+- [ ] 底部输入区：`+` 上传按钮与聊天框水平对齐（包括 600 px 窄 webview 窗口）
+- [ ] Ctrl+V 粘贴截图正常工作，缩略图显示，可删除
+- [ ] `python launch.pyw` 正常弹出 GenericAgent 窗口
+
+---
+
+## 一、背景
+
+本次改动在 upstream/main 最新代码基础上，将本地 `stapp2.py` 的二次开发成果整合进来，并同步将前端外观对齐至 Origin (`GA-Origin/GenericAgent/frontends/stapp.py`) 的视觉风格。
+
+Origin 版本外观参考：`frontends/example/GA1.jpg`（主界面）、`GA2.jpg`（侧边栏）、`GA3.jpg`（汉堡菜单）。
+
+---
+
+## 二、`frontends/stapp2.py` 改动详情
+
+### 2.1 主题 CSS 精简
+
+**旧：** `ANTHROPIC_CSS` 约 630 行，覆盖页面背景（暖棕 `#FAF9F6`）、侧边栏底色（`#F0EDE4`）、所有按钮/输入框/链接颜色，并隐藏汉堡菜单（`#MainMenu { display:none }`）。
+
+**新：** `ANTHROPIC_CSS` 缩减至仅 `:root {}` CSS 变量定义（约 20 行），保留颜色常量供 `FILE_UPLOAD_CSS` 引用，不再覆盖任何页面元素。
+
+**效果：** 页面恢复 Streamlit 默认白/浅灰主题；右上角汉堡菜单重新可见（System / Light / Dark 主题切换）。
+
+### 2.2 CSS 注入精简
+
+移除了以下注入（功能已不需要或与新风格冲突）：
+- `build_dynamic_font_css(110.0)` — 字体缩放脚本
+- `ANTHROPIC_SELECTBOX_SCRIPT` — 备用链路选择框宽度自适应脚本
+- `build_header_agent_badge_script()` — 页眉 Agent 名称徽标脚本
+
+保留：
+```python
+st.markdown(ANTHROPIC_CSS, unsafe_allow_html=True)       # 仅 :root 变量
+st.markdown(FILE_UPLOAD_CSS, unsafe_allow_html=True)      # 上传按钮 + 缩略图样式
+st.markdown(PASTE_HIDDEN_INPUT_CSS, unsafe_allow_html=True)
+_embed_html(build_paste_listener_script(), height=0, width=0)
+```
+
+### 2.3 页面标题
+
+在 CSS 注入之后、欢迎消息之前添加：
+```python
+st.title("🖥️ Cowork")
+```
+与 Origin stapp.py 第 51 行保持一致。
+
+### 2.4 侧边栏重写（`render_sidebar()`）
+
+对齐至 Origin stapp.py 第 56–111 行的完整版本，新增以下控件：
+
+| 控件 | 功能 |
+|------|------|
+| LLM Core 说明文字 | `st.caption(f"LLM Core: {当前LLM名称}")` |
+| 折叠式 LLM 选择框 | 切换后立即 `agent.next_llm()` + `st.rerun()` |
+| **强行停止任务** | `agent.abort()` 发送停止信号 |
+| **重新注入工具** | 清除 `last_tools` 缓存并从 `tool_usable_history.json` 重新注入工具历史 |
+| **🐱 桌面宠物** | 启动 `desktop_pet_v2.pyw`，注册 `_turn_end_hooks['pet']` 在每轮结束时推送摘要 |
+| **自主行动区** | "开始空闲自主行动"（将 `last_reply_time` 回拨 1800 秒）、"允许/禁止自主行动"切换、状态说明文字 |
+
+新增 import（放在文件顶部）：
+```python
+import subprocess
+from urllib.request import urlopen
+from urllib.parse import quote
+script_dir = os.path.dirname(os.path.abspath(__file__))
+```
+
+新增 I18N 支持（`set_page_config` 之后）：
+```python
+LANG = os.environ.get('GA_LANG', 'zh')
+I18N = { 'zh': {...}, 'en': {...} }
+def T(key): return I18N.get(LANG, I18N['zh']).get(key, key)
+```
+
+---
+
+## 三、新增功能：文件上传
+
+### 3.1 上传按钮 UI
+
+`FILE_UPLOAD_CSS` 将 Streamlit 原生 `st.file_uploader` 改造为极简 `+` 图标按钮（48×48 px，圆角 12 px），隐藏拖放说明区，悬停变为 Anthropic 橙色。
+
+输入区布局（`frontends/stapp2.py:1028`）：
+```python
+col_upload, col_input = st.columns([0.08, 0.92])
+```
+- 左列：`st.file_uploader`（渲染为 `+` 按钮）
+- 右列：`st.chat_input`
+
+### 3.2 窄窗口水平对齐修复
+
+webview 窗口宽 600 px，侧边栏约 200 px，主内容区约 380 px。8% 列宽约 30 px 小于按钮 min-width 48 px，导致 flexbox 换行堆叠。
+
+修复方式（`FILE_UPLOAD_CSS` 末尾）：
+```css
+[data-testid="stHorizontalBlock"]:has([data-testid="stFileUploader"]) {
+    flex-wrap: nowrap !important;
+    align-items: flex-end !important;
+}
+[data-testid="stHorizontalBlock"]:has([data-testid="stFileUploader"]) > *:first-child {
+    flex: 0 0 54px !important;
+    min-width: 54px !important;
+    max-width: 54px !important;
+}
+[data-testid="stHorizontalBlock"]:has([data-testid="stFileUploader"]) > *:last-child {
+    flex: 1 1 0 !important;
+    min-width: 0 !important;
+}
+```
+
+### 3.3 文件处理逻辑
+
+| 函数 | 位置 | 功能 |
+|------|------|------|
+| `save_uploaded_file(file_dict)` | `:439` | 保存文件到 `temp/uploaded/<timestamp>_<name>`，返回绝对路径 |
+| `generate_thumbnail(file_dict)` | `:457` | 图片用 Pillow 缩放为 80×80 base64；非图片返回 emoji 图标 |
+| `render_file_thumbnails()` | `:537` | 渲染缩略图卡片行，每张卡片含 `×` 删除按钮（通过隐藏信号输入框触发） |
+| `build_prompt_with_files(prompt, files)` | `:490` | 构建发给 Agent 的提示：图片含磁盘路径+base64 截断；文本文件内联最多 6000 字符；其他文件仅路径 |
+
+文件在用户发送消息时通过 `build_prompt_with_files` 附加到 prompt，随后清空 `uploaded_files` 列表并重置 `file_uploader_key` 刷新上传控件。
+
+---
+
+## 四、新增功能：截图粘贴
+
+### 4.1 信号机制
+
+使用两个隐藏的 `st.text_input` 作为 JS → Python 的信号通道：
+
+| 信号输入框 | placeholder | 作用 |
+|-----------|------------|------|
+| `paste_image_signal` | `__paste_image_signal__` | 接收粘贴图片的 base64 data URI |
+| `delete_file_signal` | `__delete_file_signal__` | 接收要删除的文件索引 |
+
+`PASTE_HIDDEN_INPUT_CSS` 用 `position: fixed; left: -99999px` 将这两个输入框移出可见区，并将其 Streamlit 容器高度设为 0，避免占据布局空间。
+
+### 4.2 粘贴监听 JS（`build_paste_listener_script()`，`:744`）
+
+注入到父 `window`（Streamlit 主框架）的 `paste` 事件监听器：
+1. 检测剪贴板 items 中是否有 `image/*` 类型
+2. 用 `FileReader.readAsDataURL` 转为 base64
+3. 通过 React 原生 setter 写入 `__paste_image_signal__` 输入框
+4. 触发 `input` → `blur` → `focusout` 事件链，驱动 Streamlit rerun
+
+幂等保护：`window.__pasteImageListenerInstalled__` 标志位防止重复注入。
+
+### 4.3 Python 侧处理（`:979`）
+
+```python
+_paste_val = st.session_state.get("paste_image_signal", "")
+if _paste_val and _paste_val.startswith("data:image"):
+    # 解码 base64 → bytes，构造 file_dict，追加到 uploaded_files
+    st.session_state.paste_image_signal = ""
+```
+
+粘贴的图片以 `paste_<timestamp>.png` 命名，与手动上传的文件走同一 `render_file_thumbnails()` + `build_prompt_with_files()` 流程。
+
+---
+
+## 五、`launch.pyw` 改动
+
+| 改动 | 原因 |
+|------|------|
+| Streamlit 目标从 `stapp.py` → `stapp2.py` | 切换到二次开发版前端 |
+| 移除 `--client.toolbarMode viewer` | 恢复汉堡菜单可见 |
+| `window = None` 模块级初始化 | 防止 `idle_monitor` 在窗口创建前访问 `window` 报 `NameError` |
+| `time.sleep(5)` 启动等待 | 给 Streamlit 足够启动时间再创建 webview 窗口 |
+| `idle_monitor` 初始 `time.sleep(12)` | 避免在页面加载完成前执行 JS |
+| `idle_monitor` 首行增加 `if not window` 守卫 | 短路跳过未初始化阶段 |
+| `webview.start()` 包裹 `try/except` + 诊断打印 | 捕获并显示 webview 异常，便于调试 |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,189 +1,38 @@
-# 变更说明：stapp2 二次开发功能整合
+# 变更说明
 
 ## Pull Request 说明
 
 **目标分支：** `master`  
-**源分支：** `master`（当前本地 2 commits ahead of `origin/master`）  
-**涉及提交：**
-- `2cf9c1f` feat(ui): 对齐 Origin stapp.py 外观风格，保留上传/粘贴功能
-- `b05eabc` fix: upload row layout in narrow webview + launch.pyw robustness
-
-**改动文件：**
-- `frontends/stapp2.py`（主前端，+97 / -634 行）
-- `launch.pyw`（桌面启动器，+17 / -2 行）
+**涉及文件：** `frontends/stapp2.py`、`launch.pyw`
 
 **合并前检查：**
-- [ ] `streamlit run frontends/stapp2.py` 正常启动，页面显示"🖥️ Cowork"标题
-- [ ] 侧边栏展开后出现"强行停止任务 / 重新注入工具 / 🐱 桌面宠物 / 自主行动"区
-- [ ] 右上角汉堡菜单可见（System / Light / Dark 可切换）
 - [ ] 底部输入区：`+` 上传按钮与聊天框水平对齐（包括 600 px 窄 webview 窗口）
-- [ ] Ctrl+V 粘贴截图正常工作，缩略图显示，可删除
+- [ ] Ctrl+V 粘贴截图：缩略图显示，可删除，发送后附加到消息
 - [ ] `python launch.pyw` 正常弹出 GenericAgent 窗口
 
 ---
 
-## 一、背景
+## 新增功能
 
-本次改动在 upstream/main 最新代码基础上，将本地 `stapp2.py` 的二次开发成果整合进来，并同步将前端外观对齐至 Origin (`GA-Origin/GenericAgent/frontends/stapp.py`) 的视觉风格。
+### 文件上传
 
-Origin 版本外观参考：`frontends/example/GA1.jpg`（主界面）、`GA2.jpg`（侧边栏）、`GA3.jpg`（汉堡菜单）。
+输入区左侧新增 `+` 图标按钮，点击可上传任意类型文件。
 
----
+- **缩略图预览**：图片显示缩略图，其他文件显示类型图标，支持点击 `×` 删除
+- **附件注入**：发送时自动将文件信息追加到 prompt
+  - 图片：磁盘路径 + base64（供 vision API 使用）
+  - 文本文件（`.txt .md .py .json` 等）：内联最多 6000 字符
+  - 其他：仅磁盘路径，Agent 可用 `file_read` 工具读取
+- 文件保存至 `temp/uploaded/<timestamp>_<name>`，发送后清空队列
 
-## 二、`frontends/stapp2.py` 改动详情
+### 截图粘贴
 
-### 2.1 主题 CSS 精简
+在聊天框聚焦时，Ctrl+V 粘贴剪贴板图片直接入队，无需手动保存文件。
 
-**旧：** `ANTHROPIC_CSS` 约 630 行，覆盖页面背景（暖棕 `#FAF9F6`）、侧边栏底色（`#F0EDE4`）、所有按钮/输入框/链接颜色，并隐藏汉堡菜单（`#MainMenu { display:none }`）。
-
-**新：** `ANTHROPIC_CSS` 缩减至仅 `:root {}` CSS 变量定义（约 20 行），保留颜色常量供 `FILE_UPLOAD_CSS` 引用，不再覆盖任何页面元素。
-
-**效果：** 页面恢复 Streamlit 默认白/浅灰主题；右上角汉堡菜单重新可见（System / Light / Dark 主题切换）。
-
-### 2.2 CSS 注入精简
-
-移除了以下注入（功能已不需要或与新风格冲突）：
-- `build_dynamic_font_css(110.0)` — 字体缩放脚本
-- `ANTHROPIC_SELECTBOX_SCRIPT` — 备用链路选择框宽度自适应脚本
-- `build_header_agent_badge_script()` — 页眉 Agent 名称徽标脚本
-
-保留：
-```python
-st.markdown(ANTHROPIC_CSS, unsafe_allow_html=True)       # 仅 :root 变量
-st.markdown(FILE_UPLOAD_CSS, unsafe_allow_html=True)      # 上传按钮 + 缩略图样式
-st.markdown(PASTE_HIDDEN_INPUT_CSS, unsafe_allow_html=True)
-_embed_html(build_paste_listener_script(), height=0, width=0)
-```
-
-### 2.3 页面标题
-
-在 CSS 注入之后、欢迎消息之前添加：
-```python
-st.title("🖥️ Cowork")
-```
-与 Origin stapp.py 第 51 行保持一致。
-
-### 2.4 侧边栏重写（`render_sidebar()`）
-
-对齐至 Origin stapp.py 第 56–111 行的完整版本，新增以下控件：
-
-| 控件 | 功能 |
-|------|------|
-| LLM Core 说明文字 | `st.caption(f"LLM Core: {当前LLM名称}")` |
-| 折叠式 LLM 选择框 | 切换后立即 `agent.next_llm()` + `st.rerun()` |
-| **强行停止任务** | `agent.abort()` 发送停止信号 |
-| **重新注入工具** | 清除 `last_tools` 缓存并从 `tool_usable_history.json` 重新注入工具历史 |
-| **🐱 桌面宠物** | 启动 `desktop_pet_v2.pyw`，注册 `_turn_end_hooks['pet']` 在每轮结束时推送摘要 |
-| **自主行动区** | "开始空闲自主行动"（将 `last_reply_time` 回拨 1800 秒）、"允许/禁止自主行动"切换、状态说明文字 |
-
-新增 import（放在文件顶部）：
-```python
-import subprocess
-from urllib.request import urlopen
-from urllib.parse import quote
-script_dir = os.path.dirname(os.path.abspath(__file__))
-```
-
-新增 I18N 支持（`set_page_config` 之后）：
-```python
-LANG = os.environ.get('GA_LANG', 'zh')
-I18N = { 'zh': {...}, 'en': {...} }
-def T(key): return I18N.get(LANG, I18N['zh']).get(key, key)
-```
+实现方式：页面注入 JS 监听 `paste` 事件，捕获 `image/*` 内容转为 base64，通过隐藏信号输入框触发 Streamlit rerun，Python 侧解码后与上传文件走同一处理流程。
 
 ---
 
-## 三、新增功能：文件上传
+## 修改要点
 
-### 3.1 上传按钮 UI
-
-`FILE_UPLOAD_CSS` 将 Streamlit 原生 `st.file_uploader` 改造为极简 `+` 图标按钮（48×48 px，圆角 12 px），隐藏拖放说明区，悬停变为 Anthropic 橙色。
-
-输入区布局（`frontends/stapp2.py:1028`）：
-```python
-col_upload, col_input = st.columns([0.08, 0.92])
-```
-- 左列：`st.file_uploader`（渲染为 `+` 按钮）
-- 右列：`st.chat_input`
-
-### 3.2 窄窗口水平对齐修复
-
-webview 窗口宽 600 px，侧边栏约 200 px，主内容区约 380 px。8% 列宽约 30 px 小于按钮 min-width 48 px，导致 flexbox 换行堆叠。
-
-修复方式（`FILE_UPLOAD_CSS` 末尾）：
-```css
-[data-testid="stHorizontalBlock"]:has([data-testid="stFileUploader"]) {
-    flex-wrap: nowrap !important;
-    align-items: flex-end !important;
-}
-[data-testid="stHorizontalBlock"]:has([data-testid="stFileUploader"]) > *:first-child {
-    flex: 0 0 54px !important;
-    min-width: 54px !important;
-    max-width: 54px !important;
-}
-[data-testid="stHorizontalBlock"]:has([data-testid="stFileUploader"]) > *:last-child {
-    flex: 1 1 0 !important;
-    min-width: 0 !important;
-}
-```
-
-### 3.3 文件处理逻辑
-
-| 函数 | 位置 | 功能 |
-|------|------|------|
-| `save_uploaded_file(file_dict)` | `:439` | 保存文件到 `temp/uploaded/<timestamp>_<name>`，返回绝对路径 |
-| `generate_thumbnail(file_dict)` | `:457` | 图片用 Pillow 缩放为 80×80 base64；非图片返回 emoji 图标 |
-| `render_file_thumbnails()` | `:537` | 渲染缩略图卡片行，每张卡片含 `×` 删除按钮（通过隐藏信号输入框触发） |
-| `build_prompt_with_files(prompt, files)` | `:490` | 构建发给 Agent 的提示：图片含磁盘路径+base64 截断；文本文件内联最多 6000 字符；其他文件仅路径 |
-
-文件在用户发送消息时通过 `build_prompt_with_files` 附加到 prompt，随后清空 `uploaded_files` 列表并重置 `file_uploader_key` 刷新上传控件。
-
----
-
-## 四、新增功能：截图粘贴
-
-### 4.1 信号机制
-
-使用两个隐藏的 `st.text_input` 作为 JS → Python 的信号通道：
-
-| 信号输入框 | placeholder | 作用 |
-|-----------|------------|------|
-| `paste_image_signal` | `__paste_image_signal__` | 接收粘贴图片的 base64 data URI |
-| `delete_file_signal` | `__delete_file_signal__` | 接收要删除的文件索引 |
-
-`PASTE_HIDDEN_INPUT_CSS` 用 `position: fixed; left: -99999px` 将这两个输入框移出可见区，并将其 Streamlit 容器高度设为 0，避免占据布局空间。
-
-### 4.2 粘贴监听 JS（`build_paste_listener_script()`，`:744`）
-
-注入到父 `window`（Streamlit 主框架）的 `paste` 事件监听器：
-1. 检测剪贴板 items 中是否有 `image/*` 类型
-2. 用 `FileReader.readAsDataURL` 转为 base64
-3. 通过 React 原生 setter 写入 `__paste_image_signal__` 输入框
-4. 触发 `input` → `blur` → `focusout` 事件链，驱动 Streamlit rerun
-
-幂等保护：`window.__pasteImageListenerInstalled__` 标志位防止重复注入。
-
-### 4.3 Python 侧处理（`:979`）
-
-```python
-_paste_val = st.session_state.get("paste_image_signal", "")
-if _paste_val and _paste_val.startswith("data:image"):
-    # 解码 base64 → bytes，构造 file_dict，追加到 uploaded_files
-    st.session_state.paste_image_signal = ""
-```
-
-粘贴的图片以 `paste_<timestamp>.png` 命名，与手动上传的文件走同一 `render_file_thumbnails()` + `build_prompt_with_files()` 流程。
-
----
-
-## 五、`launch.pyw` 改动
-
-| 改动 | 原因 |
-|------|------|
-| Streamlit 目标从 `stapp.py` → `stapp2.py` | 切换到二次开发版前端 |
-| 移除 `--client.toolbarMode viewer` | 恢复汉堡菜单可见 |
-| `window = None` 模块级初始化 | 防止 `idle_monitor` 在窗口创建前访问 `window` 报 `NameError` |
-| `time.sleep(5)` 启动等待 | 给 Streamlit 足够启动时间再创建 webview 窗口 |
-| `idle_monitor` 初始 `time.sleep(12)` | 避免在页面加载完成前执行 JS |
-| `idle_monitor` 首行增加 `if not window` 守卫 | 短路跳过未初始化阶段 |
-| `webview.start()` 包裹 `try/except` + 诊断打印 | 捕获并显示 webview 异常，便于调试 |
+- `launch.pyw`：启动目标切换为 `stapp2.py`；新增 `window = None` 初始化防止 idle monitor 在窗口就绪前崩溃；webview 启动等待时间调整为 5 秒

--- a/frontends/stapp2.py
+++ b/frontends/stapp2.py
@@ -198,11 +198,19 @@ div[data-testid="stFileUploader"] section button:hover::before {
     background: #ef4444;
 }
 
-/* 输入区域布局 */
-.input-row-container {
-    display: flex;
-    gap: 8px;
-    align-items: center;
+/* 上传+输入行：禁止换行，上传列固定宽度，输入列填满剩余空间 */
+[data-testid="stHorizontalBlock"]:has([data-testid="stFileUploader"]) {
+    flex-wrap: nowrap !important;
+    align-items: flex-end !important;
+}
+[data-testid="stHorizontalBlock"]:has([data-testid="stFileUploader"]) > *:first-child {
+    flex: 0 0 54px !important;
+    min-width: 54px !important;
+    max-width: 54px !important;
+}
+[data-testid="stHorizontalBlock"]:has([data-testid="stFileUploader"]) > *:last-child {
+    flex: 1 1 0 !important;
+    min-width: 0 !important;
 }
 </style>
 """

--- a/frontends/stapp2.py
+++ b/frontends/stapp2.py
@@ -16,17 +16,27 @@ def _embed_html(html_str, height=1, width=None, scrolling=False):
     h = max(int(height), 1) if height is not None else 1
     w = int(width) if (width is not None and int(width) > 0) else None
     return _cv1_html(html_str, width=w, height=h, scrolling=scrolling)
-import time, json, re, threading, queue, base64
+import time, json, re, threading, queue, base64, subprocess
+from urllib.request import urlopen
+from urllib.parse import quote
 from datetime import datetime
 from io import BytesIO
 from agentmain import GeneraticAgent
+script_dir = os.path.dirname(os.path.abspath(__file__))
 
 st.set_page_config(page_title="Cowork", layout="wide")
 
-# ─── Anthropic Light Theme CSS ───
+LANG = os.environ.get('GA_LANG', 'zh')
+if LANG not in ('zh', 'en'): LANG = 'zh'
+I18N = {
+    'zh': {'force_stop': '强行停止任务', 'reinject_tools': '重新注入工具', 'desktop_pet': '🐱 桌面宠物'},
+    'en': {'force_stop': 'Force Stop', 'reinject_tools': 'Reinject Tools', 'desktop_pet': '🐱 Desktop Pet'},
+}
+def T(key): return I18N.get(LANG, I18N['zh']).get(key, key)
+
+# ─── CSS variables (needed for FILE_UPLOAD_CSS) ───
 ANTHROPIC_CSS = """
 <style>
-/* ===== Root variables ===== */
 :root {
     --anthropic-primary: #D4A27F;
     --anthropic-primary-hover: #C4895F;
@@ -44,617 +54,6 @@ ANTHROPIC_CSS = """
     --anthropic-info: #5A7A8A;
     --anthropic-font: 'Source Sans Pro', sans-serif;
     --anthropic-mono: 'Source Code Pro', monospace;
-}
-
-/* ===== Global ===== */
-body, [data-testid="stAppViewContainer"] {
-    background-color: var(--anthropic-bg) !important;
-    color: var(--anthropic-text) !important;
-}
-
-.stApp {
-    background-color: var(--anthropic-bg) !important;
-}
-
-/* ===== Header / Top bar ===== */
-[data-testid="stHeader"], header[data-testid="stHeader"] {
-    background-color: var(--anthropic-bg) !important;
-    border-bottom: 1px solid var(--anthropic-border) !important;
-}
-/* Hide default Streamlit toolbar buttons (deploy, hamburger, etc.) */
-[data-testid="stToolbar"] {
-    visibility: hidden !important;
-}
-[data-testid="stDecoration"],
-#MainMenu {
-    display: none !important;
-    visibility: hidden !important;
-}
-/* Restore sidebar expand button (lives inside stToolbar) */
-[data-testid="stExpandSidebarButton"],
-[data-testid="stExpandSidebarButton"] * {
-    visibility: visible !important;
-}
-/* Only restore ancestor divs that contain the sidebar button */
-[data-testid="stToolbar"] div:has([data-testid="stExpandSidebarButton"]) {
-    visibility: visible !important;
-}
-/* Make top-left settings/sidebar toggle darker and easier to see */
-button[data-testid="stExpandSidebarButton"] {
-    visibility: visible !important;
-    background: #F4F1EA !important;
-    background-color: #F4F1EA !important;
-    border: none !important;
-    color: #3B2F2A !important;
-    border-radius: 10px !important;
-    box-shadow: none !important;
-}
-button[data-testid="stExpandSidebarButton"]:hover {
-    background: #EAE4D9 !important;
-    background-color: #EAE4D9 !important;
-    border-color: transparent !important;
-}
-button[data-testid="stExpandSidebarButton"],
-button[data-testid="stExpandSidebarButton"] *,
-button[data-testid="stExpandSidebarButton"] [data-testid="stIconMaterial"] {
-    color: #3B2F2A !important;
-    fill: #3B2F2A !important;
-    stroke: #3B2F2A !important;
-}
-/* Hide other toolbar buttons (deploy, etc.) */
-button[kind="header"] {
-    visibility: hidden !important;
-}
-
-/* ===== Sidebar ===== */
-[data-testid="stSidebar"], section[data-testid="stSidebar"] {
-    background-color: var(--anthropic-sidebar-bg) !important;
-    border-right: 1px solid var(--anthropic-border) !important;
-}
-
-[data-testid="stSidebar"] .stMarkdown,
-[data-testid="stSidebar"] p,
-[data-testid="stSidebar"] span,
-[data-testid="stSidebar"] label {
-    color: var(--anthropic-text) !important;
-}
-
-[data-testid="stSidebar"] hr {
-    border-color: var(--anthropic-border) !important;
-}
-
-/* ===== Sidebar Selectbox ===== */
-[data-testid="stSidebar"] [data-testid="stSelectbox"] {
-    width: fit-content !important;
-    max-width: 100% !important;
-}
-
-[data-testid="stSidebar"] [data-testid="stSelectbox"] > div {
-    width: fit-content !important;
-    max-width: 100% !important;
-}
-
-[data-testid="stSidebar"] [data-testid="stSelectbox"] label,
-[data-testid="stSidebar"] .stSelectbox label {
-    color: var(--anthropic-text-secondary) !important;
-    font-size: 0.9rem !important;
-    font-weight: 500 !important;
-}
-
-[data-testid="stSidebar"] [data-baseweb="select"] {
-    width: fit-content !important;
-    max-width: 100% !important;
-    display: inline-block !important;
-}
-
-[data-testid="stSidebar"] [data-baseweb="select"] > div {
-    width: fit-content !important;
-    max-width: 100% !important;
-    background: #F7F3EC !important;
-    border: none !important;
-    box-shadow: none !important;
-    border-radius: 12px !important;
-    min-height: 42px !important;
-    padding-right: 1.6rem !important;
-    position: relative !important;
-}
-
-[data-testid="stSidebar"] [data-baseweb="select"] > div:hover,
-[data-testid="stSidebar"] [data-baseweb="select"] > div:focus-within {
-    background: #EFE9DE !important;
-    border: none !important;
-    box-shadow: none !important;
-}
-
-[data-testid="stSidebar"] [data-baseweb="select"] input,
-[data-testid="stSidebar"] [data-baseweb="select"] span,
-[data-testid="stSidebar"] [data-baseweb="select"] div {
-    color: var(--anthropic-text) !important;
-}
-
-[data-testid="stSidebar"] [data-baseweb="select"] span {
-    white-space: nowrap !important;
-}
-
-[data-baseweb="popover"],
-[data-baseweb="menu"],
-[data-baseweb="popover"] > div,
-[data-baseweb="popover"] [role="presentation"],
-[data-baseweb="popover"] ul,
-[data-baseweb="popover"] li,
-[data-baseweb="popover"] [role="listbox"],
-[data-baseweb="popover"] [role="option"] {
-    background: #F7F3EC !important;
-    color: var(--anthropic-text) !important;
-}
-
-[role="listbox"] {
-    background: #F7F3EC !important;
-    border: 1px solid var(--anthropic-border) !important;
-    border-radius: 14px !important;
-    box-shadow: 0 10px 30px rgba(58, 47, 42, 0.12) !important;
-    padding: 0.35rem !important;
-    color: var(--anthropic-text) !important;
-}
-
-[role="option"] {
-    color: var(--anthropic-text) !important;
-    background: transparent !important;
-    border-radius: 10px !important;
-}
-
-[role="option"]:hover,
-[role="option"][aria-selected="true"] {
-    background: #EFE9DE !important;
-    color: var(--anthropic-text) !important;
-}
-
-/* ===== Title ===== */
-h1, .stTitle, [data-testid="stHeading"] h1 {
-    color: var(--anthropic-text) !important;
-    font-weight: 600 !important;
-    letter-spacing: -0.02em !important;
-}
-
-/* ===== Agent name input fixed in header bar ===== */
-[data-testid="stTextInput"] {
-    position: fixed !important;
-    top: 0 !important;
-    left: 50% !important;
-    transform: translateX(-50%) !important;
-    z-index: 999999 !important;
-    height: 60px !important;
-    display: flex !important;
-    align-items: center !important;
-    margin: 0 !important;
-    padding: 0 !important;
-}
-/* Hide the empty container left behind */
-[data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] > [data-testid="stElementContainer"]:first-child {
-    height: 0 !important;
-    overflow: hidden !important;
-    margin: 0 !important;
-    padding: 0 !important;
-}
-[data-testid="stTextInput"] > div {
-    background-color: transparent !important;
-    border: none !important;
-    box-shadow: none !important;
-    padding: 0 !important;
-    margin: 0 !important;
-    position: relative !important;
-}
-[data-testid="stTextInput"] > label {
-    display: none !important;
-}
-[data-testid="stTextInput"] input[type="text"] {
-    font-size: 1.6rem !important;
-    font-weight: 600 !important;
-    letter-spacing: -0.02em !important;
-    color: var(--anthropic-text) !important;
-    background-color: var(--anthropic-bg) !important;
-    border: none !important;
-    border-radius: 0 !important;
-    padding: 0.3rem 1.8rem 0.3rem 0.5rem !important;
-    box-shadow: none !important;
-    width: 320px !important;
-    text-align: center !important;
-    transition: all 0.2s ease !important;
-    cursor: default !important;
-    caret-color: #1a1714 !important;
-}
-[data-testid="stTextInput"] input[type="text"]:hover {
-    background-color: var(--anthropic-bg-secondary) !important;
-    border-radius: 6px !important;
-}
-[data-testid="stTextInput"] input[type="text"]:focus {
-    background-color: var(--anthropic-bg-secondary) !important;
-    border-radius: 6px !important;
-    box-shadow: none !important;
-    cursor: text !important;
-    caret-color: #1a1714 !important;
-}
-/* Edit pencil icon - visible by default, semi-transparent on focus */
-[data-testid="stTextInput"] > div::after {
-    content: '✎' !important;
-    position: absolute !important;
-    right: 8px !important;
-    top: 50% !important;
-    transform: translateY(-50%) !important;
-    font-size: 0.9rem !important;
-    color: var(--anthropic-text-secondary) !important;
-    pointer-events: none !important;
-    opacity: 0.6 !important;
-    transition: opacity 0.2s ease !important;
-}
-[data-testid="stTextInput"] > div:hover::after {
-    opacity: 0.85 !important;
-}
-[data-testid="stTextInput"] > div:focus-within::after {
-    opacity: 0 !important;
-}
-
-h2, h3, h4, h5, h6 {
-    color: var(--anthropic-text) !important;
-    font-weight: 500 !important;
-}
-
-/* ===== Buttons ===== */
-.stButton > button {
-    background-color: var(--anthropic-bg-secondary) !important;
-    color: var(--anthropic-text) !important;
-    border: 1px solid var(--anthropic-border) !important;
-    border-radius: 8px !important;
-    padding: 0.4rem 1rem !important;
-    font-weight: 500 !important;
-    transition: all 0.2s ease !important;
-}
-
-.stButton > button:hover {
-    background-color: var(--anthropic-primary) !important;
-    color: white !important;
-    border-color: var(--anthropic-primary) !important;
-}
-
-.stButton > button[kind="primary"],
-.stButton > button[data-testid="stBaseButton-primary"] {
-    background-color: var(--anthropic-primary) !important;
-    color: white !important;
-    border-color: var(--anthropic-primary) !important;
-}
-
-.stButton > button[kind="primary"]:hover,
-.stButton > button[data-testid="stBaseButton-primary"]:hover {
-    background-color: var(--anthropic-primary-hover) !important;
-    border-color: var(--anthropic-primary-hover) !important;
-}
-
-/* ===== Chat input ===== */
-[data-testid="stChatInput"],
-[data-testid="stChatInput"] > div {
-    background-color: var(--anthropic-bg) !important;
-    border-color: var(--anthropic-border) !important;
-}
-
-[data-testid="stChatInput"] {
-    margin-bottom: 12px !important;
-}
-
-[data-testid="stChatInput"] textarea,
-[data-testid="stChatInputTextArea"] {
-    color: var(--anthropic-text) !important;
-    background-color: var(--anthropic-bg) !important;
-    caret-color: #1A1714 !important;
-}
-
-[data-testid="stChatInput"] textarea::placeholder {
-    color: var(--anthropic-text-secondary) !important;
-    opacity: 0.7 !important;
-}
-
-/* Chat input container border */
-[data-testid="stChatInput"] > div {
-    border: 1px solid var(--anthropic-border) !important;
-    border-radius: 12px !important;
-    min-height: 60px !important;
-    padding: 0.35rem 0.45rem 0.35rem 0.8rem !important;
-    align-items: center !important;
-    gap: 0.5rem !important;
-    transition: none !important;
-    animation: none !important;
-}
-
-[data-testid="stChatInput"] > div:focus-within {
-    border-color: var(--anthropic-primary) !important;
-    box-shadow: 0 0 0 2px rgba(212, 162, 127, 0.2) !important;
-}
-
-[data-testid="stChatInput"] textarea,
-[data-testid="stChatInputTextArea"] {
-    min-height: 1.5rem !important;
-    padding: 0.35rem 0 !important;
-    line-height: 1.5 !important;
-    transition: none !important;
-    animation: none !important;
-}
-
-/* Chat send button */
-[data-testid="stChatInput"] button,
-[data-testid="stChatInputSubmitButton"] {
-    background-color: var(--anthropic-primary) !important;
-    color: white !important;
-    border-radius: 12px !important;
-    width: 60px !important;
-    height: 60px !important;
-    min-width: 60px !important;
-    min-height: 60px !important;
-    padding: 0 !important;
-    display: inline-flex !important;
-    align-items: center !important;
-    justify-content: center !important;
-    flex-shrink: 0 !important;
-    transition: none !important;
-    animation: none !important;
-}
-
-[data-testid="stChatInput"] button svg,
-[data-testid="stChatInputSubmitButton"] svg,
-[data-testid="stChatInput"] button [data-testid="stIconMaterial"],
-[data-testid="stChatInputSubmitButton"] [data-testid="stIconMaterial"] {
-    width: 1.25rem !important;
-    height: 1.25rem !important;
-    font-size: 1.25rem !important;
-}
-
-[data-testid="stChatInput"] button:hover {
-    background-color: var(--anthropic-primary-hover) !important;
-}
-
-/* Stop streaming button - fixed at bottom center, above chat input */
-.stop-btn-anchor {
-    display: none !important;
-}
-
-/* Collapse the wrapper so it doesn't push chat bubbles */
-[data-testid="stElementContainer"]:has(.stop-btn-anchor) {
-    height: 0 !important;
-    min-height: 0 !important;
-    margin: 0 !important;
-    padding: 0 !important;
-    overflow: visible !important;
-}
-
-[data-testid="stVerticalBlock"]:has(.stop-btn-anchor):not(:has([data-testid="stChatMessage"])) {
-    position: fixed !important;
-    bottom: 5.75rem !important;
-    left: 50% !important;
-    transform: translateX(-50%) !important;
-    z-index: 1000 !important;
-    width: auto !important;
-    background: transparent !important;
-    pointer-events: none !important;
-    gap: 0 !important;
-}
-
-[data-testid="stVerticalBlock"]:has(.stop-btn-anchor):not(:has([data-testid="stChatMessage"])) > * {
-    pointer-events: auto !important;
-}
-
-[data-testid="stVerticalBlock"]:has(.stop-btn-anchor):not(:has([data-testid="stChatMessage"])) [data-testid="stButton"] {
-    margin: 0 !important;
-}
-
-[data-testid="stVerticalBlock"]:has(.stop-btn-anchor):not(:has([data-testid="stChatMessage"])) [data-testid="stButton"] > button {
-    border-radius: 999px !important;
-    padding: 0.35rem 1.1rem !important;
-    min-height: 2rem !important;
-    font-size: 0.84rem !important;
-    font-weight: 500 !important;
-    line-height: 1 !important;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.12) !important;
-    white-space: nowrap !important;
-}
-
-[data-testid="stVerticalBlock"]:has(.stop-btn-anchor):not(:has([data-testid="stChatMessage"])) [data-testid="stButton"] > button[kind="primary"],
-[data-testid="stVerticalBlock"]:has(.stop-btn-anchor):not(:has([data-testid="stChatMessage"])) [data-testid="stButton"] > button[data-testid="stBaseButton-primary"] {
-    background-color: rgba(212, 162, 127, 0.95) !important;
-    border-color: rgba(212, 162, 127, 0.95) !important;
-}
-
-[data-testid="stVerticalBlock"]:has(.stop-btn-anchor):not(:has([data-testid="stChatMessage"])) [data-testid="stButton"] > button:hover {
-    transform: translateY(-1px) !important;
-    box-shadow: 0 3px 12px rgba(0,0,0,0.15) !important;
-}
-
-/* ===== Chat messages ===== */
-[data-testid="stChatMessage"] {
-    background-color: var(--anthropic-bg) !important;
-    border: none !important;
-    border-radius: 12px !important;
-    padding: 1rem 1.2rem !important;
-    margin-bottom: 0.5rem !important;
-}
-
-/* Assistant messages - clean white like Anthropic */
-[data-testid="stChatMessage"]:has([data-testid="stChatMessageAvatarAssistant"]) {
-    background-color: var(--anthropic-bg) !important;
-}
-
-/* User messages - subtle bordered box */
-[data-testid="stChatMessage"]:has([data-testid="stChatMessageAvatarUser"]) {
-    background-color: var(--anthropic-bg) !important;
-    border: 1px solid var(--anthropic-border) !important;
-    border-radius: 12px !important;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04) !important;
-}
-
-/* Chat message text */
-[data-testid="stChatMessage"] p,
-[data-testid="stChatMessage"] .stMarkdown {
-    color: var(--anthropic-text) !important;
-    line-height: 1.6 !important;
-}
-
-/* Message timestamp */
-.msg-timestamp {
-    text-align: left;
-    font-size: 0.73rem;
-    color: var(--anthropic-text-secondary);
-    margin-top: -0.3rem;
-    margin-bottom: 0.2rem;
-    opacity: 0.55;
-    font-family: var(--anthropic-mono);
-    letter-spacing: 0.02em;
-}
-
-/* ===== Chat avatars ===== */
-[data-testid="stChatMessageAvatarContainer"] {
-    width: 36px !important;
-    height: 36px !important;
-}
-[data-testid="stChatMessageAvatarContainer"] > div,
-[data-testid*="stChatMessageAvatar"],
-[data-testid*="chatAvatar"] {
-    width: 36px !important;
-    height: 36px !important;
-    border-radius: 50% !important;
-    display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
-    overflow: hidden !important;
-}
-
-/* User avatar - warm brown gradient */
-[data-testid*="stChatMessageAvatar"]:has(svg),
-[data-testid*="chatAvatar"][data-testid*="user"],
-[data-testid*="stChatMessageAvatar"][data-testid*="User"],
-[data-testid*="stChatMessageAvatar"][data-testid*="user"] {
-    background: linear-gradient(145deg, #D8B08A 0%, #B98259 100%) !important;
-    border: 1px solid rgba(150, 102, 67, 0.22) !important;
-    box-shadow: inset 0 1px 0 rgba(255,255,255,0.34), 0 2px 6px rgba(104, 76, 54, 0.10) !important;
-}
-/* Assistant avatar - cream gradient */
-[data-testid*="chatAvatar"][data-testid*="assistant"],
-[data-testid*="stChatMessageAvatar"][data-testid*="Assistant"],
-[data-testid*="stChatMessageAvatar"][data-testid*="assistant"],
-[data-testid="stChatMessageAvatarContainer"] > div {
-    background: linear-gradient(145deg, #F6F1E9 0%, #E5D7C7 100%) !important;
-    border: 1px solid rgba(187, 165, 141, 0.50) !important;
-    box-shadow: inset 0 1px 0 rgba(255,255,255,0.72), 0 2px 6px rgba(104, 76, 54, 0.08) !important;
-}
-
-/* ===== Inline code (not inside pre/code blocks) ===== */
-:not(pre) > code {
-    background-color: var(--anthropic-code-bg) !important;
-    border: 1px solid var(--anthropic-border) !important;
-    border-radius: 4px !important;
-    padding: 0.15em 0.4em !important;
-    font-size: 0.9em !important;
-    color: var(--anthropic-text) !important;
-}
-
-/* ===== Code blocks (pre) ===== */
-pre, .stCodeBlock, .stCodeBlock pre {
-    background-color: var(--anthropic-code-bg) !important;
-    border: 1px solid var(--anthropic-border) !important;
-    border-radius: 8px !important;
-}
-
-/* Code inside pre blocks: no extra border/background */
-pre code,
-.stCodeBlock code,
-[data-testid="stChatMessage"] pre code,
-[data-testid="stChatMessage"] .stCodeBlock code {
-    background-color: transparent !important;
-    border: none !important;
-    padding: 0 !important;
-    font-size: inherit !important;
-    color: var(--anthropic-text) !important;
-}
-
-/* ===== Toast / Alerts ===== */
-[data-testid="stToast"] {
-    background-color: var(--anthropic-bg-secondary) !important;
-    border: 1px solid var(--anthropic-border) !important;
-    border-radius: 8px !important;
-    color: var(--anthropic-text) !important;
-}
-
-/* ===== Captions ===== */
-.stCaption, [data-testid="stCaptionContainer"] {
-    color: var(--anthropic-text-secondary) !important;
-}
-
-/* ===== Divider ===== */
-[data-testid="stHorizontalBlock"] hr,
-hr {
-    border-color: var(--anthropic-border) !important;
-}
-
-/* ===== Scrollbar ===== */
-::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
-}
-::-webkit-scrollbar-track {
-    background: var(--anthropic-bg);
-}
-::-webkit-scrollbar-thumb {
-    background: var(--anthropic-border);
-    border-radius: 3px;
-}
-::-webkit-scrollbar-thumb:hover {
-    background: var(--anthropic-text-secondary);
-}
-
-/* ===== Links ===== */
-a {
-    color: var(--anthropic-accent) !important;
-}
-a:hover {
-    color: var(--anthropic-primary-hover) !important;
-}
-
-/* ===== Error/Warning/Info/Success ===== */
-[data-testid="stAlert"] {
-    border-radius: 8px !important;
-}
-
-/* ===== Bottom padding for chat ===== */
-[data-testid="stBottomBlockContainer"] {
-    background-color: var(--anthropic-bg) !important;
-}
-
-/* ===== Gear icon to open sidebar ===== */
-#sidebar-gear-toggle {
-    position: fixed !important;
-    top: 12px !important;
-    left: 12px !important;
-    z-index: 999999 !important;
-    width: 36px !important;
-    height: 36px !important;
-    display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
-    font-size: 1.3rem !important;
-    color: var(--anthropic-text-secondary) !important;
-    background: var(--anthropic-bg-secondary) !important;
-    border: 1px solid var(--anthropic-border) !important;
-    border-radius: 8px !important;
-    cursor: pointer !important;
-    transition: all 0.2s ease !important;
-    opacity: 0.7 !important;
-    user-select: none !important;
-}
-#sidebar-gear-toggle:hover {
-    opacity: 1 !important;
-    color: var(--anthropic-primary) !important;
-    border-color: var(--anthropic-primary) !important;
-    transform: rotate(30deg) !important;
-}
-/* Hide gear when sidebar is open */
-body:has([data-testid="stSidebar"][aria-expanded="true"]) #sidebar-gear-toggle {
-    display: none !important;
 }
 </style>
 """
@@ -1397,16 +796,14 @@ def init_session_state():
 
 init_session_state()
 
-# Inject Anthropic theme
+# Inject CSS variables + upload/paste CSS
 st.markdown(ANTHROPIC_CSS, unsafe_allow_html=True)
 st.markdown(FILE_UPLOAD_CSS, unsafe_allow_html=True)
 st.markdown(PASTE_HIDDEN_INPUT_CSS, unsafe_allow_html=True)
-st.markdown(build_dynamic_font_css(110.0), unsafe_allow_html=True)
-_embed_html(ANTHROPIC_SELECTBOX_SCRIPT, height=0, width=0)
-_embed_html(build_header_agent_badge_script(), height=0, width=0)
 _embed_html(build_paste_listener_script(), height=0, width=0)
 
-st.session_state.agent_name = 'Generic Agent'
+st.title("🖥️ Cowork")
+
 with st.chat_message("assistant"):
     st.markdown(f'<div class="msg-timestamp">{datetime.now().strftime("%Y-%m-%d %H:%M:%S")}</div>', unsafe_allow_html=True)
     st.write("欢迎使用GenericAgent~")
@@ -1414,21 +811,66 @@ with st.chat_message("assistant"):
 
 @st.fragment
 def render_sidebar():
-    llm_options, current_idx = agent.list_llms(), agent.llm_no
-    st.session_state.selected_llm_idx = current_idx
+    st.session_state.setdefault('autonomous_enabled', False)
+    llm_options = agent.list_llms()
+    current_idx = agent.llm_no
     llm_labels = {idx: f"{idx}: {(name or '').strip()}" for idx, name, _ in llm_options}
-    st.caption(f"当前使用的LLM为：{current_idx}: {agent.get_llm_name()}", help="可在下方选择链路")
+    st.session_state.selected_llm_idx = current_idx
+    st.caption(f"LLM Core: {llm_labels.get(current_idx, str(current_idx))}")
     st.markdown(f'<div data-testid="sidebar-llm-max-label" style="display:none">{html.escape(max(llm_labels.values(), key=len, default=""))}</div>', unsafe_allow_html=True)
-    selected_idx = st.selectbox("选择链路：", [idx for idx, _, _ in llm_options], index=next((i for i, (idx, _, _) in enumerate(llm_options) if idx == current_idx), 0), format_func=llm_labels.get, key="sidebar_llm_select")
+    selected_idx = st.selectbox("LLM", [idx for idx, _, _ in llm_options],
+        index=next((i for i, (idx, _, _) in enumerate(llm_options) if idx == current_idx), 0),
+        format_func=llm_labels.get, label_visibility="collapsed", key="sidebar_llm_select")
     if selected_idx != current_idx:
         agent.next_llm(selected_idx)
         st.session_state.selected_llm_idx = selected_idx
         st.toast(f"已切换到备用链路：{llm_labels[selected_idx]}")
         st.rerun()
-    st.divider()
-    if st.button("重新注入System Prompt"):
+    if st.button(T('force_stop')):
+        agent.abort(); st.toast("Stop signal sent"); st.rerun()
+    if st.button(T('reinject_tools')):
         agent.llmclient.last_tools = ''
-        st.toast("下次将重新注入System Prompt")
+        try:
+            hist_path = os.path.join(script_dir, '..', 'assets', 'tool_usable_history.json')
+            with open(hist_path, 'r', encoding='utf-8') as f_: tool_hist = json.load(f_)
+            agent.llmclient.backend.history.extend(tool_hist)
+            st.toast("Tools injected")
+        except Exception as e: st.toast(f"Injected tools failed: {e}")
+    if st.button(T('desktop_pet')):
+        kwargs = {'creationflags': 0x08} if sys.platform == 'win32' else {}
+        pet_script = os.path.join(script_dir, 'desktop_pet_v2.pyw')
+        if not os.path.exists(pet_script): pet_script = os.path.join(script_dir, 'desktop_pet.pyw')
+        subprocess.Popen([sys.executable, pet_script], **kwargs)
+        def _pet_req(q):
+            def _do():
+                try: urlopen(f'http://127.0.0.1:41983/?{q}', timeout=2)
+                except Exception: pass
+            threading.Thread(target=_do, daemon=True).start()
+        agent._pet_req = _pet_req
+        if not hasattr(agent, '_turn_end_hooks'): agent._turn_end_hooks = {}
+        def _pet_hook(ctx):
+            parts = [f"Turn {ctx.get('turn','?')}"]
+            if ctx.get('summary'): parts.append(ctx['summary'])
+            if ctx.get('exit_reason'): parts.append('DONE')
+            _pet_req(f'msg={quote(chr(10).join(parts))}')
+            if ctx.get('exit_reason'): _pet_req('state=idle')
+        agent._turn_end_hooks['pet'] = _pet_hook
+        st.toast("Desktop pet started")
+    if LANG == 'zh':
+        st.divider()
+        if st.button("开始空闲自主行动"):
+            st.session_state.last_reply_time = int(time.time()) - 1800
+            st.toast("已将上次回复时间设为1800秒前"); st.rerun()
+        if st.session_state.autonomous_enabled:
+            if st.button("⏸️ 禁止自主行动"):
+                st.session_state.autonomous_enabled = False
+                st.toast("⏸️ 已禁止自主行动"); st.rerun()
+            st.caption("🟢 自主行动运行中，会在你离开它30分钟后自动进行")
+        else:
+            if st.button("▶️ 允许自主行动", type="primary"):
+                st.session_state.autonomous_enabled = True
+                st.toast("✅ 已允许自主行动"); st.rerun()
+            st.caption("🔴 自主行动已停止")
 
 with st.sidebar: render_sidebar()
 

--- a/frontends/stapp2_old.py
+++ b/frontends/stapp2_old.py
@@ -9,16 +9,13 @@ except: pass
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import streamlit as st
-from streamlit.components.v1 import html as _cv1_html
-
-def _embed_html(html_str, height=1, width=None, scrolling=False):
-    """始终用 components.v1.html 嵌入 HTML 字符串（st.iframe 接受 URL，不能用于此处）"""
-    h = max(int(height), 1) if height is not None else 1
-    w = int(width) if (width is not None and int(width) > 0) else None
-    return _cv1_html(html_str, width=w, height=h, scrolling=scrolling)
-import time, json, re, threading, queue, base64
+try:
+    from streamlit import iframe as _st_iframe  # 1.56+
+    _embed_html = lambda html, **kw: _st_iframe(html, **{k: max(v, 1) if isinstance(v, int) else v for k, v in kw.items()})
+except (ImportError, AttributeError):
+    from streamlit.components.v1 import html as _embed_html  # ≤1.55
+import time, json, re, threading, queue
 from datetime import datetime
-from io import BytesIO
 from agentmain import GeneraticAgent
 
 st.set_page_config(page_title="Cowork", layout="wide")
@@ -659,182 +656,6 @@ body:has([data-testid="stSidebar"][aria-expanded="true"]) #sidebar-gear-toggle {
 </style>
 """
 
-FILE_UPLOAD_CSS = """
-<style>
-/* 直接隐藏拖放说明区，不动外层 div，避免 overflow 截断按钮 */
-div[data-testid="stFileUploaderDropzoneInstructions"] {
-    display: none !important;
-}
-
-/* section 去掉边框和内边距，仅做弹性容器居中按钮 */
-div[data-testid="stFileUploader"] section {
-    padding: 0 !important;
-    border: none !important;
-    background: transparent !important;
-    display: flex !important;
-    align-items: center !important;
-    justify-content: flex-start !important;
-    min-height: 0 !important;
-}
-
-/* Browse files 按钮直接给定 48×48，不使用绝对定位 */
-div[data-testid="stFileUploader"] section button {
-    width: 48px !important;
-    height: 48px !important;
-    min-width: 48px !important;
-    flex-shrink: 0 !important;
-    padding: 0 !important;
-    margin: 0 !important;
-    border-radius: 12px !important;
-    background: var(--anthropic-bg-secondary) !important;
-    border: 1px solid var(--anthropic-border) !important;
-    color: transparent !important;
-    font-size: 0 !important;
-    position: relative !important;
-    cursor: pointer !important;
-    transition: background 0.2s ease, border-color 0.2s ease !important;
-    box-sizing: border-box !important;
-}
-
-/* + 号绘制在按钮中央 */
-div[data-testid="stFileUploader"] section button::before {
-    content: '+';
-    font-size: 28px;
-    font-weight: 300;
-    line-height: 1;
-    color: var(--anthropic-text-secondary);
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    pointer-events: none;
-}
-
-div[data-testid="stFileUploader"] section button:hover {
-    background: var(--anthropic-primary) !important;
-    border-color: var(--anthropic-primary) !important;
-}
-
-div[data-testid="stFileUploader"] section button:hover::before {
-    color: white;
-}
-
-/* 文件缩略图容器 */
-.file-thumbnails-row {
-    display: flex;
-    gap: 10px;
-    margin-bottom: 12px;
-    flex-wrap: wrap;
-    align-items: flex-start;
-}
-
-/* 单个缩略图卡片 */
-.file-thumb-card {
-    position: relative;
-    width: 80px;
-    height: 80px;
-    border: 1px solid var(--anthropic-border);
-    border-radius: 8px;
-    overflow: hidden;
-    background: var(--anthropic-bg-secondary);
-    cursor: pointer;
-    transition: transform 0.2s;
-}
-
-.file-thumb-card:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-}
-
-.file-thumb-card img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-}
-
-.file-thumb-icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 100%;
-    font-size: 32px;
-}
-
-.file-thumb-name {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    padding: 4px;
-    font-size: 9px;
-    background: rgba(0,0,0,0.75);
-    color: white;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-/* 删除按钮样式 */
-.file-remove-btn {
-    position: absolute;
-    top: 4px;
-    right: 4px;
-    width: 20px;
-    height: 20px;
-    border-radius: 50%;
-    background: rgba(0,0,0,0.7);
-    color: white;
-    font-size: 14px;
-    font-weight: bold;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    z-index: 10;
-    transition: background 0.2s;
-}
-
-.file-remove-btn:hover {
-    background: #ef4444;
-}
-
-/* 输入区域布局 */
-.input-row-container {
-    display: flex;
-    gap: 8px;
-    align-items: center;
-}
-</style>
-"""
-
-PASTE_HIDDEN_INPUT_CSS = """
-<style>
-/* 隐藏粘贴/删除信号输入框及其 Streamlit 包装容器 */
-div[data-testid="stTextInput"]:has(input[placeholder="__paste_image_signal__"]),
-div[data-testid="stTextInput"]:has(input[placeholder="__delete_file_signal__"]) {
-    position: fixed !important;
-    left: -99999px !important;
-    top: -99999px !important;
-    width: 1px !important;
-    height: 1px !important;
-    overflow: hidden !important;
-    opacity: 0 !important;
-    pointer-events: none !important;
-    z-index: -1 !important;
-}
-/* 同时折叠 Streamlit 外层容器，避免占据布局空间 */
-div[data-testid="stElementContainer"]:has(input[placeholder="__paste_image_signal__"]),
-div[data-testid="stElementContainer"]:has(input[placeholder="__delete_file_signal__"]) {
-    height: 0 !important;
-    min-height: 0 !important;
-    overflow: hidden !important;
-    margin: 0 !important;
-    padding: 0 !important;
-}
-</style>
-"""
-
 ANTHROPIC_SELECTBOX_SCRIPT = """
 <div></div>
 <script>
@@ -1029,219 +850,6 @@ def build_dynamic_font_update_script(scale_percent: float) -> str:
 """
 
 
-def save_uploaded_file(file_dict: dict) -> str:
-    """保存上传的文件到 temp/uploaded/ 目录，返回绝对路径"""
-    os.makedirs("temp/uploaded", exist_ok=True)
-
-    # 文件名安全化
-    safe_name = re.sub(r"[^A-Za-z0-9._\-\u4e00-\u9fa5]", "_", file_dict['name'])
-    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S_%f')
-    saved_path = os.path.join("temp", "uploaded", f"{timestamp}_{safe_name}")
-
-    try:
-        with open(saved_path, "wb") as f:
-            f.write(file_dict['content'])
-        return os.path.abspath(saved_path)
-    except Exception as e:
-        print(f"[ERROR] Failed to save {file_dict['name']}: {e}")
-        return ""
-
-
-def generate_thumbnail(file_dict: dict, size=(80, 80)) -> str:
-    """
-    生成文件缩略图，返回 base64 data URI
-    - 图片：缩放后的 base64 图片
-    - 其他：返回文件类型图标的 emoji 或 SVG
-    """
-    if file_dict['type'].startswith('image/'):
-        try:
-            from PIL import Image
-
-            img = Image.open(BytesIO(file_dict['content']))
-            img.thumbnail(size, Image.Resampling.LANCZOS)
-
-            buf = BytesIO()
-            img.save(buf, format='PNG')
-            b64 = base64.b64encode(buf.getvalue()).decode()
-            return f"data:image/png;base64,{b64}"
-        except Exception as e:
-            print(f"[ERROR] Thumbnail generation failed: {e}")
-            return "📷"  # 降级为 emoji
-
-    # 非图片文件返回图标
-    ext = os.path.splitext(file_dict['name'])[1].lower()
-    icon_map = {
-        '.pdf': '📄', '.txt': '📝', '.md': '📝', '.doc': '📄', '.docx': '📄',
-        '.xls': '📊', '.xlsx': '📊', '.csv': '📊',
-        '.zip': '📦', '.rar': '📦', '.7z': '📦',
-        '.py': '🐍', '.js': '📜', '.json': '📋', '.xml': '📋',
-        '.mp3': '🎵', '.wav': '🎵', '.mp4': '🎬', '.avi': '🎬',
-    }
-    return icon_map.get(ext, '📎')
-
-
-def build_prompt_with_files(prompt: str, files: list) -> tuple:
-    """
-    构建包含文件附件信息的提示
-    返回: (agent_prompt, display_prompt)
-    """
-    if not files:
-        return prompt, prompt
-
-    attachment_info = ["\n\n[用户上传附件 — 文件已保存到本地磁盘，可用 file_read 工具读取]"]
-
-    for f in files:
-        saved_path = save_uploaded_file(f)
-        if not saved_path:
-            continue
-
-        if f['type'].startswith('image/'):
-            # 图片：提供路径 + base64（为未来 vision API 准备）
-            b64 = base64.b64encode(f['content']).decode()
-            attachment_info.append(
-                f"\n- [图片附件] {f['name']} ({f['size']} bytes)"
-                f"\n  磁盘路径: {saved_path}"
-                f"\n  data:{f['type']};base64,{b64[:100]}...(truncated)"  # 截断避免过长
-            )
-        elif f['name'].endswith(('.txt', '.md', '.py', '.json', '.log', '.csv', '.yaml', '.yml', '.js', '.ts', '.sql')):
-            # 文本文件：内联内容
-            try:
-                text = f['content'].decode('utf-8', errors='replace')
-                max_chars = 6000
-                attachment_info.append(
-                    f"\n--- 文本文件: {f['name']} ({f['size']} bytes) ---"
-                    f"\n磁盘路径: {saved_path}"
-                    f"\n{text[:max_chars]}"
-                    + ("\n[内容已截断，请用 file_read 读取完整内容]" if len(text) > max_chars else "")
-                )
-            except Exception:
-                attachment_info.append(f"\n- 文件: {f['name']} (无法解码为文本)\n  磁盘路径: {saved_path}")
-        else:
-            # 其他文件：仅路径
-            attachment_info.append(f"\n- 文件: {f['name']} ({f['size']} bytes)\n  磁盘路径: {saved_path}")
-
-    agent_prompt = prompt + "\n".join(attachment_info)
-    file_names = ', '.join(f['name'] for f in files)
-    display_prompt = f"{prompt}\n\n📎 附件: {file_names}"
-
-    return agent_prompt, display_prompt
-
-
-def render_file_thumbnails():
-    """渲染已上传文件的缩略图（_embed_html iframe，自带 deleteFile JS，无跨 iframe 依赖）"""
-    files = st.session_state.uploaded_files
-    if not files:
-        return
-
-    cards_html = []
-    for idx, f in enumerate(files):
-        thumb = generate_thumbnail(f)
-        # 转义文件名，防止破坏 HTML 属性
-        safe_name = f['name'].replace('&', '&amp;').replace('"', '&quot;').replace("'", '&#39;').replace('<', '&lt;')
-        name_display = safe_name[:18]
-
-        if thumb.startswith('data:image'):
-            inner = f'<img src="{thumb}" style="width:100%;height:100%;object-fit:cover;display:block;">'
-        else:
-            inner = (
-                f'<div style="width:100%;height:100%;display:flex;'
-                f'align-items:center;justify-content:center;font-size:30px;">'
-                f'{thumb}</div>'
-            )
-
-        card = (
-            f'<div style="position:relative;width:72px;flex-shrink:0;margin-top:6px;">'
-            f'  <div style="width:72px;height:72px;border-radius:8px;overflow:hidden;'
-            f'              border:1px solid #d5cec5;background:#eeece2;">'
-            f'    {inner}'
-            f'  </div>'
-            f'  <div style="font-size:9px;color:#6b7280;text-align:center;margin-top:3px;'
-            f'              white-space:nowrap;overflow:hidden;text-overflow:ellipsis;'
-            f'              max-width:72px;" title="{safe_name}">{name_display}</div>'
-            f'  <div onclick="deleteFile({idx})"'
-            f'       style="position:absolute;top:-6px;right:-6px;width:18px;height:18px;'
-            f'              border-radius:50%;background:#9ca3af;color:white;font-size:13px;'
-            f'              font-weight:bold;display:flex;align-items:center;'
-            f'              justify-content:center;cursor:pointer;line-height:1;'
-            f'              user-select:none;"'
-            f'       onmouseover="this.style.background=\'#ef4444\'"'
-            f'       onmouseout="this.style.background=\'#9ca3af\'">&#215;</div>'
-            f'</div>'
-        )
-        cards_html.append(card)
-
-    # 每行最多 8 张，计算 iframe 高度（6px 顶部留白 + 72px 图 + 3px + ~12px 文件名 + 4px 底部）
-    n_rows = max(1, (len(files) + 7) // 8)
-    iframe_height = n_rows * 100 + 10
-
-    full_html = (
-        '<!DOCTYPE html><html><head><style>'
-        'html,body{margin:0;padding:0;background:transparent;overflow:hidden;}'
-        '</style></head><body>'
-        '<div style="display:flex;gap:10px;flex-wrap:wrap;'
-        'padding:6px 6px 4px 2px;align-items:flex-start;">'
-        + ''.join(cards_html)
-        + '</div>'
-        '<script>'
-        'function deleteFile(idx){'
-        '  try{'
-        '    var hw=window.parent;'
-        '    var hd=hw.document;'
-        '    var inp=hd.querySelector(\'input[placeholder="__delete_file_signal__"]\');'
-        '    if(!inp)return;'
-        '    var s=Object.getOwnPropertyDescriptor(hw.HTMLInputElement.prototype,"value").set;'
-        '    s.call(inp,String(idx));'
-        '    inp.dispatchEvent(new Event("input",{bubbles:true}));'
-        '    setTimeout(function(){'
-        '      inp.dispatchEvent(new Event("blur",{bubbles:false}));'
-        '      inp.dispatchEvent(new Event("focusout",{bubbles:true}));'
-        '    },100);'
-        '  }catch(e){console.error("deleteFile:",e);}'
-        '}'
-        '</script>'
-        '</body></html>'
-    )
-    _embed_html(full_html, height=iframe_height)
-
-
-@st.dialog("文件预览", width="large")
-def preview_file_dialog():
-    """文件预览模态对话框"""
-    idx = st.session_state.preview_file_idx
-    if idx is None or idx >= len(st.session_state.uploaded_files):
-        return
-
-    f = st.session_state.uploaded_files[idx]
-
-    st.subheader(f"📎 {f['name']}")
-    st.caption(f"类型: {f['type']} | 大小: {f['size']:,} bytes")
-
-    if f['type'].startswith('image/'):
-        # 图片预览
-        st.image(f['content'], use_container_width=True)
-    elif f['name'].endswith(('.txt', '.md', '.py', '.json', '.log', '.csv', '.yaml', '.yml', '.js', '.ts', '.sql')):
-        # 文本文件预览
-        try:
-            text = f['content'].decode('utf-8', errors='replace')
-            st.code(text[:5000], language=None)
-            if len(text) > 5000:
-                st.info("内容已截断至前 5000 字符")
-        except Exception as e:
-            st.error(f"无法显示文件内容: {e}")
-    else:
-        # 其他文件显示信息
-        st.info("此文件类型不支持预览")
-        st.json({
-            "文件名": f['name'],
-            "类型": f['type'],
-            "大小": f"{f['size']:,} bytes",
-        })
-
-    if st.button("关闭", use_container_width=True):
-        st.session_state.preview_file_idx = None
-        st.rerun()
-
-
 def build_header_agent_badge_script() -> str:
     return """
 <script>
@@ -1333,56 +941,6 @@ def build_header_agent_badge_script() -> str:
 </script>
 """
 
-
-def build_paste_listener_script() -> str:
-    """注入粘贴监听 JS：捕获剪贴板图片并写入隐藏信号输入框触发 Streamlit rerun。"""
-    return """
-<script>
-(function() {
-    var hostWin = window.parent || window;
-    var hostDoc = hostWin.document || document;
-
-    // 幂等：只安装一次粘贴监听
-    if (hostWin.__pasteImageListenerInstalled__) return;
-    hostWin.__pasteImageListenerInstalled__ = true;
-
-    hostDoc.addEventListener('paste', function(e) {
-        var items = e.clipboardData && e.clipboardData.items;
-        if (!items) return;
-        for (var i = 0; i < items.length; i++) {
-            var item = items[i];
-            if (item.type && item.type.startsWith('image/')) {
-                var blob = item.getAsFile();
-                if (!blob) continue;
-                (function(b) {
-                    var reader = new FileReader();
-                    reader.onload = function(ev) {
-                        var b64 = ev.target.result;
-                        var input = hostDoc.querySelector(
-                            'input[placeholder="__paste_image_signal__"]'
-                        );
-                        if (!input) return;
-                        var setter = Object.getOwnPropertyDescriptor(
-                            hostWin.HTMLInputElement.prototype, 'value'
-                        ).set;
-                        setter.call(input, b64);
-                        input.dispatchEvent(new Event('input', { bubbles: true }));
-                        setTimeout(function() {
-                            input.dispatchEvent(new Event('blur', { bubbles: false }));
-                            input.dispatchEvent(new Event('focusout', { bubbles: true }));
-                        }, 100);
-                    };
-                    reader.readAsDataURL(b);
-                })(blob);
-                break;
-            }
-        }
-    });
-})();
-</script>
-"""
-
-
 agent = init()
 
 def init_session_state():
@@ -1390,21 +948,15 @@ def init_session_state():
         'agent_name': 'GenericAgent', 'streaming': False, 'stopping': False, 'display_queue': None,
         'partial_response': '', 'reply_ts': '', 'current_prompt': '', 'selected_llm_idx': agent.llm_no,
         'autonomous_enabled': False, 'messages': [],
-        'uploaded_files': [],  # [{'name', 'type', 'size', 'content'}, ...]
-        'file_uploader_key': 0,  # 用于重置 file_uploader
-        'preview_file_idx': None,  # 当前预览的文件索引
     }.items(): st.session_state.setdefault(key, value)
 
 init_session_state()
 
 # Inject Anthropic theme
 st.markdown(ANTHROPIC_CSS, unsafe_allow_html=True)
-st.markdown(FILE_UPLOAD_CSS, unsafe_allow_html=True)
-st.markdown(PASTE_HIDDEN_INPUT_CSS, unsafe_allow_html=True)
 st.markdown(build_dynamic_font_css(110.0), unsafe_allow_html=True)
 _embed_html(ANTHROPIC_SELECTBOX_SCRIPT, height=0, width=0)
 _embed_html(build_header_agent_badge_script(), height=0, width=0)
-_embed_html(build_paste_listener_script(), height=0, width=0)
 
 st.session_state.agent_name = 'Generic Agent'
 with st.chat_message("assistant"):
@@ -1463,31 +1015,14 @@ def poll_agent_output(max_items=20):
 def _get_response_segments(text):
     return [p for p in re.split(r'(?=\*\*LLM Running \(Turn \d+\) \.\.\.\*\*)', text) if p.strip()] or [text]
 
-def render_message(role, content, ts='', unsafe_allow_html=True, intermediate=False):
+def render_message(role, content, ts='', unsafe_allow_html=True):
     with st.chat_message(role):
-        if ts:
-            st.markdown(f'<div class="msg-timestamp">{ts}</div>', unsafe_allow_html=True)
-        if intermediate:
-            m = re.match(r'^\*\*LLM Running \(Turn (\d+)\)', content.strip())
-            label = f"Turn {m.group(1)} · 推理过程" if m else "推理过程"
-            with st.expander(label, expanded=False):
-                st.markdown(content, unsafe_allow_html=unsafe_allow_html)
-        else:
-            st.markdown(content, unsafe_allow_html=unsafe_allow_html)
+        if ts: st.markdown(f'<div class="msg-timestamp">{ts}</div>', unsafe_allow_html=True)
+        st.markdown(content, unsafe_allow_html=unsafe_allow_html)
 
 def finish_streaming_message():
     reply_ts = st.session_state.reply_ts
-    segments = _get_response_segments(st.session_state.partial_response)
-    for i, seg in enumerate(segments):
-        is_intermediate = (i < len(segments) - 1) and bool(
-            re.match(r'^\*\*LLM Running \(Turn \d+\)', seg.strip())
-        )
-        st.session_state.messages.append({
-            "role": "assistant",
-            "content": seg,
-            "time": reply_ts,
-            "intermediate": is_intermediate,
-        })
+    st.session_state.messages.extend({"role": "assistant", "content": seg, "time": reply_ts} for seg in _get_response_segments(st.session_state.partial_response))
     st.session_state.last_reply_time = int(time.time())
     st.session_state.partial_response = st.session_state.reply_ts = st.session_state.current_prompt = ''
 
@@ -1500,144 +1035,15 @@ def render_streaming_area():
     reply_ts = st.session_state.reply_ts
     with st.empty().container():
         segments = _get_response_segments(st.session_state.partial_response)
-        for i, seg in enumerate(segments):
-            is_last = (i == len(segments) - 1)
-            is_intermediate = (not is_last) and bool(
-                re.match(r'^\*\*LLM Running \(Turn \d+\)', seg.strip())
-            )
-            render_message(
-                "assistant",
-                seg + ("" if not is_last else "▌"),
-                ts=reply_ts,
-                unsafe_allow_html=False,
-                intermediate=is_intermediate,
-            )
+        for i, seg in enumerate(segments): render_message("assistant", seg + ("" if i < len(segments) - 1 else "▌"), ts=reply_ts, unsafe_allow_html=False)
     if poll_agent_output(): finish_streaming_message()
     else: time.sleep(0.2)
     st.rerun()
 
-for msg in st.session_state.messages:
-    render_message(
-        msg["role"], msg["content"],
-        ts=msg.get("time", ""),
-        unsafe_allow_html=True,
-        intermediate=msg.get("intermediate", False),
-    )
+for msg in st.session_state.messages: render_message(msg["role"], msg["content"], ts=msg.get("time", ""), unsafe_allow_html=True)
 if st.session_state.streaming: render_streaming_area()
-
-# ── 粘贴图片：隐藏信号输入框 + 处理逻辑 ──────────────────────────────────
-_paste_val = st.session_state.get("paste_image_signal", "")
-if _paste_val and _paste_val.startswith("data:image"):
-    try:
-        _header, _b64str = _paste_val.split(",", 1)
-        _mime = _header.split(":")[1].split(";")[0]          # e.g. "image/png"
-        _ext = _mime.split("/")[1]                           # e.g. "png"
-        _content = base64.b64decode(_b64str)
-        if len(_content) <= 10 * 1024 * 1024:
-            _fname = f"pasted_{datetime.now().strftime('%H%M%S%f')[:12]}.{_ext}"
-            st.session_state.uploaded_files.append({
-                'name': _fname,
-                'type': _mime,
-                'size': len(_content),
-                'content': _content,
-            })
-    except Exception:
-        pass
-    st.session_state.paste_image_signal = ""
-    st.rerun()
-
-st.text_input(
-    "paste_signal",
-    value="",
-    key="paste_image_signal",
-    label_visibility="collapsed",
-    placeholder="__paste_image_signal__",
-)
-
-# ── 删除文件信号 ──────────────────────────────────────────────────────────
-_del_val = st.session_state.get("delete_file_signal", "")
-if _del_val and _del_val.isdigit():
-    idx = int(_del_val)
-    if 0 <= idx < len(st.session_state.uploaded_files):
-        st.session_state.uploaded_files.pop(idx)
-    st.session_state.delete_file_signal = ""
-    st.rerun()
-
-st.text_input(
-    "delete_signal",
-    value="",
-    key="delete_file_signal",
-    label_visibility="collapsed",
-    placeholder="__delete_file_signal__",
-)
-
-# 1. 渲染文件缩略图（如果有上传文件）
-render_file_thumbnails()
-
-# 2. 输入区域布局: [文件上传按钮] [聊天输入框]
-col_upload, col_input = st.columns([0.08, 0.92])
-
-with col_upload:
-    # 文件上传按钮（样式化为 + 按钮）
-    uploaded_files = st.file_uploader(
-        "上传文件",
-        accept_multiple_files=True,
-        label_visibility="collapsed",
-        key=f"file_uploader_{st.session_state.file_uploader_key}",
-        help="点击上传图片、文档等文件",
-    )
-
-    # 处理新上传的文件
-    if uploaded_files:
-        for uf in uploaded_files:
-            # 检查是否已存在
-            if any(f['name'] == uf.name for f in st.session_state.uploaded_files):
-                continue
-
-            # 读取文件内容
-            content = uf.read()
-
-            # 文件大小限制: 10MB
-            if len(content) > 10 * 1024 * 1024:
-                st.warning(f"文件 {uf.name} 超过 10MB，已跳过")
-                continue
-
-            # 添加到状态
-            st.session_state.uploaded_files.append({
-                'name': uf.name,
-                'type': uf.type if uf.type else 'application/octet-stream',
-                'size': len(content),
-                'content': content,
-            })
-
-        # 重置 uploader（避免重复处理）
-        st.session_state.file_uploader_key += 1
-        st.rerun()
-
-with col_input:
-    # 聊天输入框
-    prompt = st.chat_input("请输入指令", disabled=st.session_state.streaming)
-
-
-# 4. 处理消息发送
-if prompt:
-    # 构建包含文件的完整提示
-    files = st.session_state.uploaded_files
-    agent_prompt, display_prompt = build_prompt_with_files(prompt, files)
-
-    # 添加用户消息（显示简化版）
-    st.session_state.messages.append({
-        "role": "user",
-        "content": display_prompt,
-        "time": datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    })
-
-    # 发送给 agent（完整版，包含文件内容）
-    start_agent_task(agent_prompt)
-
-    # 清空已上传文件
-    st.session_state.uploaded_files.clear()
-    st.session_state.file_uploader_key += 1
-
+if prompt := st.chat_input("请输入指令", disabled=st.session_state.streaming):
+    st.session_state.messages.append({"role": "user", "content": prompt, "time": datetime.now().strftime("%Y-%m-%d %H:%M:%S")})
+    start_agent_task(prompt)
     st.rerun()
 

--- a/launch.pyw
+++ b/launch.pyw
@@ -3,6 +3,7 @@ import webview, threading, subprocess, sys, time, os, ctypes, atexit, socket, ra
 WINDOW_WIDTH, WINDOW_HEIGHT, RIGHT_PADDING, TOP_PADDING = 600, 900, 0, 100
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
+window = None
 frontends_dir = os.path.join(script_dir, "frontends")
 
 def find_free_port(lo=18501, hi=18599):
@@ -151,8 +152,16 @@ if __name__ == '__main__':
         x_pos = screen_width - WINDOW_WIDTH - RIGHT_PADDING
     else: x_pos = 100
     time.sleep(5)
+    print(f'[Launch] Creating window at x={x_pos} y={TOP_PADDING} url=http://localhost:{port}')
     window = webview.create_window(
         title='GenericAgent', url=f'http://localhost:{port}',
         width=WINDOW_WIDTH, height=WINDOW_HEIGHT, x=x_pos, y=TOP_PADDING,
         resizable=True, text_select=True)
-    webview.start()
+    print(f'[Launch] Window object: {window}')
+    try:
+        webview.start()
+        print('[Launch] webview.start() returned normally — window was closed')
+    except Exception as e:
+        import traceback
+        print(f'[Launch] webview.start() raised: {e}')
+        traceback.print_exc()

--- a/launch.pyw
+++ b/launch.pyw
@@ -18,7 +18,7 @@ def get_screen_width():
 
 def start_streamlit(port):
     global proc
-    cmd = [sys.executable, "-m", "streamlit", "run", os.path.join(frontends_dir, "stapp.py"), "--server.port", str(port), "--server.address", "localhost", "--server.headless", "true", "--client.toolbarMode", "viewer"]
+    cmd = [sys.executable, "-m", "streamlit", "run", os.path.join(frontends_dir, "stapp2.py"), "--server.port", str(port), "--server.address", "localhost", "--server.headless", "true"]
     proc = subprocess.Popen(cmd)
     atexit.register(proc.kill)
 
@@ -67,9 +67,13 @@ PASTE_HOOK_JS = """if (!window._pasteHooked) { window._pasteHooked = true;
 
 def idle_monitor():
     last_trigger_time = 0
+    # 等待窗口加载完毕再开始监控
+    time.sleep(12)
     while True:
         time.sleep(5)
         try:
+            if not window or not window.evaluate_js('document.readyState'):
+                continue
             window.evaluate_js(PASTE_HOOK_JS)
             now = time.time()
             if now - last_trigger_time < 120: continue
@@ -146,7 +150,7 @@ if __name__ == '__main__':
         screen_width = get_screen_width()
         x_pos = screen_width - WINDOW_WIDTH - RIGHT_PADDING
     else: x_pos = 100
-    time.sleep(2) 
+    time.sleep(5)
     window = webview.create_window(
         title='GenericAgent', url=f'http://localhost:{port}',
         width=WINDOW_WIDTH, height=WINDOW_HEIGHT, x=x_pos, y=TOP_PADDING,

--- a/start_streamlit.bat
+++ b/start_streamlit.bat
@@ -1,0 +1,4 @@
+@echo off
+cd /d "%~dp0"
+.venv\Scripts\streamlit.exe run frontends/stapp.py --server.port 8501
+pause

--- a/test_files/test.txt
+++ b/test_files/test.txt
@@ -1,0 +1,9 @@
+This is a test file for GenericAgent file upload functionality.
+
+The file upload feature allows users to:
+1. Upload multiple files (images, documents, etc.)
+2. Preview files before sending
+3. Delete individual files
+4. Send files along with messages to the Agent
+
+The Agent can then use the file_read tool to access the uploaded files.


### PR DESCRIPTION
# 变更说明

## Pull Request 说明

**目标分支：** `master`  
**涉及文件：** `frontends/stapp2.py`、`launch.pyw`

**合并前检查：**
- [ ] 底部输入区：`+` 上传按钮与聊天框水平对齐（包括 600 px 窄 webview 窗口）
- [ ] Ctrl+V 粘贴截图：缩略图显示，可删除，发送后附加到消息
- [ ] `python launch.pyw` 正常弹出 GenericAgent 窗口

---

## 新增功能

### 文件上传

输入区左侧新增 `+` 图标按钮，点击可上传任意类型文件。

- **缩略图预览**：图片显示缩略图，其他文件显示类型图标，支持点击 `×` 删除
- **附件注入**：发送时自动将文件信息追加到 prompt
  - 图片：磁盘路径 + base64（供 vision API 使用）
  - 文本文件（`.txt .md .py .json` 等）：内联最多 6000 字符
  - 其他：仅磁盘路径，Agent 可用 `file_read` 工具读取
- 文件保存至 `temp/uploaded/<timestamp>_<name>`，发送后清空队列

### 截图粘贴

在聊天框聚焦时，Ctrl+V 粘贴剪贴板图片直接入队，无需手动保存文件。

实现方式：页面注入 JS 监听 `paste` 事件，捕获 `image/*` 内容转为 base64，通过隐藏信号输入框触发 Streamlit rerun，Python 侧解码后与上传文件走同一处理流程。

---

## 修改要点

- `launch.pyw`：启动目标切换为 `stapp2.py`；新增 `window = None` 初始化防止 idle monitor 在窗口就绪前崩溃；webview 启动等待时间调整为 5 秒