### PR TITLE
refactor(tui): extract _select_origin_widget helper

### DIFF
--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -3424,6 +3424,11 @@ def render_sidebar(sessions: dict[int, AgentSession], current_id: Optional[int])
 
 
 # ---------- App ----------
+# Textual 8.2.6 renamed _select_start to _select_state (SelectState.start.container).
+def _select_origin_widget(screen: Any) -> Any:
+    if (state := getattr(screen, "_select_state", None)) is not None:
+        return start.container if (start := getattr(state, "start", None)) is not None else None
+    return legacy[0] if (legacy := getattr(screen, "_select_start", None)) is not None else None
 
 
 class HelpScreen(ModalScreen):
@@ -3757,13 +3762,7 @@ class GenericAgentTUI(App[None]):
             scroll_lines = app.SELECT_AUTO_SCROLL_LINES
 
             candidates = [select_widget]
-            # Textual 8.2.6 renamed _select_start to _select_state (SelectState.start.container).
-            select_state = getattr(screen, "_select_state", None)
-            if select_state is not None:
-                sw = select_state.start.container
-            else:
-                ss = getattr(screen, "_select_start", None)
-                sw = ss[0] if ss is not None else None
+            sw = _select_origin_widget(screen)
             if sw is not None and sw is not select_widget:
                 candidates.append(sw)
 


### PR DESCRIPTION
The previous head was based on `fc6b5ad`, which is no longer in `main`'s history after the recent force-push, so this PR was rendering a bogus 250-commit / 100-file diff against an ancient merge base. Re-applied cleanly on top of `4086d5c`. The test file the original description mentioned has been dropped, since the tree carries no test suite and no pytest dependency.

Changes:

- Extract the inline Textual 8.x / ≤7.x branch in `_patch_auto_scroll_for_selection` into a module-level `_select_origin_widget(screen)` helper at the top of the `# ---------- App ----------` section. The call site becomes a one-liner.
- Guard `.start` before dereferencing it. This is future-proofing rather than a fix for a currently reachable state: `SelectState.start` is non-optional in Textual 8.2.6, so the existing `select_state.start.container` cannot raise on any shape Textual produces today. The guard only means that a future private-API change degrades to "no extra auto-scroll candidate" instead of an `AttributeError` raised inside a mouse-move handler.

No behaviour change on any input Textual produces today. Verified by running the current inline implementation and the helper side by side over a 20-case matrix covering every presence / absence / `None` combination of `_select_state`, `_select_state.start` and `_select_start`: 12 cases identical, and the only 8 differences are exactly the guard described above — the inline version raises `AttributeError`, the helper returns `None`. An empty `_select_start` tuple still raises `IndexError` in both, unchanged.

Refs #373, #379
