### PR TITLE
feat: add optional TinyFish web research tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ The entire core loop is just **~100 lines of code** (`agent_loop.py`).
 
 > Additionally, 2 **memory management tools** (`update_working_checkpoint`, `start_long_term_update`) allow the agent to persist context and accumulate experience across sessions.
 
+Optional web research providers can add specialized tools without changing the core browser-control path. For example, setting `TINYFISH_API_KEY` (or `tinyfish_api_key` in `mykey.py`) enables `tinyfish_search` for ranked web search and `tinyfish_fetch` for browser-rendered content extraction.
+
 4️⃣ **Capability Extension Mechanism**
 > _Capable of dynamically creating new tools._
 

--- a/assets/tools_schema.json
+++ b/assets/tools_schema.json
@@ -53,6 +53,26 @@
       "switch_tab_id": {"type": "string", "description": "[Optional] Tab ID to switch to before executing"}}}
   }},
   {"type": "function", "function": {
+    "name": "tinyfish_search",
+    "description": "Optional TinyFish integration. Ranked web search without using the local browser. Requires TINYFISH_API_KEY or tinyfish_api_key/tinyfish_config in mykey.py",
+    "parameters": {"type": "object", "properties": {
+      "query": {"type": "string", "description": "Search query. Supports normal search operators such as site: and -site:"},
+      "location": {"type": "string", "description": "Country code for geo-targeted results, e.g. US, GB, FR, DE", "default": "US"},
+      "language": {"type": "string", "description": "Language code for results, e.g. en, fr, de, ja", "default": "en"},
+      "page": {"type": "integer", "description": "Page number starting from 0, max 10", "default": 0},
+      "max_results": {"type": "integer", "description": "Maximum results to return to the model", "default": 10}}}
+  }},
+  {"type": "function", "function": {
+    "name": "tinyfish_fetch",
+    "description": "Optional TinyFish integration. Render URLs in a real browser and extract clean page content, links, and image links. Use after search results for web research. Requires TINYFISH_API_KEY or tinyfish_api_key/tinyfish_config in mykey.py",
+    "parameters": {"type": "object", "properties": {
+      "urls": {"type": "array", "items": {"type": "string"}, "description": "HTTP/HTTPS URLs to extract. Maximum 10"},
+      "format": {"type": "string", "enum": ["markdown", "html", "json"], "description": "Output format for extracted content", "default": "markdown"},
+      "links": {"type": "boolean", "description": "Include all outbound links", "default": false},
+      "image_links": {"type": "boolean", "description": "Include all image URLs", "default": false},
+      "max_chars": {"type": "integer", "description": "Approximate maximum extracted text characters returned across all pages", "default": 20000}}}
+  }},
+  {"type": "function", "function": {
     "name": "update_working_checkpoint",
     "description": "Short-term working notepad, auto-injected each turn to prevent info loss in long tasks. Call during early/mid stages, not at end. When: (1) after reading SOP, store user needs & key constraints (skip for simple 1-2 step tasks); (2) before subtask switch or context flush; (3) after repeated failures, re-read SOP and must store new findings; (4) on new task, update content, clear old progress but keep valid constraints.\n\nDon't call: simple tasks (1-2 steps), task completed (use long-term memory tool)",
     "parameters": {"type": "object", "properties": {

--- a/assets/tools_schema_cn.json
+++ b/assets/tools_schema_cn.json
@@ -53,6 +53,26 @@
       "switch_tab_id": {"type": "string", "description": "可选的标签页 ID，切换到该标签页执行"}}}
   }},
   {"type": "function", "function": {
+    "name": "tinyfish_search",
+    "description": "可选 TinyFish 集成。不打开本地浏览器，直接进行排序后的网页搜索。需要设置 TINYFISH_API_KEY，或在 mykey.py 中设置 tinyfish_api_key/tinyfish_config",
+    "parameters": {"type": "object", "properties": {
+      "query": {"type": "string", "description": "搜索关键词。支持 site:、-site: 等常规搜索运算符"},
+      "location": {"type": "string", "description": "地域国家代码，如 US、GB、FR、DE", "default": "US"},
+      "language": {"type": "string", "description": "结果语言代码，如 en、fr、de、ja", "default": "en"},
+      "page": {"type": "integer", "description": "页码，从0开始，最大10", "default": 0},
+      "max_results": {"type": "integer", "description": "最多返回给模型的结果数量", "default": 10}}}
+  }},
+  {"type": "function", "function": {
+    "name": "tinyfish_fetch",
+    "description": "可选 TinyFish 集成。用真实浏览器渲染 URL 并提取干净正文、链接和图片链接。适合搜索后做网页研究。需要设置 TINYFISH_API_KEY，或在 mykey.py 中设置 tinyfish_api_key/tinyfish_config",
+    "parameters": {"type": "object", "properties": {
+      "urls": {"type": "array", "items": {"type": "string"}, "description": "要提取的 HTTP/HTTPS URL，最多10个"},
+      "format": {"type": "string", "enum": ["markdown", "html", "json"], "description": "提取内容的输出格式", "default": "markdown"},
+      "links": {"type": "boolean", "description": "是否包含页面上的全部链接", "default": false},
+      "image_links": {"type": "boolean", "description": "是否包含页面上的全部图片URL", "default": false},
+      "max_chars": {"type": "integer", "description": "返回给模型的正文字符数上限（近似值）", "default": 20000}}}
+  }},
+  {"type": "function", "function": {
     "name": "update_working_checkpoint",
     "description": "短期工作便签，每轮自动注入上下文，防长任务信息丢失。前中期调用，非结束时。何时调用：(1)任务开始读SOP后，存用户需求和关键约束/参数（简单1-2步任务除外）；(2)子任务切换或上下文即将被冲刷前；(3)多次重试失败后，重读SOP并必须调用存储新发现；(4)切换新任务时更新内容，清旧进度但保留仍有效的约束。\n\n何时不调用：简单任务（1-2步且无严重约束）、任务已完成时（应当用长期结算工具）",
     "parameters": {"type": "object", "properties": {

--- a/ga.py
+++ b/ga.py
@@ -2,6 +2,7 @@ import sys, os, re, json, time, threading, importlib
 from datetime import datetime
 from pathlib import Path
 import tempfile, traceback, subprocess, itertools, collections, difflib
+import requests
 if sys.stdout is None: sys.stdout = open(os.devnull, "w")
 if sys.stderr is None: sys.stderr = open(os.devnull, "w")
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -171,6 +172,68 @@ def web_execute_js(script, switch_tab_id=None, no_monitor=False):
         result = simphtml.execute_js_rich(script, driver, no_monitor=no_monitor)
         return result
     except Exception as e: return {"status": "error", "msg": format_error(e)}
+
+def _get_tinyfish_api_key():
+    key = os.environ.get("TINYFISH_API_KEY", "").strip()
+    if key: return key
+    try:
+        from llmcore import reload_mykeys
+        mykeys = reload_mykeys()[0]
+    except Exception:
+        mykeys = {}
+    key = str(mykeys.get("tinyfish_api_key", "") or mykeys.get("tinyfish_apikey", "") or "").strip()
+    if key: return key
+    cfg = mykeys.get("tinyfish_config") or {}
+    if isinstance(cfg, dict): return str(cfg.get("apikey") or cfg.get("api_key") or "").strip()
+    return ""
+
+def _tinyfish_headers():
+    api_key = _get_tinyfish_api_key()
+    if not api_key:
+        return None, {
+            "status": "error",
+            "msg": "TinyFish API key missing. Set TINYFISH_API_KEY or tinyfish_api_key/tinyfish_config in mykey.py.",
+        }
+    return {"X-API-Key": api_key, "Content-Type": "application/json"}, None
+
+def tinyfish_search(query, location="US", language="en", page=0, max_results=10):
+    headers, err = _tinyfish_headers()
+    if err: return err
+    try:
+        params = {"query": query, "page": int(page or 0)}
+        if location: params["location"] = location
+        if language: params["language"] = language
+        resp = requests.get("https://api.search.tinyfish.ai", headers=headers, params=params, timeout=30)
+        if resp.status_code >= 400:
+            return {"status": "error", "http_status": resp.status_code, "msg": smart_format(resp.text, max_str_len=1000)}
+        data = resp.json()
+        max_results = max(1, min(int(max_results or 10), 20))
+        data["results"] = data.get("results", [])[:max_results]
+        return {"status": "success", **data}
+    except Exception as e:
+        return {"status": "error", "msg": format_error(e)}
+
+def tinyfish_fetch(urls, format="markdown", links=False, image_links=False, max_chars=20000):
+    headers, err = _tinyfish_headers()
+    if err: return err
+    if isinstance(urls, str): urls = [urls]
+    urls = [str(u).strip() for u in (urls or []) if str(u).strip()]
+    if not urls: return {"status": "error", "msg": "urls must contain at least one URL."}
+    if len(urls) > 10: return {"status": "error", "msg": "TinyFish fetch accepts at most 10 URLs per request."}
+    if format not in {"markdown", "html", "json"}: format = "markdown"
+    try:
+        payload = {"urls": urls, "format": format, "links": bool(links), "image_links": bool(image_links)}
+        resp = requests.post("https://api.fetch.tinyfish.ai", headers=headers, json=payload, timeout=150)
+        if resp.status_code >= 400:
+            return {"status": "error", "http_status": resp.status_code, "msg": smart_format(resp.text, max_str_len=1000)}
+        data = resp.json()
+        per_page = max(1000, int(max_chars or 20000) // max(len(data.get("results", [])), 1))
+        for item in data.get("results", []):
+            if isinstance(item.get("text"), str):
+                item["text"] = smart_format(item["text"], max_str_len=per_page, omit_str="\n\n[omitted long content]\n\n")
+        return {"status": "success", **data}
+    except Exception as e:
+        return {"status": "error", "msg": format_error(e)}
 
 def expand_file_refs(text, base_dir=None):
     """展开文本中的 {{file:路径:起始行:结束行}} 引用为实际文件内容。
@@ -354,6 +417,38 @@ class GenericAgentHandler(BaseHandler):
         result = json.dumps(result, ensure_ascii=False, default=json_default)
         maxlen = 8000 // args.get('_tool_num', 1)
         return StepOutcome(smart_format(result, max_str_len=maxlen), next_prompt=next_prompt)
+
+    def do_tinyfish_search(self, args, response):
+        '''Use TinyFish Search API for ranked web search without controlling the local browser.'''
+        query = args.get("query", "")
+        if not query: return StepOutcome({"status": "error", "msg": "query is required"}, next_prompt="\n")
+        yield f"[Action] TinyFish search: {query[:80]}\n"
+        result = tinyfish_search(
+            query=query,
+            location=args.get("location", "US"),
+            language=args.get("language", "en"),
+            page=args.get("page", 0),
+            max_results=args.get("max_results", 10),
+        )
+        yield f"[Status] {result.get('status')}\n"
+        next_prompt = self._get_anchor_prompt(skip=args.get('_index', 0) > 0)
+        return StepOutcome(result, next_prompt=next_prompt)
+
+    def do_tinyfish_fetch(self, args, response):
+        '''Use TinyFish Fetch API to render and extract clean content from web pages.'''
+        urls = args.get("urls") or args.get("url")
+        yield "[Action] TinyFish fetch content\n"
+        max_chars = 30000 // args.get('_tool_num', 1)
+        result = tinyfish_fetch(
+            urls=urls,
+            format=args.get("format", "markdown"),
+            links=args.get("links", False),
+            image_links=args.get("image_links", False),
+            max_chars=args.get("max_chars", max_chars),
+        )
+        yield f"[Status] {result.get('status')}\n"
+        next_prompt = self._get_anchor_prompt(skip=args.get('_index', 0) > 0)
+        return StepOutcome(result, next_prompt=next_prompt)
     
     def do_file_patch(self, args, response):
         path = self._get_abs_path(args.get("path", ""))

--- a/mykey_template.py
+++ b/mykey_template.py
@@ -417,6 +417,13 @@ native_oai_config = {
 # dingtalk_client_secret = 'your_app_secret'
 # dingtalk_allowed_users = ['your_staff_id']        # 留空或 ['*'] 表示允许所有钉钉用户
 
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  TinyFish 网页研究集成（可选；启用 tinyfish_search / tinyfish_fetch 工具）
+# ══════════════════════════════════════════════════════════════════════════════
+#  也可以通过环境变量 TINYFISH_API_KEY 设置。
+# tinyfish_api_key = 'tf-<your-tinyfish-key>'
+
 # 可选：Langfuse 追踪。不设此项则不 import langfuse，零影响
 # langfuse_config = {
 #     'public_key': 'pk-lf-...',

--- a/mykey_template_en.py
+++ b/mykey_template_en.py
@@ -74,3 +74,9 @@ native_oai_config = {
 # ── 5. Chat platform integrations (optional) ─────────────────────────────────
 # tg_bot_token = '...'
 # tg_allowed_users = [123456789]
+
+
+# ── 6. TinyFish web research integration (optional) ─────────────────────────
+#  Enables the tinyfish_search and tinyfish_fetch tools.
+#  You may also set this as the TINYFISH_API_KEY environment variable.
+# tinyfish_api_key = 'tf-<your-tinyfish-key>'

--- a/tests/test_tinyfish_tools.py
+++ b/tests/test_tinyfish_tools.py
@@ -1,0 +1,83 @@
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import ga
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class TinyFishToolTests(unittest.TestCase):
+    def setUp(self):
+        self._env = mock.patch.dict(os.environ, {"TINYFISH_API_KEY": "tf-test"}, clear=False)
+        self._env.start()
+
+    def tearDown(self):
+        self._env.stop()
+
+    @mock.patch("ga.requests.get")
+    def test_search_sends_key_and_limits_results(self, get):
+        get.return_value = FakeResponse(
+            payload={
+                "query": "agent tools",
+                "results": [{"title": str(i), "url": f"https://example.com/{i}"} for i in range(5)],
+                "total_results": 5,
+            }
+        )
+
+        result = ga.tinyfish_search("agent tools", location="GB", language="en", page=2, max_results=3)
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(len(result["results"]), 3)
+        get.assert_called_once()
+        _, kwargs = get.call_args
+        self.assertEqual(kwargs["headers"]["X-API-Key"], "tf-test")
+        self.assertEqual(kwargs["params"]["query"], "agent tools")
+        self.assertEqual(kwargs["params"]["location"], "GB")
+        self.assertEqual(kwargs["params"]["page"], 2)
+
+    @mock.patch("ga.requests.post")
+    def test_fetch_posts_payload_and_truncates_text(self, post):
+        post.return_value = FakeResponse(
+            payload={
+                "results": [
+                    {"url": "https://example.com", "title": "Example", "text": "x" * 5000, "format": "markdown"}
+                ],
+                "errors": [],
+            }
+        )
+
+        result = ga.tinyfish_fetch(["https://example.com"], links=True, image_links=True, max_chars=1200)
+
+        self.assertEqual(result["status"], "success")
+        self.assertLess(len(result["results"][0]["text"]), 5000)
+        post.assert_called_once()
+        _, kwargs = post.call_args
+        self.assertEqual(kwargs["headers"]["X-API-Key"], "tf-test")
+        self.assertEqual(kwargs["json"]["urls"], ["https://example.com"])
+        self.assertTrue(kwargs["json"]["links"])
+        self.assertTrue(kwargs["json"]["image_links"])
+
+    def test_fetch_rejects_more_than_ten_urls(self):
+        result = ga.tinyfish_fetch([f"https://example.com/{i}" for i in range(11)])
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("at most 10", result["msg"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Context
This adds TinyFish as an optional web research provider for GenericAgent. It keeps the existing browser-control tools unchanged while exposing search and rendered extraction when a user configures a TinyFish API key. No new dependency is added because the repo already depends on `requests`.

## Summary
- add optional `tinyfish_search` and `tinyfish_fetch` tools for ranked web search and browser-rendered content extraction
- support `TINYFISH_API_KEY`, `tinyfish_api_key`, or `tinyfish_config` for configuration
- document the integration in README and key templates
- add mocked unit tests for request shaping, result limiting, and URL count validation

## Verification
- `python3 -m json.tool assets/tools_schema.json`
- `python3 -m json.tool assets/tools_schema_cn.json`
- `python3 tests/test_tinyfish_tools.py`
- `python3 -m unittest discover -s tests`
- `python3 -m py_compile ga.py tests/test_tinyfish_tools.py`
- `git diff --check`
- live smoke-tested TinyFish search and fetch endpoints with a local API key