### PR TITLE
feat: add optional TinyFish search tool

### DIFF
--- a/assets/tools_schema.json
+++ b/assets/tools_schema.json
@@ -53,6 +53,16 @@
       "switch_tab_id": {"type": "string", "description": "[Optional] Tab ID to switch to before executing"}}}
   }},
   {"type": "function", "function": {
+    "name": "tinyfish_search",
+    "description": "Optional TinyFish search. Ranked web search without using the local browser. Requires TINYFISH_API_KEY or tinyfish_api_key in mykey.py",
+    "parameters": {"type": "object", "properties": {
+      "query": {"type": "string", "description": "Search query. Supports operators such as site: and -site:"},
+      "location": {"type": "string", "description": "Country code, e.g. US, GB, FR, DE", "default": "US"},
+      "language": {"type": "string", "description": "Language code, e.g. en, fr, de, ja", "default": "en"},
+      "page": {"type": "integer", "description": "Page number from 0 to 10", "default": 0},
+      "max_results": {"type": "integer", "description": "Maximum results returned to the model", "default": 10}}}
+  }},
+  {"type": "function", "function": {
     "name": "update_working_checkpoint",
     "description": "Short-term working notepad, auto-injected each turn to prevent info loss in long tasks. Call during early/mid stages, not at end. When: (1) after reading SOP, store user needs & key constraints (skip for simple 1-2 step tasks); (2) before subtask switch or context flush; (3) after repeated failures, re-read SOP and must store new findings; (4) on new task, update content, clear old progress but keep valid constraints.\n\nDon't call: simple tasks (1-2 steps), task completed (use long-term memory tool)",
     "parameters": {"type": "object", "properties": {

--- a/assets/tools_schema_cn.json
+++ b/assets/tools_schema_cn.json
@@ -53,6 +53,16 @@
       "switch_tab_id": {"type": "string", "description": "可选的标签页 ID，切换到该标签页执行"}}}
   }},
   {"type": "function", "function": {
+    "name": "tinyfish_search",
+    "description": "可选 TinyFish 搜索。不打开本地浏览器，直接进行排序后的网页搜索。需要设置 TINYFISH_API_KEY，或在 mykey.py 中设置 tinyfish_api_key",
+    "parameters": {"type": "object", "properties": {
+      "query": {"type": "string", "description": "搜索关键词。支持 site:、-site: 等搜索运算符"},
+      "location": {"type": "string", "description": "国家代码，如 US、GB、FR、DE", "default": "US"},
+      "language": {"type": "string", "description": "语言代码，如 en、fr、de、ja", "default": "en"},
+      "page": {"type": "integer", "description": "页码，从0到10", "default": 0},
+      "max_results": {"type": "integer", "description": "最多返回给模型的结果数量", "default": 10}}}
+  }},
+  {"type": "function", "function": {
     "name": "update_working_checkpoint",
     "description": "短期工作便签，每轮自动注入上下文，防长任务信息丢失。前中期调用，非结束时。何时调用：(1)任务开始读SOP后，存用户需求和关键约束/参数（简单1-2步任务除外）；(2)子任务切换或上下文即将被冲刷前；(3)多次重试失败后，重读SOP并必须调用存储新发现；(4)切换新任务时更新内容，清旧进度但保留仍有效的约束。\n\n何时不调用：简单任务（1-2步且无严重约束）、任务已完成时（应当用长期结算工具）",
     "parameters": {"type": "object", "properties": {

--- a/ga.py
+++ b/ga.py
@@ -7,6 +7,7 @@ if sys.stderr is None: sys.stderr = open(os.devnull, "w")
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from agent_loop import BaseHandler, StepOutcome, json_default
+import tinyfish_tools
 script_dir = os.path.dirname(os.path.abspath(__file__))
 
 def code_run(code, code_type="python", timeout=60, cwd=None, code_cwd=None, stop_signal=None, maxlen=10000):
@@ -354,6 +355,14 @@ class GenericAgentHandler(BaseHandler):
         result = json.dumps(result, ensure_ascii=False, default=json_default)
         maxlen = 8000 // args.get('_tool_num', 1)
         return StepOutcome(smart_format(result, max_str_len=maxlen), next_prompt=next_prompt)
+
+    def do_tinyfish_search(self, args, response):
+        query = args.get("query", "")
+        if not query: return StepOutcome({"status": "error", "msg": "query is required"}, next_prompt="\n")
+        yield f"[Action] TinyFish search: {query[:80]}\n"
+        result = tinyfish_tools.search(query, args.get("location", "US"), args.get("language", "en"), args.get("page", 0), args.get("max_results", 10))
+        yield f"[Status] {result.get('status')}\n"
+        return StepOutcome(result, next_prompt=self._get_anchor_prompt(skip=args.get('_index', 0) > 0))
     
     def do_file_patch(self, args, response):
         path = self._get_abs_path(args.get("path", ""))

--- a/tinyfish_tools.py
+++ b/tinyfish_tools.py
@@ -1,0 +1,28 @@
+import os
+
+import requests
+
+
+def _api_key():
+    key = os.environ.get("TINYFISH_API_KEY", "").strip()
+    if key: return key
+    try:
+        import mykey
+    except ImportError:
+        return ""
+    return str(getattr(mykey, "tinyfish_api_key", "") or getattr(mykey, "tinyfish_apikey", "")).strip()
+
+
+def search(query, location="US", language="en", page=0, max_results=10):
+    key = _api_key()
+    if not key:
+        return {"status": "error", "msg": "TinyFish API key missing. Set TINYFISH_API_KEY or tinyfish_api_key in mykey.py."}
+    params = {"query": query, "page": int(page or 0)}
+    if location: params["location"] = location
+    if language: params["language"] = language
+    resp = requests.get("https://api.search.tinyfish.ai", headers={"X-API-Key": key}, params=params, timeout=30)
+    if resp.status_code >= 400:
+        return {"status": "error", "http_status": resp.status_code, "msg": resp.text[:1000]}
+    data = resp.json()
+    data["results"] = data.get("results", [])[:max(1, min(int(max_results or 10), 20))]
+    return {"status": "success", **data}


### PR DESCRIPTION
## Context
This adds TinyFish Search as an optional web research provider. The integration is isolated in `tinyfish_tools.py`, following the optional integration pattern used by Langfuse tracing: no new dependency and no behavior change unless a TinyFish API key is configured.

## Summary
- add `tinyfish_search` for ranked web search without controlling the local browser
- read credentials from `TINYFISH_API_KEY` or `tinyfish_api_key` in `mykey.py`
- keep TinyFish API request logic outside the core agent loop and browser tooling

## Verification
- `python3 -m json.tool assets/tools_schema.json`
- `python3 -m json.tool assets/tools_schema_cn.json`
- `python3 -m py_compile ga.py tinyfish_tools.py`
- `python3 -m unittest discover -s tests`
- live smoke-tested TinyFish search through `tinyfish_tools.search(...)` with a local API key