### PR TITLE
feat(tui): click-to-expand folds, streaming spinner, layout polish

### DIFF
--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -50,6 +50,11 @@ _ANSI_CONTROL_RE = re.compile(
     r"|\x1b[=>]"
 )
 
+# Strip the leading `**LLM Running (Turn N) ...**` marker that agent_loop yields per turn.
+# fold_turns still needs the marker in source content to split turns, so we only strip at
+# render time. Applies to the live (last) text segment, since folded turns don't include it.
+_TURN_MARKER_RE = re.compile(r"^\s*\**LLM Running \(Turn \d+\) \.\.\.\**\s*", re.MULTILINE)
+
 
 def fold_turns(text: str) -> list[dict]:
     placeholders: list[str] = []
@@ -145,6 +150,12 @@ class ChatMessage:
     _body_widget: Any = field(default=None, repr=False)
     _cached_body: Any = field(default=None, repr=False)
     _cache_key: tuple = field(default=(), repr=False)
+    # Fold indices the user has manually toggled away from the global default.
+    # Effective expansion = (default ⊕ in this set), where default = not fold_mode.
+    _toggled_folds: set = field(default_factory=set, repr=False)
+    _segment_widgets: list = field(default_factory=list, repr=False)
+    _segment_sig: tuple = field(default=(), repr=False)
+    _spinner_widget: Any = field(default=None, repr=False)
 
 
 @dataclass
@@ -232,6 +243,14 @@ class SelectableStatic(Static):
             return None
         return selection.extract("\n".join(lines)), "\n"
 
+
+class FoldHeader(SelectableStatic):
+    # Clickable collapsed/expanded turn header. App.on_click reads .msg/.fold_idx
+    # to toggle msg._toggled_folds and remount the segments around this widget.
+    def __init__(self, body, msg, fold_idx, **kwargs):
+        super().__init__(body, **kwargs)
+        self.msg = msg
+        self.fold_idx = fold_idx
 
 
 def _read_clipboard_text() -> str:
@@ -761,6 +780,8 @@ class GenericAgentTUI(App[None]):
         height: auto;
         margin-bottom: 0;
     }
+    .fold-header:hover { background: #161b22; }
+    .spinner { height: 1; }
 
     #palette {
         height: auto;
@@ -803,6 +824,9 @@ class GenericAgentTUI(App[None]):
         height: 3;
         min-height: 3;
         max-height: 5;
+        /* min-width guards TextArea.render_lines against `range() arg 3 must not be zero`
+           when the content region collapses to ≤ 0 cols (narrow window + sidebar shown). */
+        min-width: 10;
         background: #161b22;
         border: none;
         margin-bottom: 1;
@@ -846,6 +870,8 @@ class GenericAgentTUI(App[None]):
         self._resize_timer = None
         self._quit_armed: bool = False
         self._quit_timer = None
+        self._spinner_frame: int = 0
+        self._spinner_timer = None
         self._handlers: dict = {
             "help": self._cmd_help, "status": self._cmd_status, "sessions": self._cmd_status,
             "new": self._cmd_new, "switch": self._cmd_switch, "close": self._cmd_close,
@@ -1056,14 +1082,30 @@ class GenericAgentTUI(App[None]):
             self._disarm_quit()
 
     def action_toggle_sidebar(self) -> None:
-        self.query_one("#sidebar", Static).toggle_class("-hidden")
-
-    def action_toggle_fold(self) -> None:
-        self.fold_mode = not self.fold_mode
-        # Invalidate assistant caches: fold state changes the rendered length.
+        # display:none/block reflow doesn't always settle within one refresh, so
+        # mirror the resize debounce: invalidate width-keyed caches, then remount
+        # via a short timer (call_after_refresh alone races the layout and the
+        # remount can capture the old content_region.width — leaving messages
+        # wrapped at the previous width after Ctrl+B).
+        sidebar = self.query_one("#sidebar", Static)
+        sidebar.toggle_class("-hidden")
         for sess in self.sessions.values():
             for m in sess.messages:
                 if m.role == "assistant":
+                    m._cached_body = None
+                    m._cache_key = ()
+        if self._resize_timer is not None:
+            self._resize_timer.stop()
+        self._resize_timer = self.set_timer(0.05, self._flush_resize)
+
+    def action_toggle_fold(self) -> None:
+        self.fold_mode = not self.fold_mode
+        # Global toggle is authoritative: clear per-fold overrides so the new state
+        # is uniformly all-collapsed or all-expanded.
+        for sess in self.sessions.values():
+            for m in sess.messages:
+                if m.role == "assistant":
+                    m._toggled_folds.clear()
                     m._cached_body = None
                     m._cache_key = ()
         self._remount_current_session()
@@ -1130,6 +1172,18 @@ class GenericAgentTUI(App[None]):
             palette.action_select()
 
     def on_click(self, event: events.Click) -> None:
+        w = event.widget
+        if isinstance(w, FoldHeader):
+            msg = w.msg
+            idx = w.fold_idx
+            if idx in msg._toggled_folds:
+                msg._toggled_folds.discard(idx)
+            else:
+                msg._toggled_folds.add(idx)
+            msg._cached_body = None
+            msg._cache_key = ()
+            self._remount_assistant_message(msg)
+            return
         try:
             sidebar = self.query_one("#sidebar", Static)
         except Exception:
@@ -1199,6 +1253,9 @@ class GenericAgentTUI(App[None]):
             m._role_widget = None
             m._body_widget = None
             m._hint_widget = None
+            m._segment_widgets = []
+            m._segment_sig = ()
+            m._spinner_widget = None
         for m in self.current.messages:
             self._mount_message(container, m)
         container.scroll_end(animate=False)
@@ -1412,6 +1469,10 @@ class GenericAgentTUI(App[None]):
             nm._hint_widget = None
             nm._cached_body = None
             nm._cache_key = ()
+            nm._segment_widgets = []
+            nm._segment_sig = ()
+            nm._toggled_folds = set()
+            nm._spinner_widget = None
             new.messages.append(nm)
         new.task_seq = old.task_seq
         n = len(new.agent.llmclient.backend.history)
@@ -1747,11 +1808,11 @@ class GenericAgentTUI(App[None]):
                 break
         if agent_id != self.current_id:
             return
-        if found and found._body_widget is not None:
+        if found and found._segment_widgets:
             try:
                 container = self.query_one("#messages", VerticalScroll)
                 was_at_bottom = self._at_bottom(container)
-                found._body_widget.update(self._build_assistant_body(found))
+                self._stream_update_assistant(found)
                 if was_at_bottom:
                     container.scroll_end(animate=False)
             except Exception:
@@ -1761,6 +1822,7 @@ class GenericAgentTUI(App[None]):
         if refresh_chrome:
             self._refresh_sidebar()
             self._refresh_topbar()
+        self._ensure_spinner()
 
     # ---------------- UI refresh ----------------
     def _system(self, text: str) -> None:
@@ -1774,6 +1836,7 @@ class GenericAgentTUI(App[None]):
         self._refresh_topbar()
         self._refresh_sidebar()
         self._refresh_messages()
+        self._ensure_spinner()
 
     def _swap_input_for_session(self) -> None:
         """Persist the InputArea's text/history/pastes per-session so switching
@@ -1843,6 +1906,9 @@ class GenericAgentTUI(App[None]):
             for m in sess.messages:
                 m._role_widget = None
                 m._body_widget = None
+                m._segment_widgets = []
+                m._segment_sig = ()
+                m._spinner_widget = None
             self._last_session_id = sess.agent_id
         for m in sess.messages:
             if m._role_widget is None:
@@ -1857,21 +1923,9 @@ class GenericAgentTUI(App[None]):
         except Exception:
             return 100
 
-    def _build_assistant_body(self, m: ChatMessage):
+    def _render_md(self, text: str, width: int):
         # Markdown via RichVisual loses segment.style.meta["offset"] so mouse selection
         # can't anchor; round-trip through ANSI → Text.from_ansi to restore selectability.
-        width = self._messages_width()
-        key = (len(m.content or ""), m.done, width, self.fold_mode)
-        if m._cache_key == key and m._cached_body is not None:
-            return m._cached_body
-        suffix = "" if m.done else " …"
-        raw = m.content or ""
-        cleaned = _ANSI_CONTROL_RE.sub("", raw)
-        if self.fold_mode:
-            cleaned = render_folded_text(cleaned)
-        text = cleaned + suffix
-        if not raw.strip():
-            return Text(suffix or "（空）", style=C_DIM)
         try:
             from io import StringIO
             from rich.console import Console
@@ -1879,13 +1933,85 @@ class GenericAgentTUI(App[None]):
             Console(file=buf, width=width, force_terminal=True,
                     color_system="truecolor", legacy_windows=False
                     ).print(HardBreakMarkdown(text), end="")
-            body = Text.from_ansi(buf.getvalue().rstrip("\n"))
+            return Text.from_ansi(buf.getvalue().rstrip("\n"))
         except Exception:
-            body = Text(text, style=C_FG)
-        if m.done:  # streaming content keeps changing — only cache final
-            m._cached_body = body
+            return Text(text, style=C_FG)
+
+    def _assistant_segments(self, m: ChatMessage, width: int) -> list[tuple]:
+        """Return [(kind, body, fold_idx_or_None)]. kind ∈ {'text','fold-header','fold-body'}.
+        fold_idx is the position in fold_turns() output — stable across streaming since
+        new turns only append. Last segment carries the streaming suffix."""
+        raw = m.content or ""
+        # Cache final renders — Markdown re-parse on every resize is expensive over long history.
+        key = (len(raw), m.done, width, self.fold_mode, frozenset(m._toggled_folds))
+        if m.done and m._cache_key == key and m._cached_body is not None:
+            return m._cached_body
+        # No streaming suffix here — spinner lives in m._spinner_widget so Markdown
+        # rendering (unclosed code fences, paragraph whitespace stripping) can't eat it.
+        if not raw.strip():
+            return [("text", Text("（空）" if m.done else " ", style=C_DIM), None)]
+        cleaned = _ANSI_CONTROL_RE.sub("", raw)
+        raw_segs = fold_turns(cleaned)
+        out: list[tuple] = []
+        last_i = len(raw_segs) - 1
+        for i, seg in enumerate(raw_segs):
+            if seg["type"] == "fold":
+                # fold_mode=True → default collapsed; False → default expanded. Per-fold
+                # clicks flip the default for that fold via the toggle set.
+                expanded = (not self.fold_mode) ^ (i in m._toggled_folds)
+                arrow = "▾" if expanded else "▸"
+                title = seg.get("title") or "completed turn"
+                header = Text(); header.append(f"{arrow} ", style=C_DIM); header.append(title, style=C_MUTED)
+                out.append(("fold-header", header, i))
+                if expanded:
+                    out.append(("fold-body", self._render_md(seg.get("content", ""), width), i))
+            else:
+                content = _TURN_MARKER_RE.sub("", seg.get("content", ""), count=1)
+                out.append(("text", self._render_md(content, width), None))
+        if m.done:
+            m._cached_body = out
             m._cache_key = key
-        return body
+        return out
+
+    _SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+
+    def _spinner_glyph(self) -> str:
+        return self._SPINNER_FRAMES[self._spinner_frame % len(self._SPINNER_FRAMES)]
+
+    def _has_streaming(self) -> bool:
+        if self.current_id is None:
+            return False
+        return any(m.role == "assistant" and not m.done for m in self.current.messages)
+
+    def _ensure_spinner(self) -> None:
+        # Independent timer keeps frames advancing between chunks (chunks may stall on the
+        # network). Self-stops once no assistant message in the current session is streaming.
+        running = self._has_streaming()
+        if running and self._spinner_timer is None:
+            self._spinner_timer = self.set_interval(0.1, self._spinner_tick)
+        elif not running and self._spinner_timer is not None:
+            self._spinner_timer.stop()
+            self._spinner_timer = None
+            self._spinner_frame = 0
+
+    def _spinner_tick(self) -> None:
+        self._spinner_frame = (self._spinner_frame + 1) % len(self._SPINNER_FRAMES)
+        if self.current_id is None:
+            self._ensure_spinner(); return
+        glyph = Text(self._spinner_glyph(), style=C_DIM)
+        for m in self.current.messages:
+            if m.role == "assistant" and not m.done and m._spinner_widget is not None:
+                try: m._spinner_widget.update(glyph)
+                except Exception: pass
+        if not self._has_streaming():
+            self._ensure_spinner()
+
+    @staticmethod
+    def _segment_sig(segs: list[tuple]) -> tuple:
+        # Topology fingerprint: ignores body content so streaming chunks within the same
+        # last text segment don't invalidate the structure. Used to decide stream-update
+        # (in-place .update of last widget) vs. full remount (when folds appear/expand).
+        return tuple((kind, idx) for kind, _, idx in segs)
 
     _ROLE_COLOR = {"user": C_PURPLE, "system": C_BLUE, "assistant": C_GREEN}
 
@@ -1908,16 +2034,117 @@ class GenericAgentTUI(App[None]):
 
         if m.kind == "choice":  # selected_label is not None
             body = Text(); body.append("✓ ", style=C_GREEN); body.append(m.selected_label, style=C_FG)
-        elif m.role == "user":
+            m._body_widget = SelectableStatic(body, classes="msg")
+            container.mount(m._body_widget)
+            return
+        if m.role == "user":
             body = Text(); body.append("> ", style=C_DIM); body.append(m.content, style=C_FG)
             for path in m.image_paths:
                 body.append(f"\n📎 {path}", style=C_MUTED)
-        elif m.role == "system":
-            body = Text(m.content, style=C_MUTED)
-        else:
-            body = self._build_assistant_body(m)
-        m._body_widget = SelectableStatic(body, classes="msg")
-        container.mount(m._body_widget)
+            m._body_widget = SelectableStatic(body, classes="msg")
+            container.mount(m._body_widget)
+            return
+        if m.role == "system":
+            m._body_widget = SelectableStatic(Text(m.content, style=C_MUTED), classes="msg")
+            container.mount(m._body_widget)
+            return
+        # assistant — multi-segment for per-fold click-to-expand
+        segs = self._assistant_segments(m, self._messages_width())
+        self._mount_assistant_segments(container, m, segs)
+
+    def _mount_assistant_segments(self, container, m: ChatMessage, segs: list[tuple],
+                                  after=None) -> None:
+        m._segment_widgets = []
+        last_text = None
+        anchor = after
+        for kind, body, fold_idx in segs:
+            if kind == "fold-header":
+                w = FoldHeader(body, m, fold_idx, classes="msg fold-header")
+            else:
+                w = SelectableStatic(body, classes="msg")
+            if anchor is None:
+                container.mount(w)
+            else:
+                container.mount(w, after=anchor)
+                anchor = w
+            m._segment_widgets.append(w)
+            if kind == "text":
+                last_text = w
+        m._body_widget = last_text  # keeps existing streaming `.update()` paths working
+        m._segment_sig = self._segment_sig(segs)
+        self._sync_spinner_widget(container, m, anchor)
+
+    def _sync_spinner_widget(self, container, m: ChatMessage, anchor) -> None:
+        """Spinner is a tiny dedicated Static after segment widgets — outside Markdown
+        so unclosed code fences / paragraph trimming can't eat it. Mounted iff streaming."""
+        if m.done:
+            if m._spinner_widget is not None:
+                try: m._spinner_widget.remove()
+                except Exception: pass
+                m._spinner_widget = None
+            return
+        if m._spinner_widget is None:
+            w = Static(Text(self._spinner_glyph(), style=C_DIM), classes="msg spinner")
+            if anchor is None:
+                container.mount(w)
+            else:
+                container.mount(w, after=anchor)
+            m._spinner_widget = w
+
+    def _stream_update_assistant(self, m: ChatMessage) -> None:
+        """Cheap path for per-chunk streaming: if the fold topology is unchanged, only
+        the last text segment got new content, so render and update that one widget.
+        Otherwise (a new Turn marker appeared), do a full remount."""
+        new_sig = self._assistant_sig_only(m)
+        if (new_sig == m._segment_sig and m._segment_widgets
+                and new_sig and new_sig[-1][0] == "text"):
+            width = self._messages_width()
+            raw = m.content or ""
+            cleaned = _ANSI_CONTROL_RE.sub("", raw)
+            last_seg = fold_turns(cleaned)[-1]
+            last_text = _TURN_MARKER_RE.sub("", last_seg.get("content", ""), count=1)
+            m._segment_widgets[-1].update(self._render_md(last_text, width))
+            if m.done and m._spinner_widget is not None:
+                try: m._spinner_widget.remove()
+                except Exception: pass
+                m._spinner_widget = None
+            return
+        self._remount_assistant_message(m)
+
+    def _assistant_sig_only(self, m: ChatMessage) -> tuple:
+        # Topology signature without rendering bodies — used by the streaming fast path.
+        raw = m.content or ""
+        if not raw.strip():
+            return (("text", None),)
+        cleaned = _ANSI_CONTROL_RE.sub("", raw)
+        sig = []
+        for i, seg in enumerate(fold_turns(cleaned)):
+            if seg["type"] == "fold":
+                sig.append(("fold-header", i))
+                if (not self.fold_mode) ^ (i in m._toggled_folds):
+                    sig.append(("fold-body", i))
+            else:
+                sig.append(("text", None))
+        return tuple(sig)
+
+    def _remount_assistant_message(self, m: ChatMessage) -> None:
+        """Rebuild just this message's segments in-place. Used by click-to-expand and
+        by streaming when fold topology changes."""
+        try:
+            container = self.query_one("#messages", VerticalScroll)
+        except Exception:
+            return
+        anchor = m._role_widget
+        for w in m._segment_widgets:
+            try: w.remove()
+            except Exception: pass
+        m._segment_widgets = []
+        if m._spinner_widget is not None:
+            try: m._spinner_widget.remove()
+            except Exception: pass
+            m._spinner_widget = None
+        segs = self._assistant_segments(m, self._messages_width())
+        self._mount_assistant_segments(container, m, segs, after=anchor)
 
 
 # ---------- CLI ----------


### PR DESCRIPTION
- Per-fold click-to-expand: assistant messages render as a sequence of text/fold-header/fold-body widgets; FoldHeader is a clickable Static that toggles m._toggled_folds and remounts just that message
- Ctrl+O is authoritative: clears all per-fold overrides so the state is uniformly all-collapsed or all-expanded
- Streaming spinner: dedicated tiny Static (`m._spinner_widget`) after segment widgets, driven by an independent 100ms timer. Bypasses Markdown completely so unclosed code fences / paragraph whitespace trimming can't eat it
- Hide `**LLM Running (Turn N) ...**` markers at render time only; fold_turns still uses them for splitting
- Ctrl+B sidebar toggle: invalidate width-keyed cache and reuse the resize debounce path so the chat reflows reliably after toggling
- #input min-width: 10 — guards Textual TextArea.render_lines against `range() arg 3 must not be zero` when sidebar is shown on a very narrow window and #main collapses to ≤ 0 cols