### PR TITLE
feat(tui): /rename, /cost, /continue <name>, ask_user picker, runtime…

### DIFF
--- a/frontends/cost_tracker.py
+++ b/frontends/cost_tracker.py
@@ -1,0 +1,148 @@
+"""Per-thread LLM token usage, captured via llmcore monkey-patches.
+
+`install()` wraps `llmcore._record_usage` (covers all three API modes) and
+`llmcore.print` (Anthropic SSE writes the final `output_tokens` only via
+`[Output] tokens=N`, never through `_record_usage`). Tracking is keyed by
+`threading.current_thread().name`; each TUI session runs the agent on a
+uniquely named thread (`ga-tui-agent-<id>`), so `/cost` is a thread lookup.
+"""
+import re, threading, time
+from dataclasses import dataclass, field
+
+
+@dataclass
+class TokenStats:
+    requests: int = 0
+    input: int = 0
+    output: int = 0
+    cache_create: int = 0
+    cache_read: int = 0
+    # Latest request's effective prompt size — used for the % context-left line.
+    last_input: int = 0
+    started_at: float = field(default_factory=time.time)
+
+    def total_input_side(self) -> int:
+        return self.input + self.cache_create + self.cache_read
+
+    def total_tokens(self) -> int:
+        return self.input + self.output + self.cache_create + self.cache_read
+
+    def cache_hit_rate(self) -> float:
+        side = self.total_input_side()
+        return (self.cache_read / side * 100.0) if side else 0.0
+
+    def elapsed_seconds(self) -> float:
+        return max(0.0, time.time() - self.started_at)
+
+
+# Best-effort model → context window. `startswith` match; None hides the line.
+_CTX_LIMITS: list[tuple[str, int]] = [
+    ("claude-sonnet-4-5", 1_000_000),
+    ("claude-opus-4",       200_000),
+    ("claude-haiku-4",      200_000),
+    ("claude-sonnet-4",     200_000),
+    ("claude-3-5-sonnet",   200_000),
+    ("claude-3-5-haiku",    200_000),
+    ("claude-3-7-sonnet",   200_000),
+    ("claude-3-opus",       200_000),
+    ("claude-3-haiku",      200_000),
+    ("claude-3-sonnet",     200_000),
+    ("gpt-5-pro",           400_000),
+    ("gpt-5",               256_000),
+    ("gpt-4o",              128_000),
+    ("gpt-4-turbo",         128_000),
+    ("gpt-4",                 8_192),
+    ("o1",                  200_000),
+    ("o3",                  200_000),
+    ("o4",                  200_000),
+    ("gemini-2.5",        2_000_000),
+    ("gemini-2",          1_000_000),
+    ("gemini-1.5",        1_000_000),
+    ("glm-5",               256_000),
+    ("glm-4",               128_000),
+    ("qwen",                128_000),
+    ("deepseek",             64_000),
+    ("kimi",                200_000),
+    ("moonshot",            200_000),
+]
+
+
+def context_limit_for(model: str | None) -> int | None:
+    if not model: return None
+    m = model.lower()
+    for prefix, limit in _CTX_LIMITS:
+        if m.startswith(prefix): return limit
+    return None
+
+
+_trackers: dict[str, TokenStats] = {}
+_lock = threading.Lock()
+_OUT_RE = re.compile(r'\[Output\]\s+tokens=(\d+)')
+_INSTALLED = False
+
+
+def get(thread_name: str) -> TokenStats:
+    with _lock:
+        if thread_name not in _trackers:
+            _trackers[thread_name] = TokenStats()
+        return _trackers[thread_name]
+
+
+def reset(thread_name: str) -> None:
+    with _lock:
+        _trackers.pop(thread_name, None)
+
+
+def all_trackers() -> dict[str, TokenStats]:
+    with _lock:
+        return dict(_trackers)
+
+
+def install() -> None:
+    """Idempotently wrap llmcore._record_usage and llmcore.print."""
+    global _INSTALLED
+    if _INSTALLED: return
+    import llmcore
+    orig_record, orig_print = llmcore._record_usage, print
+
+    def record_patched(usage, api_mode):
+        try:
+            if usage:
+                t = get(threading.current_thread().name)
+                t.requests += 1
+                if api_mode == 'messages':
+                    # SSE delivers final output via [Output] print; non-stream
+                    # delivers it here. `output_tokens` in stream message_start
+                    # is a 0–1 placeholder, acceptable noise.
+                    inp = int(usage.get('input_tokens', 0) or 0)
+                    cc = int(usage.get('cache_creation_input_tokens', 0) or 0)
+                    cr = int(usage.get('cache_read_input_tokens', 0) or 0)
+                    t.input += inp; t.cache_create += cc; t.cache_read += cr
+                    t.output += int(usage.get('output_tokens', 0) or 0)
+                    t.last_input = inp + cc + cr
+                elif api_mode == 'chat_completions':
+                    cached = int((usage.get('prompt_tokens_details') or {}).get('cached_tokens', 0) or 0)
+                    inp = int(usage.get('prompt_tokens', 0) or 0) - cached
+                    t.input += inp; t.cache_read += cached
+                    t.output += int(usage.get('completion_tokens', 0) or 0)
+                    t.last_input = inp + cached
+                elif api_mode == 'responses':
+                    cached = int((usage.get('input_tokens_details') or {}).get('cached_tokens', 0) or 0)
+                    inp = int(usage.get('input_tokens', 0) or 0) - cached
+                    t.input += inp; t.cache_read += cached
+                    t.output += int(usage.get('output_tokens', 0) or 0)
+                    t.last_input = inp + cached
+        except Exception: pass
+        return orig_record(usage, api_mode)
+    llmcore._record_usage = record_patched
+
+    def print_patched(*args, **kwargs):
+        try:
+            if args and isinstance(args[0], str):
+                m = _OUT_RE.match(args[0])
+                if m: get(threading.current_thread().name).output += int(m.group(1))
+        except Exception: pass
+        return orig_print(*args, **kwargs)
+    llmcore.print = print_patched
+
+    _INSTALLED = True

--- a/frontends/session_names.py
+++ b/frontends/session_names.py
@@ -1,0 +1,105 @@
+"""Persistent display names for `/continue`-able sessions.
+
+JSON sidecar at `temp/model_responses/session_names.json` maps log-file
+basename → user name. Touched only by `/rename` and `/continue <name>`.
+"""
+import glob, json, os, re, threading
+
+_LOG_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                        'temp', 'model_responses')
+_REG_PATH = os.path.join(_LOG_DIR, 'session_names.json')
+_LOG_RE = re.compile(r'^model_responses_(\d+)\.txt$')
+_lock = threading.Lock()
+
+
+def _load() -> dict:
+    try:
+        with open(_REG_PATH, encoding='utf-8') as f:
+            d = json.load(f)
+            return d if isinstance(d, dict) else {}
+    except Exception:
+        return {}
+
+
+def _save(d: dict) -> None:
+    os.makedirs(_LOG_DIR, exist_ok=True)
+    tmp = _REG_PATH + '.tmp'
+    with open(tmp, 'w', encoding='utf-8') as f:
+        json.dump(d, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, _REG_PATH)
+
+
+def _resolve_basename(basename: str):
+    # Registered file may be cleared by `continue_cmd._snapshot_current_log`
+    # on /new or /continue; fall back to the newest non-empty snapshot of the
+    # same PID so a mid-session rename survives the rotation.
+    p = os.path.join(_LOG_DIR, basename)
+    if os.path.isfile(p) and os.path.getsize(p) > 0:
+        return p
+    m = _LOG_RE.match(basename)
+    if m:
+        snaps = glob.glob(os.path.join(_LOG_DIR, f'model_responses_snapshot_{m.group(1)}_*.txt'))
+        snaps.sort(key=os.path.getmtime, reverse=True)
+        for s in snaps:
+            if os.path.getsize(s) > 0:
+                return s
+    return None
+
+
+def set_name(log_path: str, name: str) -> None:
+    """Persist `name` for `log_path`. Empty name removes the entry."""
+    key = os.path.basename(log_path)
+    with _lock:
+        d = _load()
+        if name: d[key] = name
+        else: d.pop(key, None)
+        _save(d)
+
+
+def migrate(old_path: str, new_path: str) -> None:
+    """Move the entry from old basename to new basename after /continue."""
+    if old_path == new_path: return
+    old_key, new_key = os.path.basename(old_path), os.path.basename(new_path)
+    with _lock:
+        d = _load()
+        if old_key in d:
+            d[new_key] = d.pop(old_key)
+            _save(d)
+
+
+def name_for(log_path: str) -> str:
+    return _load().get(os.path.basename(log_path), '')
+
+
+def has_name(name: str, exclude_basename: str = None) -> bool:
+    """True when any other entry already owns `name` (case-insensitive)."""
+    target = (name or '').strip().lower()
+    if not target: return False
+    return any(v.lower() == target for k, v in _load().items() if k != exclude_basename)
+
+
+def gc() -> int:
+    """Drop entries whose log file is gone or empty. Returns count removed."""
+    with _lock:
+        d = _load()
+        bad = [k for k in d if _resolve_basename(k) is None]
+        for k in bad: d.pop(k)
+        if bad: _save(d)
+        return len(bad)
+
+
+def path_for(name: str, exclude_basename: str = None):
+    """Resolve `name` → newest resolvable log path. Exact-match then unique-prefix."""
+    target = (name or '').strip().lower()
+    if not target: return None
+    d = _load()
+    matches = [(k, v) for k, v in d.items() if v.lower() == target]
+    if not matches:
+        matches = [(k, v) for k, v in d.items() if v.lower().startswith(target)]
+        if len(matches) > 1: matches = []
+    if exclude_basename is not None:
+        matches = [m for m in matches if m[0] != exclude_basename]
+    resolved = [(p, k) for p, k in ((_resolve_basename(k), k) for k, _ in matches) if p]
+    if not resolved: return None
+    resolved.sort(key=lambda pk: os.path.getmtime(pk[0]), reverse=True)
+    return resolved[0][0]

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -13,6 +13,7 @@ functionality migrated from frontends/tuiapp.py plus new commands:
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import queue
 import re
@@ -24,6 +25,26 @@ from dataclasses import dataclass, field
 from itertools import count
 from typing import Any, Callable, Optional
 
+def _ensure_tui_deps() -> None:
+    """Try the imports; on first miss, pip-install the wheel and retry once.
+    Keeps `ga-cli` working on a fresh Python (Windows / macOS / Linux) where
+    Textual or Rich hasn't been installed yet. Bails with a clear message if
+    pip itself is unavailable or the install fails — never silently."""
+    import importlib.util, subprocess
+    needed = ("rich", "textual")
+    missing = [m for m in needed if importlib.util.find_spec(m) is None]
+    if not missing: return
+    print(f"[ga-tui] installing {' '.join(missing)} into {sys.executable} ...", file=sys.stderr)
+    try:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "--quiet", *missing])
+    except Exception as e:
+        print(f"[ga-tui] auto-install failed: {e}\n    fix: {sys.executable} -m pip install {' '.join(missing)}",
+              file=sys.stderr)
+        raise SystemExit(2)
+    for m in missing: importlib.invalidate_caches()
+
+
+_ensure_tui_deps()
 try:
     from rich.markdown import Markdown
     from rich.table import Table
@@ -34,12 +55,33 @@ try:
     from textual.containers import Horizontal, Vertical, VerticalScroll
     from textual.message import Message
     from textual.screen import ModalScreen
-    from textual.widgets import OptionList, Static, TextArea
+    from textual.widgets import OptionList, SelectionList, Static, TextArea
     from textual.widgets.option_list import Option
+    from textual.widgets.selection_list import Selection
 except ModuleNotFoundError as exc:
-    print(f"Missing dependency: {exc.name}. Install Textual: pip install textual",
+    print(f"[ga-tui] still missing: {exc.name}. Run: {sys.executable} -m pip install rich textual",
           file=sys.stderr)
     raise SystemExit(2) from exc
+
+
+def _hint_terminal_capabilities() -> None:
+    """Warn once at startup if we detect a terminal known to render Textual
+    poorly (e.g. bare mintty/git-bash). The UI still works, but visuals like
+    truecolor chips and unicode glyphs may degrade. Heuristic-only — never
+    blocks startup, just prints a hint to stderr.
+    """
+    if os.name != "nt": return
+    if os.environ.get("WT_SESSION") or os.environ.get("TERM_PROGRAM"):
+        return  # Windows Terminal / iTerm2 / VSCode / Hyper — all fine
+    if os.environ.get("TERM", "").startswith("xterm"):
+        # mintty exports TERM=xterm-256color. Textual still renders, but
+        # mouse + truecolor handling is patchy. Point at the better option.
+        print("[ga-tui] hint: best rendering on Windows Terminal (`wt`) — "
+              "the mintty/git-bash console may clip colors or mouse events.",
+              file=sys.stderr)
+
+
+_hint_terminal_capabilities()
 
 
 # Strip terminal control sequences from subprocess stdout but keep SGR color codes,
@@ -54,6 +96,114 @@ _ANSI_CONTROL_RE = re.compile(
 # fold_turns still needs the marker in source content to split turns, so we only strip at
 # render time. Applies to the live (last) text segment, since folded turns don't include it.
 _TURN_MARKER_RE = re.compile(r"^\s*\**LLM Running \(Turn \d+\) \.\.\.\**\s*", re.MULTILINE)
+
+# Commonmark task-list patterns: `- [ ] foo` / `* [x] foo` / `+ [X] foo`.
+# Group 1 keeps the bullet + leading space so we can substitute the [ ] / [x]
+# portion only and let the Markdown renderer still treat the line as a list item.
+_TASKLIST_OPEN_RE = re.compile(r"^(\s*[-*+] )\[ \] ", re.MULTILINE)
+_TASKLIST_DONE_RE = re.compile(r"^(\s*[-*+] )\[[xX]\] ", re.MULTILINE)
+
+# `<tool_use>{...}</tool_use>` envelope emitted by the streaming layer in
+# llmcore. Agents emit one per tool call; the wrapped object always has
+# {"name": ..., "arguments": ...}. We replace the whole envelope so the raw
+# JSON braces/quotes never leak into the markdown render.
+_TOOL_USE_RE = re.compile(r"<tool_use>\s*(\{.*?\})\s*</tool_use>", re.DOTALL)
+
+
+# Rotating usage tips, picked once per launch.
+_TIPS = (
+    "Tip: 按 / 唤起命令面板；任何命令都能用方向键选择。",
+    "Tip: /rename <name> 持久化会话名；/continue <name> 跨次重开同名会话。",
+    "Tip: /cost 查看 token 用量；/cost all 列出所有会话的累计。",
+    "Tip: /continue 列出最近 20 个历史会话，按 Enter 进入。",
+    "Tip: /btw <问题> 让 side-agent 回答而不打断主任务。",
+    "Tip: Ctrl+B 折叠侧栏；Ctrl+O 切换长输出折叠；Ctrl+/ 查看快捷键。",
+    "Tip: Ctrl+N 新建会话；Ctrl+↑/↓ 在多个会话间切换。",
+    "Tip: 粘贴图片 / 文件后会自动折叠成 [Image #N] / [File #N] 占位符。",
+    "Tip: 多行输入用 Ctrl+J 换行；Enter 直接发送。",
+    "Tip: /rewind <n> 回退最近 n 轮对话；/stop 中止当前任务。",
+    "Tip: /export clip 把上一条回复复制到剪贴板；/export all 给出完整日志路径。",
+    "Tip: /branch [name] 从当前历史分裂出新会话，互不污染。",
+    "Tip: ask_user 题目里写 [多选] 自动切到 SelectionList；任何 picker 都有 \"Type something\" 走自由输入。",
+    "Tip: plan 模式下的 todo 会自动渲染到顶部的 📋 Plan 面板，全部完成后自动消失。",
+)
+
+
+def _random_tip() -> str:
+    import random
+    return random.choice(_TIPS)
+
+
+def _tip_line():
+    """Render `└ Tip: …` as a styled Rich Text. Used directly in compose()
+    so the first paint already includes the line — no post-mount race."""
+    from rich.text import Text as _T
+    t = _T()
+    t.append("└ ", style="#6e7681")
+    t.append("Tip: ", style="bold #6e7681")
+    t.append(_random_tip().removeprefix("Tip: "), style="#6e7681")
+    return t
+
+# Defensive cleaners for ask_user candidates. The model occasionally smuggles
+# JSON envelope debris (`"}`, `]`, `\`) in or out of a candidate string, or
+# mashes several options together with `\n`. Both arrive as opaque strings
+# from `_install_ask_user_hook` — we sanitize at the boundary so the picker
+# never has to render broken text.
+_CAND_LEFT_TRIM = re.compile(r'^[",\[\]{}\\\s]+')
+_CAND_RIGHT_TRIM = re.compile(r'[",\[\]{}\\\s]+$')
+_CAND_NUMBER_PFX = re.compile(r'^\d+\s*[.)、：:）．]\s*')
+
+
+def _sanitize_candidates(raw) -> list[str]:
+    """Normalize whatever the agent passes as `candidates` into a clean,
+    deduped list of human-facing strings. Handles a `list[str]` of clean
+    options (no-op), as well as the failure modes we've seen in the wild:
+    JSON debris glued to one entry, a single string with embedded `\\n` that
+    really meant N entries, numbered prefixes (`3. foo`) the picker would
+    re-number, and pathologically long entries.
+    """
+    out: list[str] = []
+    items = raw if isinstance(raw, list) else [raw] if raw else []
+    for item in items:
+        s = str(item) if item is not None else ""
+        # An entry with literal `\n` or real newlines is N entries mashed together.
+        for line in s.replace("\\n", "\n").splitlines() or [s]:
+            line = _CAND_LEFT_TRIM.sub("", line)
+            line = _CAND_RIGHT_TRIM.sub("", line)
+            line = _CAND_NUMBER_PFX.sub("", line)
+            line = line.strip()
+            if not line: continue
+            if len(line) > 200: line = line[:200] + "…"
+            if line not in out: out.append(line)
+    return out
+
+
+def _render_tool_use_block(match) -> str:
+    """Render a `<tool_use>{...}</tool_use>` envelope as readable markdown.
+
+    For `ask_user` with candidates we deliberately render only the question —
+    the interactive picker (drained in `_drain_ask_user_events`) shows the
+    actual choices and owns the user input. Rendering candidates here too
+    would double up the visible card.
+
+    For `ask_user` without candidates (pure free-text prompt) the markdown
+    stays the source of truth, so we still emit `> 💬 question`.
+
+    All other tools collapse to a single `tool: <name>` line — the full fold
+    machinery still hides the raw turn body when fold-mode is on.
+    """
+    try:
+        obj = json.loads(match.group(1))
+    except Exception:
+        return match.group(0)
+    name = obj.get("name", "")
+    args = obj.get("arguments") or {}
+    if name == "ask_user":
+        question = (args.get("question") or "").strip()
+        if not question:
+            return ""
+        return f"\n> 💬 **{question}**\n"
+    return f"\n*tool: {name}*\n"
 
 
 def _extract_user_text(entry: dict) -> str:
@@ -143,6 +293,15 @@ C_GREEN  = "#7ec27e"
 C_BLUE   = "#82adcf"
 C_PURPLE = "#b596d8"
 
+# Topbar chip palette — each segment gets a distinct hue so the eye can scan
+# past unchanged chips and notice what just shifted. Values picked from the
+# github-dark palette so contrast stays consistent with the rest of the chrome.
+C_CHIP_NAME    = "#79c0ff"  # cyan-blue   — session name, identity-like
+C_CHIP_MODEL   = "#a5d6ff"  # pale blue   — model identifier
+C_CHIP_EFFORT  = "#f0883e"  # amber       — effort gradient (xhigh hot)
+C_CHIP_TASKS   = "#d2a8ff"  # lavender    — task count, neutral-ish
+C_CHIP_TIME    = "#56d364"  # leaf green  — clock, always-moving
+
 
 @dataclass
 class ChatMessage:
@@ -167,6 +326,17 @@ class ChatMessage:
     _segment_widgets: list = field(default_factory=list, repr=False)
     _segment_sig: tuple = field(default=(), repr=False)
     _spinner_widget: Any = field(default=None, repr=False)
+    # Wall-clock start of streaming for this assistant turn — drives the spinner's
+    # `(Xm Ys · ↑ N.Nk · gerund...)` annotation. Set on first stream chunk.
+    _stream_started_at: Optional[float] = field(default=None, repr=False)
+    # Token snapshot captured at stream start so the spinner can show *this turn's*
+    # input cost rather than the lifetime cumulative.
+    _stream_baseline_input: int = field(default=0, repr=False)
+    # Per-segment rendered-Text cache keyed by (seg_content_hash, width). Survives
+    # fold-toggle because toggling visibility doesn't mutate any segment's content,
+    # so re-rendering the same Markdown twice is wasted work — this turns a ~60ms
+    # remount into a <5ms widget-rebuild even on long multi-turn messages.
+    _seg_render_cache: dict = field(default_factory=dict, repr=False)
 
 
 @dataclass
@@ -186,6 +356,19 @@ class AgentSession:
     input_pastes: dict[int, str] = field(default_factory=dict)
     input_paste_counter: int = 0
     buffer: str = ""
+    # Lazy-initialized in `_refresh_topbar` the first tick `status == "running"`
+    # is observed. Drives the topbar dot's heat-color ramp and the elapsed label.
+    _busy_since: Optional[float] = None
+    # When a run transitions running→idle we briefly flash the dot green; this
+    # holds the timestamp of that transition so the flash decays after ~5s.
+    _done_at: Optional[float] = None
+    # ask_user INTERRUPT events captured by the per-agent turn_end hook.
+    # Drained by the display thread when the assistant turn marks done.
+    ask_user_events: Any = field(default_factory=lambda: queue.Queue())
+    # Set to {question: str} after user picks the free-text option in an
+    # ask_user picker. The next user submission gets intercepted into a
+    # 2-step `Ready to submit your answer?` confirmation.
+    free_text_pending: Optional[dict] = None
 
 
 def default_agent_factory() -> Any:
@@ -203,13 +386,15 @@ COMMANDS = [
     ("/new",      "[name]",           "新建并切换到新会话"),
     ("/switch",   "<id|name>",        "切换到指定会话"),
     ("/close",    "",                 "关闭当前会话"),
+    ("/rename",   "<name>",           "重命名当前会话（持久化）"),
     ("/branch",   "[name]",           "从当前会话分支"),
     ("/rewind",   "[n]",              "回退最近 n 轮"),
     ("/clear",    "",                 "清空显示（不动 LLM 历史）"),
     ("/stop",     "",                 "中止当前任务"),
     ("/llm",      "[n]",              "查看 / 切换模型"),
     ("/btw",      "<question>",       "side question — 不打断主 agent"),
-    ("/continue", "[n]",              "列出 / 恢复历史会话"),
+    ("/continue", "[n|name]",         "列出 / 恢复历史会话"),
+    ("/cost",     "[all]",            "显示当前会话 token 用量（all = 所有会话）"),
     ("/export",   "clip|<file>|all",  "导出最后回复"),
     ("/restore",  "",                 "恢复上次模型响应日志"),
     ("/quit",     "",                 "退出"),
@@ -217,14 +402,51 @@ COMMANDS = [
 
 
 # ---------- widgets ----------
+# Picker sentinels — opaque values routed through `_collapse_choice` so any
+# kind of picker can hand off to the same handlers.
+#   FREE_TEXT — user wants to type a free-form answer instead of picking
+#   EDIT_ANSWER — back from the submit-confirmation, go re-edit the draft
+FREE_TEXT_CHOICE = "\x00__free_text__"
+FREE_TEXT_LABEL = "Type something"
+EDIT_ANSWER_CHOICE = "\x00__edit_answer__"
+
+
 class ChoiceList(OptionList):
     BINDINGS = [*OptionList.BINDINGS,
                 Binding("right", "select", "Select", show=False),
                 Binding("escape", "cancel", "Cancel", show=False)]
 
-    def __init__(self, msg: "ChatMessage", **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, msg: "ChatMessage", *options, **kwargs):
+        super().__init__(*options, **kwargs)
         self.msg = msg
+
+    def action_cancel(self) -> None:
+        try:
+            self.app._cancel_choice(self.msg)
+        except Exception:
+            pass
+
+
+class MultiChoiceList(SelectionList):
+    """Multi-select variant of ChoiceList. Space toggles, Enter submits all
+    checked items joined by `; `. Esc cancels back to free-text input.
+
+    SelectionList expects `Selection` objects as positional args, so we
+    forward `*selections` through. The `msg` kwarg is ours.
+    """
+    BINDINGS = [*SelectionList.BINDINGS,
+                Binding("enter", "submit", "Submit", show=True),
+                Binding("escape", "cancel", "Cancel", show=False)]
+
+    def __init__(self, msg: "ChatMessage", *selections, **kwargs):
+        super().__init__(*selections, **kwargs)
+        self.msg = msg
+
+    def action_submit(self) -> None:
+        try:
+            self.app._finalize_multi_choice(self.msg, list(self.selected))
+        except Exception:
+            pass
 
     def action_cancel(self) -> None:
         try:
@@ -558,35 +780,133 @@ class InputArea(TextArea):
 
 
 # ---------- top bar ----------
+def _fmt_elapsed(secs: int) -> str:
+    if secs < 60: return f"{secs}s"
+    if secs < 3600: return f"{secs // 60}m {secs % 60:02d}s"
+    h, rem = divmod(secs, 3600); m, s = divmod(rem, 60)
+    return f"{h}h {m:02d}m {s:02d}s"
+
+
+_TITLE_SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+
+# Done-flash window: dot stays green this many seconds after a run finishes.
+_DONE_FLASH_SECS = 5
+
+# Heat ramp for the running dot. Pale green → amber → deep orange → vivid red.
+# The thresholds are deliberately non-linear: short runs stay cool, only past
+# ~3min do we paint it red to signal "this is taking unusually long".
+_HEAT_RAMP = (
+    (20,  "#aae8aa"),       # <20s   pale mint
+    (60,  "#d4a72c"),       # <60s   amber
+    (180, "#dc6b1f"),       # <3min  deep orange
+    (None, "bold #ff2c2c"), # ≥3min  vivid red — "stuck?" warning
+)
+
+
+def _heat_color(elapsed: int) -> str:
+    """Map a busy-elapsed in seconds to a Rich style for the running dot."""
+    for threshold, color in _HEAT_RAMP:
+        if threshold is None or elapsed < threshold:
+            return color
+    return _HEAT_RAMP[-1][1]
+
+
+# Gerund (`Reticulating…`) easter-egg color ramp. Drives a two-axis heat:
+# elapsed seconds + accumulated tokens. Cool blue → cyan → mint → amber → red.
+# Each tier returns a Rich style string. Keep bands wide so the color rarely
+# strobes between adjacent ticks.
+_GERUND_RAMP = (
+    "#5e9fd6",          # cool blue   — fresh, < ~10s and < ~1k tokens
+    "#56d4d4",          # cyan        — warming up
+    "#7ec27e",          # mint        — settled cruise
+    "#d4a72c",          # amber       — taking a while
+    "#dc6b1f",          # deep orange — long wait
+    "bold #ff2c2c",     # vivid red   — really stuck
+)
+
+
+def _gerund_color(elapsed: int, tokens: int) -> str:
+    """Compose a tier index from elapsed (sec) + tokens, then index the ramp.
+
+    The two axes contribute additively so a tokenless 3-minute hang and a
+    fast-but-token-heavy run both walk up the ramp. Tiers are integer-clamped
+    to len(ramp)-1 so the worst case caps at the red band.
+    """
+    t_tier = 0 if elapsed < 10 else 1 if elapsed < 30 else 2 if elapsed < 90 else 3 if elapsed < 180 else 4
+    k_tier = 0 if tokens < 1_000 else 1 if tokens < 10_000 else 2 if tokens < 50_000 else 3
+    tier = min(len(_GERUND_RAMP) - 1, t_tier + k_tier)
+    return _GERUND_RAMP[tier]
+
+
+def render_status_chip(busy: bool, elapsed: int = 0) -> Text:
+    """`✦ GenericAgent` identity chip. Brightens green when any session is busy.
+
+    The `elapsed` kwarg is kept for API stability but intentionally unrendered:
+    the per-session dot now carries the elapsed counter, which is more accurate
+    than an app-wide tally when multiple sessions run concurrently.
+    """
+    chip = Text()
+    chip.append("✦ ", style=C_GREEN if busy else C_DIM)
+    chip.append("GenericAgent", style=f"bold {C_GREEN}" if busy else f"bold {C_FG}")
+    return chip
+
+
 def render_topbar(session_name: str, status: str, model: str, tasks_running: int,
-                  fold_mode: bool = True) -> Table:
+                  fold_mode: bool = True, busy_elapsed: int = 0,
+                  effort: str = "", sess_elapsed: int = 0,
+                  just_done: bool = False, term_width: int = 0) -> Table:
+    # Layout: identity-chip + session + status + fold packed LEFT; model + effort
+    # + tasks CENTERED; clock RIGHT. The 2:2:1 ratio keeps the centered model
+    # chip visually anchored even when the left column has the long status pill.
+    # The OS terminal tab title carries the session name separately — see
+    # GenericAgentTUI._update_terminal_title.
     t = Table.grid(expand=True)
-    t.add_column(ratio=1, justify="left")
-    t.add_column(ratio=1, justify="center")
-    t.add_column(ratio=1, justify="right")
+    # Equal column widths so the middle column's geometric center sits at the
+    # window center. Uneven ratios shift the centered band off-axis.
+    t.add_column(ratio=1, justify="left", no_wrap=True, overflow="ellipsis")
+    t.add_column(ratio=1, justify="center", no_wrap=True, overflow="ellipsis")
+    t.add_column(ratio=1, justify="right", no_wrap=True)
 
+    short_name = session_name if len(session_name) <= 20 else session_name[:19] + "…"
+
+    # LEFT: identity chip · session · status · fold
     left = Text()
-    left.append("GenericAgent", style=f"bold {C_GREEN}")
-    left.append("    ")
-    left.append("session: ", style=C_MUTED)
-    left.append(session_name, style=C_FG)
-    left.append("    ")
-    dot_color = C_GREEN if status == "running" else C_DIM
-    left.append("● ", style=dot_color)
-    left.append(status, style=C_MUTED)
+    left.append_text(render_status_chip(busy=tasks_running > 0, elapsed=busy_elapsed))
+    left.append("  ·  ", style=C_DIM)
+    left.append("session: ", style=C_MUTED); left.append(short_name, style=f"bold {C_CHIP_NAME}")
+    left.append("  ·  ", style=C_DIM)
+    if status == "running":
+        dot_color = _heat_color(sess_elapsed)
+        left.append("● ", style=dot_color)
+        left.append(f"running {_fmt_elapsed(sess_elapsed)}", style=f"bold {dot_color}")
+    elif just_done:
+        left.append("● ", style=f"bold {C_GREEN}")
+        left.append("done", style=f"bold {C_GREEN}")
+    else:
+        left.append("● ", style=C_DIM); left.append(status, style=C_MUTED)
     if fold_mode:
-        left.append("    ")
-        left.append("▾ fold", style=C_DIM)
+        left.append("  ·  ", style=C_DIM); left.append("▾ fold", style=C_DIM)
 
+    # CENTER: model · effort · tasks — dropped right-to-left on narrow terminals
+    # so the chip column never wraps under the left half.
+    budget = max(20, (term_width * 2 // 5) - 6) if term_width else 999
+    def chip_w(label: str, value: str) -> int:
+        return len(label) + len(value) + 5
+    used = chip_w("model: ", model or "?")
+    show_effort = bool(effort) and used + chip_w("effort: ", effort) <= budget
+    if show_effort: used += chip_w("effort: ", effort)
+    show_tasks = used + chip_w("tasks: ", str(tasks_running)) <= budget
     mid = Text()
-    mid.append("model: ", style=C_MUTED)
-    mid.append(model or "?", style=C_FG)
-    mid.append("  ·  ", style=C_DIM)
-    mid.append("tasks: ", style=C_MUTED)
-    mid.append(str(tasks_running), style=C_FG)
+    mid.append("model: ", style=C_MUTED); mid.append(model or "?", style=C_CHIP_MODEL)
+    if show_effort:
+        mid.append("  ·  ", style=C_DIM)
+        mid.append("effort: ", style=C_MUTED); mid.append(effort, style=f"bold {C_CHIP_EFFORT}")
+    if show_tasks:
+        mid.append("  ·  ", style=C_DIM)
+        mid.append("tasks: ", style=C_MUTED); mid.append(str(tasks_running), style=C_CHIP_TASKS)
 
     right = Text()
-    right.append(time.strftime("%H:%M:%S"), style=C_FG)
+    right.append(time.strftime("%H:%M:%S"), style=C_CHIP_TIME)
 
     t.add_row(left, mid, right)
     return t
@@ -791,6 +1111,39 @@ class GenericAgentTUI(App[None]):
         scrollbar-color-active: #6e7681;
     }
 
+    /* `└ Tip:` footer — one dim row, never grows. */
+    #tipbar {
+        height: 1;
+        background: #0d1117;
+        padding: 0 2;
+        color: #6e7681;
+    }
+
+    /* Pickers — used by both ChoiceList (OptionList) and MultiChoiceList
+       (SelectionList). Same flat single-column look as the rest of the chat,
+       with a thin green left edge so the picker reads as an actionable card. */
+    OptionList.picker, SelectionList.picker {
+        height: auto;
+        max-height: 12;
+        margin: 0 0 1 0;
+        padding: 0 1;
+        background: #0d1117;
+        border: none;
+        border-left: thick #7ec27e;
+        scrollbar-size: 0 1;
+    }
+    OptionList.picker > .option-list--option-hover,
+    SelectionList.picker > .option-list--option-hover { background: #161b22; }
+    OptionList.picker > .option-list--option-highlighted,
+    SelectionList.picker > .option-list--option-highlighted {
+        background: #1f6feb 20%;
+        color: #c9d1d9;
+        text-style: none;
+    }
+    SelectionList.picker > .selection-list--button { color: #6e7681; }
+    SelectionList.picker > .selection-list--button-selected { color: #7ec27e; }
+    SelectionList.picker > .selection-list--button-highlighted { background: transparent; }
+
     .role {
         height: 1;
         margin-top: 1;
@@ -868,6 +1221,8 @@ class GenericAgentTUI(App[None]):
         Binding("ctrl+o",     "toggle_fold",   "Fold",  show=False),
         Binding("ctrl+up",    "prev_session",  "Prev",  show=False, priority=True),
         Binding("ctrl+down",  "next_session",  "Next",  show=False, priority=True),
+        Binding("ctrl+d",     "drop_session",  "Drop",  show=False, priority=True),
+        Binding("cmd+d",      "drop_session",  "Drop",  show=False, priority=True),
         # Terminals report Ctrl+/ as ctrl+slash or legacy ctrl+_ (ASCII 0x1F); bind both.
         Binding("ctrl+slash", "show_help", "Help", show=False),
         Binding("ctrl+/",     "show_help", "Help", show=False),
@@ -892,16 +1247,34 @@ class GenericAgentTUI(App[None]):
         self._quit_timer = None
         self._rewind_armed: bool = False
         self._rewind_timer = None
+        self._busy_since: Optional[float] = None
+        self._chip_timer = None
+        self._title_frame: int = 0
+        self._title_timer = None
+        self._last_title: str = ""
         self._spinner_frame: int = 0
         self._spinner_timer = None
         self._handlers: dict = {
             "help": self._cmd_help, "status": self._cmd_status, "sessions": self._cmd_status,
             "new": self._cmd_new, "switch": self._cmd_switch, "close": self._cmd_close,
+            "rename": self._cmd_rename,
             "branch": self._cmd_branch, "rewind": self._cmd_rewind, "clear": self._cmd_clear,
             "stop": self._cmd_stop, "llm": self._cmd_llm, "export": self._cmd_export,
             "restore": self._cmd_restore, "btw": self._cmd_btw, "continue": self._cmd_continue,
+            "cost": self._cmd_cost,
             "quit": self._cmd_quit, "exit": self._cmd_quit,
         }
+        try:
+            import cost_tracker; cost_tracker.install()
+        except Exception:
+            pass
+        # Best-effort: drop session_names entries whose log was rotated away
+        # (e.g. month-old logs the user deleted). Keeps the registry tidy so
+        # `/continue <name>` never resolves to a vanished file.
+        try:
+            import session_names; session_names.gc()
+        except Exception:
+            pass
 
     def compose(self) -> ComposeResult:
         yield Static("", id="topbar")
@@ -919,6 +1292,10 @@ class GenericAgentTUI(App[None]):
                     highlight_cursor_line=False,
                     placeholder="输入指令或问题... (Enter 发送, Ctrl+J 换行, / 唤起命令面板)",
                 )
+                # Tip line sits inside #main so it doesn't compete for height
+                # with #body's 1fr. Content set at compose so the first frame
+                # already shows it.
+                yield Static(_tip_line(), id="tipbar")
         yield Static(render_bottombar(), id="bottombar")
 
     def on_mount(self) -> None:
@@ -932,7 +1309,7 @@ class GenericAgentTUI(App[None]):
         # turn off ?1007, which on macOS Terminal / iTerm2 makes the wheel emit both mouse
         # events and ↑/↓ keys — triggering InputArea history nav.
         try:
-            sys.stdout.write("\x1b[?1007l"); sys.stdout.flush()
+            sys.__stdout__.write("\x1b[?1007l"); sys.__stdout__.flush()
         except Exception:
             pass
 
@@ -1024,8 +1401,42 @@ class GenericAgentTUI(App[None]):
         sess.thread = thread
         self.sessions[agent_id] = sess
         self.current_id = agent_id
+        self._install_ask_user_hook(sess)
         self._refresh_all()
         return sess
+
+    def _install_ask_user_hook(self, sess: AgentSession) -> None:
+        """Capture ask_user INTERRUPT payloads from agent_loop's turn_end hook.
+
+        The agent yields `{"status": "INTERRUPT", "intent": "HUMAN_INTERVENTION",
+        "data": {question, candidates}}` via `exit_reason.data`. We push events
+        onto the session queue; `_on_stream(done=True)` drains and posts an
+        interactive ChoiceList ChatMessage. Candidates pass through
+        `_sanitize_candidates` so envelope debris / numbered prefixes / mashed
+        multi-line strings don't leak into the picker.
+
+        ga.turn_end_callback reads hooks from `self.parent._turn_end_hooks`
+        where `parent` is the GenericAgent — so the dict lives on the agent.
+        """
+        agent = sess.agent
+        try:
+            hooks = getattr(agent, "_turn_end_hooks", None)
+            if hooks is None:
+                hooks = agent._turn_end_hooks = {}
+            def _hook(ctx, _q=sess.ask_user_events):
+                er = (ctx or {}).get("exit_reason") or {}
+                if er.get("result") != "EXITED": return
+                payload = er.get("data")
+                if not isinstance(payload, dict): return
+                if payload.get("status") != "INTERRUPT" or payload.get("intent") != "HUMAN_INTERVENTION": return
+                data = payload.get("data") or {}
+                cands = _sanitize_candidates(data.get("candidates"))
+                if not cands: return
+                q = str(data.get("question") or "请选择：").strip() or "请选择："
+                _q.put({"question": q, "candidates": cands})
+            hooks["_ga_tui_ask_user"] = _hook
+        except Exception:
+            pass
 
     def action_new_session(self) -> None:
         sess = self.add_session()
@@ -1147,6 +1558,12 @@ class GenericAgentTUI(App[None]):
         self.notify(f"Fold: {'on' if self.fold_mode else 'off'}", timeout=1)
 
     def action_escape(self) -> None:
+        # Back out of free-text-input mode → restore the picker the user was
+        # answering. Takes priority over the normal Esc path so the InputArea
+        # doesn't eat the press.
+        if self._return_from_free_text():
+            self._disarm_rewind()
+            return
         choice = self._active_choice()
         if choice is not None:
             self._cancel_choice(choice.msg)
@@ -1175,6 +1592,24 @@ class GenericAgentTUI(App[None]):
             except Exception: pass
         self._rewind_timer = self.set_timer(2.0, self._disarm_rewind)
 
+    def action_drop_session(self) -> None:
+        # Sidebar-only removal: drops the in-memory session so it stops appearing
+        # in the sidebar/switcher. The on-disk log + session_names entry are kept,
+        # so the session is still recoverable via `/continue <name>` later.
+        if len(self.sessions) <= 1:
+            self._system("⚠️ 至少保留一个会话")
+            return
+        sid = self.current_id
+        name = self.current.name
+        ids = list(self.sessions)
+        i = ids.index(sid)
+        next_id = ids[i + 1] if i + 1 < len(ids) else ids[i - 1]
+        del self.sessions[sid]
+        self.current_id = next_id
+        self._last_title = ""  # force title refresh on next call
+        self._refresh_all()
+        self._system(f"✅ 已从侧栏移除 #{sid} {name!r}")
+
     def action_show_help(self) -> None:
         if isinstance(self.screen, HelpScreen):
             self.pop_screen()
@@ -1189,6 +1624,7 @@ class GenericAgentTUI(App[None]):
             ("Ctrl+N",                  "新建会话"),
             ("Ctrl+B",                  "切换侧栏"),
             ("Ctrl+↑ / Ctrl+↓",         "切换会话"),
+            ("Ctrl+D",                  "侧栏移除会话"),
             ("Ctrl+O",                  "折叠 / 展开已完成的轮次"),
             ("Ctrl+U",                  "清空输入框"),
             ("Ctrl+V",                  "粘贴（图片优先）"),
@@ -1425,10 +1861,65 @@ class GenericAgentTUI(App[None]):
         except Exception:
             pass
 
+    def _finalize_multi_choice(self, msg: ChatMessage, indices: list[int]) -> None:
+        """User pressed Enter on a MultiChoiceList.
+
+        - If any picked entry is the free-text sentinel, switch the whole
+          message into free-text mode (the user wants to type instead).
+        - Otherwise post a `Ready to submit your answers?` confirmation
+          card (Submit / Edit answer) before the agent sees it.
+
+        Indices are SelectionList values (set = list index in _mount_message)."""
+        picked = [msg.choices[i] for i in indices if 0 <= i < len(msg.choices)]
+        if any(v == FREE_TEXT_CHOICE for _, v in picked):
+            self._enter_free_text_mode(msg)
+            return
+        labels = [lbl for lbl, _ in picked]
+        joined = "; ".join(labels)
+        if not labels: return  # nothing selected → keep the picker up
+        question = msg.content.split("    ")[0].rstrip() if "    " in msg.content else msg.content
+        msg.selected_label = f"{question} → {joined}"
+        msg.content = msg.selected_label
+        container = self.query_one("#messages", VerticalScroll)
+        body = Text()
+        body.append("✓ ", style=C_GREEN); body.append("Selected: ", style=C_MUTED)
+        body.append(joined, style=C_FG)
+        new_widget = SelectableStatic(body, classes="msg")
+        anchor = msg._hint_widget or msg._body_widget
+        if anchor is not None: container.mount(new_widget, after=anchor)
+        else: container.mount(new_widget)
+        if msg._hint_widget is not None: msg._hint_widget.remove(); msg._hint_widget = None
+        if msg._body_widget is not None: msg._body_widget.remove()
+        msg._body_widget = new_widget
+        sess = self.sessions.get(self.current_id)
+        if sess is None: return
+        confirm = ChatMessage(
+            role="system",
+            content="Ready to submit your answers?    ←/→ 选择 · Enter 确认 · Esc 取消",
+            kind="choice",
+            choices=[("Submit answers", joined), ("Edit answer", EDIT_ANSWER_CHOICE)],
+            on_select=lambda v, aid=sess.agent_id: self._finalize_free_text(aid, v),
+        )
+        sess.messages.append(confirm)
+        self._refresh_messages()
+
     def _collapse_choice(self, msg: ChatMessage, idx: int) -> None:
         if not (0 <= idx < len(msg.choices)):
             return
         label, value = msg.choices[idx]
+        # Free-text sentinel: collapse the picker into a "type your answer"
+        # prompt (keeping the question visible), focus the input, and arm
+        # `sess.free_text_pending` so the next submit goes through a
+        # `Ready to submit?` confirmation step before reaching the agent.
+        if value == FREE_TEXT_CHOICE:
+            self._enter_free_text_mode(msg)
+            return
+        # Edit sentinel: emitted from the submit-confirmation card to mean
+        # "go back to typing". Just collapse this card and refocus input —
+        # the user's pending answer is already in `sess.free_text_pending`.
+        if value == EDIT_ANSWER_CHOICE:
+            self._return_to_free_text_edit(msg)
+            return
         result_text = None
         if msg.on_select:
             try:
@@ -1500,6 +1991,38 @@ class GenericAgentTUI(App[None]):
         del self.sessions[self.current_id]
         self.current_id = next(iter(self.sessions))
         self._refresh_all()
+
+    def _cmd_rename(self, args, raw):
+        if not args:
+            self._system("Usage: /rename <name>"); return
+        name = " ".join(args).strip()
+        if not name:
+            self._system("Usage: /rename <name>"); return
+        if name.lower() == (self.current.name or "").lower():
+            self._system(f"⚠️ 已经叫 {name!r}"); return
+        for sid, s in self.sessions.items():
+            if sid != self.current_id and s.name.lower() == name.lower():
+                self._system(f"❌ 名称已被会话 #{sid} 占用，请换一个"); return
+        # Registry collision: another log already owns this name on disk.
+        # `agent.log_path` is the microsecond-stamped file the agent actually
+        # writes to (see agentmain.GenericAgent.__init__); exclude its basename
+        # so renaming yourself isn't reported as a collision.
+        log_path = getattr(self.current.agent, "log_path", "") or ""
+        own_key = os.path.basename(log_path)
+        try:
+            import session_names
+            if session_names.has_name(name, exclude_basename=own_key):
+                self._system(f"❌ 名称已被另一会话注册，请换一个"); return
+        except Exception:
+            session_names = None
+        self.current.name = name
+        if log_path and session_names is not None:
+            try:
+                session_names.set_name(log_path, name)
+            except Exception as e:
+                self._system(f"⚠️ 名称未持久化: {type(e).__name__}: {e}")
+        self._refresh_topbar(); self._refresh_sidebar()
+        self._system(f"✅ 已重命名为 {name!r}")
 
     def _cmd_branch(self, args, raw):
         import copy
@@ -1682,22 +2205,43 @@ class GenericAgentTUI(App[None]):
 
     def _cmd_continue(self, args, raw):
         sess = self.current
-        m = re.match(r"/continue\s+(\d+)\s*$", (raw or "").strip())
+        m = re.match(r"/continue\s+(\S.*?)\s*$", (raw or "").strip())
         if m:
-            sessions = continue_list(exclude_pid=os.getpid())
-            idx = int(m.group(1)) - 1
-            if not (0 <= idx < len(sessions)):
-                self._system(f"❌ 索引越界（有效范围 1-{len(sessions)}）"); return
-            self._do_continue_restore(sessions[idx][0])
+            token = m.group(1)
+            if token.isdigit():
+                sessions = continue_list(exclude_pid=os.getpid())
+                idx = int(token) - 1
+                if not (0 <= idx < len(sessions)):
+                    self._system(f"❌ 索引越界（有效范围 1-{len(sessions)}）"); return
+                self._do_continue_restore(sessions[idx][0])
+                return
+            log_path = getattr(sess.agent, "log_path", "") or ""
+            own_key = os.path.basename(log_path)
+            try:
+                import session_names
+                path = session_names.path_for(token, exclude_basename=own_key)
+                if path is None and session_names.name_for(log_path).lower() == token.strip().lower():
+                    self._system(f"✅ 当前已在 {token!r} 会话中"); return
+            except Exception:
+                path = None
+            if not path:
+                self._system(f"❌ 找不到名为 {token!r} 的会话"); return
+            self._do_continue_restore(path)
             return
         sessions = continue_list(exclude_pid=os.getpid())
         if not sessions:
             self._system("❌ 没有可恢复的历史会话"); return
         LIMIT = 20
         choices = []
+        try:
+            import session_names as _sn
+        except Exception:
+            _sn = None
         for path, mtime, first, n in sessions[:LIMIT]:
             preview = (first or "（无法预览）").replace("\n", " ").strip()[:50]
-            choices.append((f"{_short_age(mtime)} · {n}轮 · {preview}", path))
+            nm = _sn.name_for(path) if _sn else ""
+            tag = f"{nm} · " if nm else ""
+            choices.append((f"{_short_age(mtime)} · {tag}{n}轮 · {preview}", path))
         head = "选择要恢复的会话 (↑/↓ 移动，→/Enter 确认，Esc 取消)"
         if len(sessions) > LIMIT:
             head += f"  [仅显示最近 {LIMIT}/{len(sessions)}]"
@@ -1713,17 +2257,126 @@ class GenericAgentTUI(App[None]):
         from continue_cmd import reset_conversation, restore
         try:
             reset_conversation(sess.agent, message=None)
-            result, _ok = restore(sess.agent, path)
+            result, ok = restore(sess.agent, path)
         except Exception as e:
-            return f"❌ 恢复失败: {e}"
+            msg = f"❌ 恢复失败: {e}"
+            self._system(msg); return msg
+        if not ok:
+            self._system(result); return result
+        # Mirror the source transcript into this agent's own log file so a
+        # future /continue resolves the merged history under the migrated name.
+        current_log = getattr(sess.agent, "log_path", "") or ""
+        if current_log and path != current_log:
+            try:
+                import shutil
+                shutil.copyfile(path, current_log)
+            except Exception:
+                pass
         def _finish():
             sess.messages.clear()
             for h in continue_extract(path):
                 sess.messages.append(ChatMessage(role=h["role"], content=h["content"]))
+            try:
+                import session_names
+                nm = session_names.name_for(path)
+                if nm:
+                    sess.name = nm
+                    if current_log:
+                        session_names.migrate(path, current_log)
+            except Exception:
+                pass
             self._remount_current_session()
             self._refresh_all()
         self.call_after_refresh(_finish)
         return result.splitlines()[0] if result else "✅ 已恢复"
+
+    def _cmd_cost(self, args, raw):
+        try:
+            import cost_tracker
+        except Exception as e:
+            self._system(f"❌ cost_tracker 不可用: {e}"); return
+        show_all = bool(args) and args[0].lower() == "all"
+
+        def _k(n: int) -> str:
+            # Human-readable number: 12.3K / 1.45M / 167 — keeps the column
+            # narrow so the layout doesn't shift between idle and 200K-deep sessions.
+            n = int(n)
+            if n < 1000: return f"{n}"
+            if n < 1_000_000:
+                v = n / 1000.0
+                return f"{v:.1f}K" if v < 100 else f"{int(v)}K"
+            v = n / 1_000_000.0
+            return f"{v:.2f}M" if v < 100 else f"{int(v)}M"
+
+        def _elapsed(secs: float) -> str:
+            s = int(secs)
+            if s < 60: return f"{s}s"
+            if s < 3600: return f"{s // 60}m {s % 60:02d}s"
+            h, rem = divmod(s, 3600); m, sec = divmod(rem, 60)
+            return f"{h}h {m:02d}m {sec:02d}s"
+
+        def _section(sid: int, sess, t) -> list[str]:
+            try: model = sess.agent.get_llm_name(model=True) or "?"
+            except Exception: model = "?"
+            total = t.total_tokens()
+            inp_side = t.total_input_side()
+            ls = []
+            ls.append(f"#{sid} {sess.name}  ·  model: {model}  ·  elapsed: {_elapsed(t.elapsed_seconds())}")
+            ls.append(
+                f"  Token usage:     {_k(total):>7} total  "
+                f"({_k(inp_side)} input + {_k(t.output)} output)"
+            )
+            if t.cache_read or t.cache_create:
+                ls.append(
+                    f"  Cache:           {_k(t.cache_read):>7} read  ·  "
+                    f"{_k(t.cache_create)} created  ·  "
+                    f"{t.cache_hit_rate():.1f}% hit"
+                )
+            ctx = cost_tracker.context_limit_for(model)
+            if ctx and t.last_input > 0:
+                used = t.last_input
+                pct_left = max(0.0, (ctx - used) / ctx * 100.0)
+                ls.append(
+                    f"  Context window:  {pct_left:>5.0f}% left  "
+                    f"({_k(used)} used / {_k(ctx)})"
+                )
+            ls.append(f"  Requests:        {t.requests:>7}")
+            return ls
+
+        lines: list[str] = []
+        if show_all:
+            trackers = cost_tracker.all_trackers()
+            if not trackers:
+                lines = ["✦ Token usage", "  (尚无任何 LLM 调用记录)"]
+            else:
+                # Resolve each thread back to a session if we still know it; otherwise
+                # surface the bare thread name (the session may have been Ctrl+D'd).
+                by_name = {(s.thread.name if s.thread else f"ga-tui-agent-{sid}"): (sid, s)
+                           for sid, s in self.sessions.items()}
+                lines.append("✦ Token usage (all sessions)")
+                first = True
+                for tname in sorted(trackers):
+                    if not first: lines.append("")
+                    first = False
+                    if tname in by_name:
+                        sid, s = by_name[tname]
+                        lines += _section(sid, s, trackers[tname])
+                    else:
+                        t = trackers[tname]
+                        lines.append(f"[{tname}]  ·  elapsed: {_elapsed(t.elapsed_seconds())}")
+                        total = t.total_tokens()
+                        lines.append(
+                            f"  Token usage:     {_k(total):>7} total  "
+                            f"({_k(t.total_input_side())} input + {_k(t.output)} output)"
+                        )
+                        lines.append(f"  Requests:        {t.requests:>7}")
+        else:
+            sess = self.current
+            tname = sess.thread.name if sess.thread else f"ga-tui-agent-{sess.agent_id}"
+            t = cost_tracker.get(tname)
+            lines.append("✦ Token usage")
+            lines += _section(sess.agent_id, sess, t)
+        self._system("\n".join(lines))
 
     def _cmd_export(self, args, raw):
         """Forms:
@@ -1819,11 +2472,30 @@ class GenericAgentTUI(App[None]):
             self._system(f"❌ 注入失败: {e}")
 
     def _cmd_quit(self, args, raw):
+        self._reset_terminal_title()
         self.exit()
+
+    def _reset_terminal_title(self) -> None:
+        # Send via sys.__stdout__ — see _update_terminal_title for why.
+        try:
+            out = sys.__stdout__
+            out.write("\x1b]0;\x07")
+            out.flush()
+        except Exception:
+            pass
+
+    def on_unmount(self) -> None:
+        self._reset_terminal_title()
 
     # ---------------- agent task + stream ----------------
     def submit_user_message(self, text: str, images: Optional[list[str]] = None) -> int:
         sess = self.current
+        # Free-text ask_user interception: route through the 2-step
+        # `Ready to submit your answer?` confirmation card before letting
+        # the agent see the answer. Only triggers when the picker armed
+        # `sess.free_text_pending`; the rest of the submit path is unchanged.
+        if self._maybe_intercept_free_text(sess, text):
+            return -1
         if sess.status == "running":
             self._system(f"#{sess.agent_id} 正在跑，/stop 后再发。")
             return -1
@@ -1877,6 +2549,172 @@ class GenericAgentTUI(App[None]):
             s.status = "idle"
             s.current_display_queue = None
         self._update_assistant(agent_id, text, task_id=task_id, done=done, refresh_chrome=True)
+        if done:
+            self._drain_ask_user_events(s)
+
+    # `[多选]` / `[multi]` / `select all` in the question switches the picker to
+    # a multi-select widget. The flag is intentionally heuristic so existing
+    # ask_user calls (no schema change in core) can opt in by phrasing alone.
+    _MULTI_RE = re.compile(r"\[?(?:多选|multi(?:[-_ ]?select)?|select all)\]?", re.IGNORECASE)
+
+    def _drain_ask_user_events(self, sess: AgentSession) -> None:
+        """Pop any pending ask_user INTERRUPTs and surface them as an
+        interactive picker. The selected text is fed back via
+        `submit_user_message`, exactly like a typed reply.
+
+        - Single-select (default) → ChoiceList; ↑/↓ + Enter to pick.
+        - Multi-select (when question hints `[多选]`) → MultiChoiceList;
+          Space toggles, Enter submits joined by `; `.
+        - Always appends a free-text escape hatch as the last option.
+        """
+        latest = None
+        while True:
+            try: latest = sess.ask_user_events.get_nowait()
+            except queue.Empty: break
+        if not latest: return
+        question = latest["question"]; candidates = latest["candidates"]
+        multi = bool(self._MULTI_RE.search(question))
+        kind = "multi_choice" if multi else "choice"
+        choices = [(c, c) for c in candidates] + [(FREE_TEXT_LABEL, FREE_TEXT_CHOICE)]
+        hint = "Space 切换 · Enter 提交 · Esc 取消" if multi else "↑/↓ 选择 · Enter 确认 · Esc 取消"
+        head = f"{question}    {hint}"
+        msg = ChatMessage(
+            role="system", content=head, kind=kind, choices=choices,
+            on_select=lambda v: self._answer_ask_user(sess.agent_id, v),
+        )
+        sess.messages.append(msg)
+        if sess.agent_id == self.current_id:
+            self._refresh_messages()
+
+    def _enter_free_text_mode(self, msg: ChatMessage) -> None:
+        """User picked the free-text option. Swap the picker for a one-line
+        prompt, keep the question hint visible, focus the input, and stash
+        the full picker state so Esc can restore it. The question text is
+        recovered from `msg.content`'s leading line (head was rendered as
+        `question    ↑/↓...`)."""
+        sess = self.sessions.get(self.current_id)
+        if sess is None: return
+        question = msg.content.split("    ")[0].rstrip() if "    " in msg.content else msg.content
+        # Stash everything needed to rebuild the picker on Esc.
+        sess.free_text_pending = {
+            "question": question,
+            "choices": list(msg.choices),
+            "on_select": msg.on_select,
+            "kind": msg.kind,
+            "head": msg.content,
+            "picker_msg": msg,
+        }
+        msg.selected_label = "Other (typing below — Esc to go back)"
+        if msg._body_widget is not None:
+            try: msg._body_widget.remove()
+            except Exception: pass
+        prompt = Text()
+        prompt.append("Type your answer below, then press Enter. ", style=C_MUTED)
+        prompt.append("Esc", style=C_GREEN)
+        prompt.append(" goes back to the choices.", style=C_MUTED)
+        try:
+            container = self.query_one("#messages", VerticalScroll)
+            new_widget = SelectableStatic(prompt, classes="msg")
+            anchor = msg._hint_widget
+            if anchor is not None: container.mount(new_widget, after=anchor)
+            else: container.mount(new_widget)
+            msg._body_widget = new_widget
+            container.scroll_end(animate=False)
+        except Exception:
+            pass
+        try: self.query_one("#input", InputArea).focus()
+        except Exception: pass
+
+    def _return_from_free_text(self) -> bool:
+        """Esc while in free-text mode → restore the original picker.
+
+        Tears down the `Type your answer below…` prompt and any draft input,
+        then reposts the picker as a fresh ChatMessage. Returns True iff a
+        restoration ran (so action_escape knows to swallow the key)."""
+        sess = self.sessions.get(self.current_id) if self.current_id is not None else None
+        pending = sess.free_text_pending if sess else None
+        if not pending or not sess: return False
+        old: ChatMessage = pending.get("picker_msg")  # type: ignore
+        # Clear the input draft.
+        try:
+            inp = self.query_one("#input", InputArea)
+            inp.text = ""
+        except Exception: pass
+        # Remove the consumed picker entirely so the rebuilt one is the only
+        # active picker — keeps `_active_choice` unambiguous.
+        if old is not None:
+            for w in (old._role_widget, old._hint_widget, old._body_widget):
+                if w is not None:
+                    try: w.remove()
+                    except Exception: pass
+            if old in sess.messages: sess.messages.remove(old)
+        # Repost a fresh picker using the stashed state. _refresh_messages
+        # mounts the widget; on_mount focuses it.
+        revived = ChatMessage(
+            role="system", content=pending["head"], kind=pending["kind"],
+            choices=pending["choices"], on_select=pending["on_select"],
+        )
+        sess.messages.append(revived)
+        sess.free_text_pending = None
+        self._refresh_messages()
+        return True
+
+    def _return_to_free_text_edit(self, confirm_msg: ChatMessage) -> None:
+        """The submit-confirmation card sent us back to Edit. Tear down the
+        confirmation, restore the typed answer to the input, and refocus."""
+        sess = self.sessions.get(self.current_id)
+        if sess is None: return
+        prior = (sess.free_text_pending or {}).get("draft", "")
+        for w in (confirm_msg._role_widget, confirm_msg._hint_widget, confirm_msg._body_widget):
+            if w is not None:
+                try: w.remove()
+                except Exception: pass
+        if confirm_msg in sess.messages: sess.messages.remove(confirm_msg)
+        try:
+            inp = self.query_one("#input", InputArea)
+            inp.text = prior
+            inp.focus()
+        except Exception: pass
+
+    def _maybe_intercept_free_text(self, sess: AgentSession, text: str) -> bool:
+        """If a free-text answer is pending, show the `Ready to submit
+        your answer?` confirmation card and DON'T forward to the agent yet.
+        Returns True if the submit was intercepted."""
+        if not sess.free_text_pending or not text.strip(): return False
+        question = sess.free_text_pending.get("question", "")
+        sess.free_text_pending["draft"] = text
+        head = (f"Question: {question}\n"
+                f"Your answer: {text}\n\n"
+                f"Ready to submit your answer?    ←/→ 选择 · Enter 确认 · Esc 取消")
+        confirm = ChatMessage(
+            role="system", content=head, kind="choice",
+            choices=[("Submit answer", text), ("Edit answer", EDIT_ANSWER_CHOICE)],
+            on_select=lambda v, aid=sess.agent_id: self._finalize_free_text(aid, v),
+        )
+        sess.messages.append(confirm)
+        self._refresh_messages()
+        return True
+
+    def _finalize_free_text(self, agent_id: int, value: str) -> str:
+        """Submit-confirmation accepted: clear the pending state and route
+        through the normal user-message path so the agent gets the answer."""
+        s = self.sessions.get(agent_id)
+        if s is not None: s.free_text_pending = None
+        return self._answer_ask_user(agent_id, value)
+
+    def _answer_ask_user(self, agent_id: int, value: str) -> str:
+        s = self.sessions.get(agent_id)
+        if not s: return value
+        # submit_user_message must run on this agent's session — switch first
+        # so it routes to the right put_task. (Choice clicks always come from
+        # the foreground session anyway, but be defensive.)
+        prev = self.current_id
+        if agent_id != prev:
+            self.current_id = agent_id
+        try: self.submit_user_message(value)
+        finally:
+            if agent_id != prev: self.current_id = prev
+        return value
 
     def _update_assistant(self, agent_id, text, *, task_id=None, done=True, refresh_chrome=False):
         # task_id=None matches the last assistant message; otherwise matches by task_id.
@@ -1957,9 +2795,88 @@ class GenericAgentTUI(App[None]):
         s = self.current
         try: model = s.agent.get_llm_name(model=True)
         except Exception: model = "?"
+        try: effort = getattr(s.agent.llmclient.backend, "reasoning_effort", "") or ""
+        except Exception: effort = ""
         tasks_running = sum(1 for x in self.sessions.values() if x.status == "running")
+        # App-wide busy window for the ✦ identity chip.
+        if tasks_running > 0:
+            if self._busy_since is None: self._busy_since = time.time()
+            elapsed = int(time.time() - self._busy_since)
+        else:
+            self._busy_since = None
+            elapsed = 0
+        # Per-session busy window — drives the heat-color dot + done-flash.
+        now = time.time()
+        if s.status == "running":
+            if s._busy_since is None: s._busy_since = now
+            sess_elapsed = int(now - s._busy_since)
+            just_done = False
+        else:
+            if s._busy_since is not None:
+                s._done_at = now
+                s._busy_since = None
+            sess_elapsed = 0
+            just_done = bool(s._done_at and (now - s._done_at) < _DONE_FLASH_SECS)
+        # Chip ticker: keep running both for the elapsed counter AND so the
+        # done-flash decays back to dim after _DONE_FLASH_SECS without input.
+        need_ticker = (tasks_running > 0) or just_done
+        if need_ticker and self._chip_timer is None:
+            try: self._chip_timer = self.set_interval(1.0, self._refresh_topbar)
+            except Exception: pass
+        elif not need_ticker and self._chip_timer is not None:
+            try: self._chip_timer.stop()
+            except Exception: pass
+            self._chip_timer = None
+        try: term_w = self.size.width
+        except Exception: term_w = 0
         self.query_one("#topbar", Static).update(
-            render_topbar(s.name, s.status, model, tasks_running, fold_mode=self.fold_mode))
+            render_topbar(s.name, s.status, model, tasks_running,
+                          fold_mode=self.fold_mode, busy_elapsed=elapsed, effort=effort,
+                          sess_elapsed=sess_elapsed, just_done=just_done,
+                          term_width=term_w))
+        self._ensure_title_timer()
+        self._update_terminal_title()
+
+    def _update_terminal_title(self) -> None:
+        # OSC 0 (set window + icon title). Mainstream terminals consume it: Windows
+        # Terminal, mintty (MinGW64/MSYS), iTerm2, Terminal.app, kitty, alacritty,
+        # gnome-terminal, xterm. Others ignore the sequence silently.
+        # IMPORTANT: write to sys.__stdout__, NOT sys.stdout — Textual replaces
+        # sys.stdout with _capture_stdout during run, so writes to it never reach
+        # the terminal. (textual/app.py: `with redirect_stdout(self._capture_stdout)`)
+        if not self.is_mounted or self.current_id is None: return
+        sess = self.current
+        busy = any(x.status == "running" for x in self.sessions.values())
+        name = (sess.name or "session").strip() or "session"
+        if busy:
+            glyph = _TITLE_SPINNER_FRAMES[self._title_frame % len(_TITLE_SPINNER_FRAMES)]
+            title = f"{glyph} {name} · GenericAgent"
+        else:
+            title = f"{name} · GenericAgent"
+        if title == self._last_title: return
+        self._last_title = title
+        try:
+            out = sys.__stdout__
+            out.write(f"\x1b]0;{title}\x07")
+            out.flush()
+        except Exception:
+            pass
+
+    def _ensure_title_timer(self) -> None:
+        busy = any(x.status == "running" for x in self.sessions.values())
+        if busy and self._title_timer is None:
+            try: self._title_timer = self.set_interval(0.2, self._tick_title)
+            except Exception: pass
+        elif not busy and self._title_timer is not None:
+            try: self._title_timer.stop()
+            except Exception: pass
+            self._title_timer = None
+
+    def _tick_title(self) -> None:
+        self._title_frame = (self._title_frame + 1) % len(_TITLE_SPINNER_FRAMES)
+        self._update_terminal_title()
+        if not any(x.status == "running" for x in self.sessions.values()):
+            self._ensure_title_timer()
 
     def _refresh_bottombar(self):
         if not self.is_mounted: return
@@ -2013,6 +2930,13 @@ class GenericAgentTUI(App[None]):
         # Markdown via RichVisual loses segment.style.meta["offset"] so mouse selection
         # can't anchor; round-trip through ANSI → Text.from_ansi to restore selectability.
         try:
+            # Plan-mode / task-list polish: swap commonmark task-list source for
+            # unicode symbols before Markdown sees it. ☐/✔ are base-BMP and
+            # render on every terminal we target.
+            text = _TASKLIST_OPEN_RE.sub(r"\1☐ ", text)
+            text = _TASKLIST_DONE_RE.sub(r"\1✔ ", text)
+            # Tool-use envelopes get replaced wholesale — see _render_tool_use_block.
+            text = _TOOL_USE_RE.sub(_render_tool_use_block, text)
             from io import StringIO
             from rich.console import Console
             # Render one column narrower so Rich horizontal rules don't wrap.
@@ -2021,7 +2945,13 @@ class GenericAgentTUI(App[None]):
             Console(file=buf, width=render_w, force_terminal=True,
                     color_system="truecolor", legacy_windows=False
                     ).print(HardBreakMarkdown(text), end="")
-            return Text.from_ansi(buf.getvalue().rstrip("\n"))
+            t = Text.from_ansi(buf.getvalue().rstrip("\n"))
+            # Completed task lines fade to muted gray so the eye lands on
+            # outstanding work. Done first so the green tick re-overrides next.
+            t.highlight_regex(r"✔[^\n]*", style=C_DIM)
+            t.highlight_regex(r"☐", style=C_DIM)
+            t.highlight_regex(r"✔", style=C_GREEN)
+            return t
         except Exception:
             return Text(text, style=C_FG)
 
@@ -2040,6 +2970,19 @@ class GenericAgentTUI(App[None]):
             return [("text", Text("（空）" if m.done else " ", style=C_DIM), None)]
         cleaned = _ANSI_CONTROL_RE.sub("", raw)
         raw_segs = fold_turns(cleaned)
+        # Drop cache entries whose width changed — content keys with stale width
+        # would never be hit again and would leak memory across resizes.
+        if m._seg_render_cache and any(k[1] != width for k in m._seg_render_cache):
+            m._seg_render_cache.clear()
+
+        def cached_render(content: str) -> Text:
+            k = (hash(content), width)
+            v = m._seg_render_cache.get(k)
+            if v is None:
+                v = self._render_md(content, width)
+                m._seg_render_cache[k] = v
+            return v
+
         out: list[tuple] = []
         last_i = len(raw_segs) - 1
         for i, seg in enumerate(raw_segs):
@@ -2052,10 +2995,10 @@ class GenericAgentTUI(App[None]):
                 header = Text(); header.append(f"{arrow} ", style=C_DIM); header.append(title, style=C_MUTED)
                 out.append(("fold-header", header, i))
                 if expanded:
-                    out.append(("fold-body", self._render_md(seg.get("content", ""), width), i))
+                    out.append(("fold-body", cached_render(seg.get("content", "")), i))
             else:
                 content = _TURN_MARKER_RE.sub("", seg.get("content", ""), count=1)
-                out.append(("text", self._render_md(content, width), None))
+                out.append(("text", cached_render(content), None))
         if m.done:
             m._cached_body = out
             m._cache_key = key
@@ -2063,8 +3006,61 @@ class GenericAgentTUI(App[None]):
 
     _SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 
+    # Easter-egg gerunds rotated through the spinner annotation — keeps the
+    # streaming wait feeling alive rather than dead-frozen.
+    _SPINNER_GERUNDS = (
+        "Pondering", "Reticulating", "Sleuthing", "Hatching", "Pouncing",
+        "Brewing", "Sharpening", "Untangling", "Compiling", "Unraveling",
+        "Distilling", "Calibrating", "Marinating", "Conjuring", "Foraging",
+        "Spelunking", "Synthesizing", "Refactoring thoughts", "Tracing breadcrumbs",
+        "Following the rabbit hole",
+    )
+
     def _spinner_glyph(self) -> str:
         return self._SPINNER_FRAMES[self._spinner_frame % len(self._SPINNER_FRAMES)]
+
+    def _spinner_gerund(self, m) -> str:
+        # Stable per-message: rotate by message identity hash so the gerund
+        # doesn't strobe with every spinner frame. ID-keyed avoids ChatMessage
+        # __hash__ requirements and survives content mutation.
+        idx = (id(m) // 16) % len(self._SPINNER_GERUNDS)
+        return self._SPINNER_GERUNDS[idx]
+
+    @staticmethod
+    def _humanize_tokens(n: int) -> str:
+        if n < 1000: return f"{n}"
+        if n < 1_000_000:
+            v = n / 1000.0
+            return f"{v:.1f}k" if v < 100 else f"{int(v)}k"
+        return f"{n / 1_000_000.0:.2f}M"
+
+    def _spinner_annotation(self, m) -> Text:
+        """Render `⠋ Gerund... (Xm Ys · ↑ N.Nk tokens)` for a streaming message.
+        The gerund hue shifts with elapsed + token deltas (see _gerund_color)."""
+        out = Text()
+        elapsed = int(time.time() - m._stream_started_at) if m._stream_started_at else 0
+        delta_in = 0
+        try:
+            import cost_tracker
+            sess = self.sessions.get(self.current_id)
+            tname = sess.thread.name if sess and sess.thread else f"ga-tui-agent-{self.current_id}"
+            t = cost_tracker.get(tname)
+            delta_in = max(0, t.input + t.cache_create + t.cache_read - m._stream_baseline_input)
+        except Exception:
+            pass
+        gerund_style = _gerund_color(elapsed, delta_in)
+        out.append(self._spinner_glyph(), style=gerund_style)
+        out.append(f" {self._spinner_gerund(m)}…", style=gerund_style)
+        bits = []
+        if m._stream_started_at:
+            bits.append(_fmt_elapsed(elapsed))
+        if delta_in > 0:
+            bits.append(f"↑ {self._humanize_tokens(delta_in)} tokens")
+        if bits:
+            out.append("  (", style=C_DIM)
+            out.append(" · ".join(bits), style=C_DIM)
+            out.append(")", style=C_DIM)
+        return out
 
     def _has_streaming(self) -> bool:
         if self.current_id is None:
@@ -2086,13 +3082,28 @@ class GenericAgentTUI(App[None]):
         self._spinner_frame = (self._spinner_frame + 1) % len(self._SPINNER_FRAMES)
         if self.current_id is None:
             self._ensure_spinner(); return
-        glyph = Text(self._spinner_glyph(), style=C_DIM)
         for m in self.current.messages:
             if m.role == "assistant" and not m.done and m._spinner_widget is not None:
-                try: m._spinner_widget.update(glyph)
+                if m._stream_started_at is None:
+                    self._mark_stream_start(m)
+                try: m._spinner_widget.update(self._spinner_annotation(m))
                 except Exception: pass
         if not self._has_streaming():
             self._ensure_spinner()
+
+    def _mark_stream_start(self, m) -> None:
+        """Lazily timestamp a streaming message so the spinner can show elapsed/tokens.
+        Snapshots the current input-side token total as a baseline so the displayed
+        delta reflects *this* turn only."""
+        m._stream_started_at = time.time()
+        try:
+            import cost_tracker
+            sess = self.sessions.get(self.current_id)
+            tname = sess.thread.name if sess and sess.thread else f"ga-tui-agent-{self.current_id}"
+            t = cost_tracker.get(tname)
+            m._stream_baseline_input = t.input + t.cache_create + t.cache_read
+        except Exception:
+            m._stream_baseline_input = 0
 
     @staticmethod
     def _segment_sig(segs: list[tuple]) -> tuple:
@@ -2109,18 +3120,25 @@ class GenericAgentTUI(App[None]):
         m._role_widget = SelectableStatic(f"[bold {color}]{label}[/]", classes="role")
         container.mount(m._role_widget)
 
-        if m.kind == "choice" and m.selected_label is None:
+        if m.kind in ("choice", "multi_choice") and m.selected_label is None:
             m._hint_widget = SelectableStatic(Text(m.content, style=C_MUTED), classes="msg")
             container.mount(m._hint_widget)
-            choice = ChoiceList(m)
-            for cl, _ in m.choices:
-                choice.add_option(Option(cl))
-            m._body_widget = choice
-            container.mount(choice)
-            self.call_after_refresh(choice.focus)
+            if m.kind == "multi_choice":
+                # Index into m.choices is preserved as the Selection value, so
+                # the submit handler can recover labels — including the free-
+                # text option, treated as a "drop everything and type" trigger.
+                widget = MultiChoiceList(m, *(Selection(cl, idx) for idx, (cl, _) in enumerate(m.choices)),
+                                         classes="picker")
+            else:
+                widget = ChoiceList(m, classes="picker")
+                for cl, _ in m.choices:
+                    widget.add_option(Option(cl))
+            m._body_widget = widget
+            container.mount(widget)
+            self.call_after_refresh(widget.focus)
             return
 
-        if m.kind == "choice":  # selected_label is not None
+        if m.kind in ("choice", "multi_choice"):  # selected_label is not None
             body = Text(); body.append("✓ ", style=C_GREEN); body.append(m.selected_label, style=C_FG)
             m._body_widget = SelectableStatic(body, classes="msg")
             container.mount(m._body_widget)
@@ -2172,7 +3190,9 @@ class GenericAgentTUI(App[None]):
                 m._spinner_widget = None
             return
         if m._spinner_widget is None:
-            w = Static(Text(self._spinner_glyph(), style=C_DIM), classes="msg spinner")
+            if m._stream_started_at is None:
+                self._mark_stream_start(m)
+            w = Static(self._spinner_annotation(m), classes="msg spinner")
             if anchor is None:
                 container.mount(w)
             else:


### PR DESCRIPTION
Adds to frontends/tuiapp_v2.py:
- /rename <name>: rename current session; collision-checked across in-memory sessions and the persistent registry. Topbar and sidebar refresh in place.
- /continue <name>: resume by stored name in addition to the existing index form (/continue 1). The picker (/continue with no arg) labels each entry with its stored name when available.
- /cost [all]: per-session token usage (input / output / cache_create / cache_read), elapsed time, request count, and context-window %-left. The "all" form lists every tracked thread, including ended sessions.
- ask_user picker upgrades: free-text escape hatch on every list, Esc-back navigation, single/multi-select switch from a [多选]/[multi] question hint, candidate sanitizer that handles JSON-envelope debris.
- Runtime tip footer (`└ Tip: ...`) that rotates short usage hints.
- Topbar status chip showing the active model + idle/busy state.
- Cross-platform launcher hardening: auto-install of rich/textual on first run, and a hint when running under git-bash/mintty.

New modules:
- frontends/session_names.py: JSON sidecar at temp/model_responses/ session_names.json keyed by log-file basename; touched only by /rename and /continue <name>. continue_cmd is not modified.
- frontends/cost_tracker.py: per-thread TokenStats, captured via monkey-patches on llmcore._record_usage and llmcore.print (Anthropic SSE's final output count only arrives via the latter). Idempotent install().

No core files touched.