### PR TITLE
fix: navigate main window after bridge ready to prevent white screen

### DIFF
--- a/frontends/desktop/src-tauri/src/lib.rs
+++ b/frontends/desktop/src-tauri/src/lib.rs
@@ -196,7 +196,7 @@ fn ensure_bridge_running() {
 }
 
 #[tauri::command]
-fn start_bridge_with_config(python_path: String, project_dir: String) -> Result<(), String> {
+fn start_bridge_with_config(app_handle: tauri::AppHandle, python_path: String, project_dir: String) -> Result<(), String> {
     // Save to settings
     let path = settings_path();
     let obj = serde_json::json!({"python_path": python_path, "project_dir": project_dir});
@@ -222,6 +222,20 @@ fn start_bridge_with_config(python_path: String, project_dir: String) -> Result<
     if !wait_for_port(14168, Duration::from_secs(15)) {
         return Err("Bridge did not become ready within 15s".into());
     }
+
+    // Navigate main window to bridge URL and show it, hide setup
+    if let Some(main_win) = app_handle.get_webview_window("main") {
+        let url = tauri::Url::parse("http://127.0.0.1:14168/").unwrap();
+        let _ = main_win.navigate(url);
+        // Small delay for page to start loading
+        thread::sleep(Duration::from_millis(300));
+        let _ = main_win.show();
+        let _ = main_win.set_focus();
+    }
+    if let Some(setup_win) = app_handle.get_webview_window("setup") {
+        let _ = setup_win.hide();
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Problem
When the setup window starts the bridge, the main window shows a white screen because it was created before the bridge was running and failed to load http://127.0.0.1:14168/.

## Fix
After bridge becomes ready in `start_bridge_with_config`, navigate the main window to reload the bridge URL, then show it and hide the setup window. All window switching logic is now handled on the Rust side.

## Changes
- Added `app_handle: tauri::AppHandle` parameter to `start_bridge_with_config`
- After port ready: navigate main window → show + focus → hide setup window