### PR TITLE
feat(cli): one-line startup banner showing model name

### DIFF
--- a/agentmain.py
+++ b/agentmain.py
@@ -265,6 +265,14 @@ if __name__ == '__main__':
         try: import readline
         except Exception: pass
         agent.inc_out = True
+        if sys.stdout.isatty():
+            try: model = agent.get_llm_name(model=True) or '?'
+            except Exception: model = '?'
+            try:
+                sys.stdout.write(f'\x1b[92m✦\x1b[0m \x1b[1mGenericAgent\x1b[0m '
+                                 f'\x1b[90m· cli · model:\x1b[0m {model}\n')
+                sys.stdout.flush()
+            except Exception: pass
         while True:
             q = input('> ').strip()
             if not q: continue


### PR DESCRIPTION
When `python agentmain.py` is run on a TTY, print a single dim/colored line on entry so the user sees which model the CLI is talking to before typing. No-op on pipes / non-TTY; wrapped in try/except so any rendering error degrades to the prior silent startup.

  ✦ GenericAgent · cli · model: <model-name>