### PR TITLE
Add chrome-tabs-create in tmwd_cdp_bridge

### DIFF
--- a/assets/tmwd_cdp_bridge/background.js
+++ b/assets/tmwd_cdp_bridge/background.js
@@ -21,6 +21,16 @@ async function handleExtMessage(msg, sender) {
   if (msg.cmd === 'batch') return await handleBatch(msg, sender);
   if (msg.cmd === 'tabs') {
     try {
+      if (msg.method === 'create') {
+        const tab = await chrome.tabs.create({
+          url: msg.url,
+          active: msg.active !== undefined ? msg.active : false,
+          index: msg.index,
+          windowId: msg.windowId,
+          openerTabId: msg.openerTabId
+        });
+        return { ok: true, data: { id: tab.id, url: tab.url, title: tab.title } };
+      }
       if (msg.method === 'switch') {
         const tab = await chrome.tabs.update(msg.tabId, { active: true });
         await chrome.windows.update(tab.windowId, { focused: true });

--- a/assets/tmwd_cdp_bridge/content.js
+++ b/assets/tmwd_cdp_bridge/content.js
@@ -35,7 +35,7 @@ async function handle(el) {
     } else if (cmd === 'batch') {
       resp = await chrome.runtime.sendMessage({ cmd: 'batch', commands: req.commands, tabId: req.tabId });
     } else if (cmd === 'tabs') {
-      resp = await chrome.runtime.sendMessage({ cmd: 'tabs', method: req.method, tabId: req.tabId });
+      resp = await chrome.runtime.sendMessage({ cmd: 'tabs', method: req.method, tabId: req.tabId, url: req.url, active: req.active, index: req.index, windowId: req.windowId, openerTabId: req.openerTabId });
     } else {
       resp = { ok: false, error: 'unknown cmd: ' + cmd };
     }


### PR DESCRIPTION
想要不干扰用户浏览器已经打开的浏览页面，就想每次用浏览器都在新开tab页干活，cdp开tab页总是激活浏览器，所以这里增加了稳定的新增tab页的功能，参数 active 控制是否后台打开，可以在后台新开tab页进行浏览。