### PR TITLE
Add standalone in-session review command

### DIFF
--- a/frontends/chatapp_common.py
+++ b/frontends/chatapp_common.py
@@ -14,6 +14,7 @@ HELP_COMMANDS = (
     ("/continue", "列出可恢复会话"),
     ("/continue [n]", "恢复第 n 个会话"),
     ("/btw <q>", "side question — 临时插问主 agent 进展，不打断主线"),
+    ("/review [scope]", "in-session code review; 默认审当前 git diff"),
     ("/llm", "查看当前模型列表"),
     ("/llm [n]", "切换到第 n 个模型"),
 )
@@ -25,6 +26,7 @@ TELEGRAM_MENU_COMMANDS = (
     ("restore", "恢复上次对话历史"),
     ("continue", "列出可恢复会话；/continue n 恢复第 n 个"),
     ("btw", "临时插问主 agent 进展，不打断主线"),
+    ("review", "in-session code review；/review scope 指定范围"),
     ("llm", "查看模型列表；/llm n 切换到指定模型"),
 )
 
@@ -310,6 +312,8 @@ class AgentChatMixin:
         if op == "/btw":
             answer = await asyncio.to_thread(_handle_btw_frontend, self.agent, cmd)
             return await self.send_text(chat_id, answer, **ctx)
+        if op == "/review":
+            return await self.run_agent(chat_id, cmd, **ctx)
         return await self.send_text(chat_id, HELP_TEXT, **ctx)
 
     async def run_agent(self, chat_id, text, **ctx):
@@ -345,3 +349,4 @@ from agentmain import GeneraticAgent as _GA
 from continue_cmd import handle_frontend_command as _handle_continue_frontend, install as _install_continue, reset_conversation as _reset_conversation
 _install_continue(_GA)
 from btw_cmd import handle_frontend_command as _handle_btw_frontend, install as _install_btw; _install_btw(_GA)
+from review_cmd import install as _install_review; _install_review(_GA)

--- a/frontends/review_cmd.py
+++ b/frontends/review_cmd.py
@@ -1,0 +1,81 @@
+"""`/review` 命令:in-session adversarial code reviewer。
+
+用户输入整段作为 user_request 注入 inline prompt;主 agent 在当前 session 内按 prompt
+协议自取审阅范围(用户点名的文件 / git diff)并 echo 报告,不开 subagent、不写落盘文件。
+
+prompt 与 SOP 仅来自 `memory/review_sop/`,作为独立公共入口,不读取其他工作流的私有 prompt。
+"""
+from __future__ import annotations
+import os
+from typing import Optional
+
+CODE_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_PROMPT_DIR = 'review_sop'
+_INLINE_PROMPT_ZH = 'review_inline_prompt.txt'
+_INLINE_PROMPT_EN = 'review_inline_prompt.en.txt'
+_STUB_FALLBACK = (
+    '[/review in-session] (⚠️ prompt 文件缺失: {fpath} → {err})\n\n'
+    '# 本轮用户请求\n{user_request}\n\n'
+    '请按 memory/code_review_principles.md 评审,直接 echo 报告到对话。\n'
+    '不要写 review.md,不要打 [ROUND END]。'
+)
+
+def _render_prompt(user_request: str) -> str:
+    """加载 /review inline prompt 并注入 user_request + ga_root。"""
+    lang = os.environ.get('GA_LANG', '').strip().lower()
+    fname = _INLINE_PROMPT_EN if lang == 'en' else _INLINE_PROMPT_ZH
+    fpath = os.path.join(CODE_ROOT, 'memory', _PROMPT_DIR, fname)
+    ga_root = CODE_ROOT.replace('\\', '/')
+    try:
+        with open(fpath, 'r', encoding='utf-8') as f:
+            return f.read().format(user_request=user_request, ga_root=ga_root)
+    except Exception as e:
+        return _STUB_FALLBACK.format(fpath=fpath, err=e, user_request=user_request)
+
+def _help_text() -> str:
+    return (
+        '**/review 用法**: in-session adversarial code reviewer\n\n'
+        '`/review                  ` # 默认审本次 uncommitted 改动(主 agent 跑 git diff)\n'
+        '`/review <自然语言请求>   ` # 主 agent 按你描述的范围去审\n\n'
+        '例:\n'
+        '  `/review`\n'
+        '  `/review 我刚改了 review_cmd.py 和 tuiapp_v2.py,关注 prompt 注入`\n'
+        '  `/review 审 frontends 目录下所有改过的文件`\n\n'
+        '产出:直接对话 markdown(不写文件、不开 subagent)。\n'
+        '协议: `memory/review_sop/review_inline_prompt.txt` + `memory/code_review_principles.md`'
+    )
+
+_DEFAULT_REQUEST_ZH = '(无具体请求 — 默认审本次 uncommitted 改动:用 code_run 跑 `git diff --stat HEAD` 与 `git diff HEAD`)'
+_DEFAULT_REQUEST_EN = '(no specific request — default to uncommitted diff: run `git diff --stat HEAD` and `git diff HEAD`)'
+_HEADER_ZH = '> 🔍 /review (in-session) → 主 agent 当场审,直接 echo 报告\n\n'
+_HEADER_EN = '> 🔍 /review (in-session) → main agent reviews here, echoes the report inline\n\n'
+
+def handle(agent, body: str, display_queue) -> Optional[str]:
+    """body 是已剥离 `/review` 前缀的纯参数文本(由 install 剥离)。
+    help → 推 done;否则注入 user_request 到 inline prompt return 给主 agent。
+    不发任何 'done' message(否则前端 `if 'done': break + finally:agent.abort` 会干掉主 agent)。
+    """
+    if body in ('help', '?', '-h', '--help'):
+        display_queue.put({'done': _help_text(), 'source': 'system'})
+        return None
+    en = os.environ.get('GA_LANG', '').strip().lower() == 'en'
+    user_request = body or (_DEFAULT_REQUEST_EN if en else _DEFAULT_REQUEST_ZH)
+    header = _HEADER_EN if en else _HEADER_ZH
+    return header + _render_prompt(user_request)
+
+def install(cls):
+    """`/review` 一律接管,前缀剥离在此完成,handle 只接 body(职责单一)。"""
+    orig = cls._handle_slash_cmd
+    if getattr(orig, '_review_patched', False): return
+    def patched(self, raw_query, display_queue):
+        s = (raw_query or '').strip()
+        if s == '/review':
+            body = ''
+        elif s.startswith('/review ') or s.startswith('/review\t'):
+            body = s[len('/review'):].strip()
+        else:
+            return orig(self, raw_query, display_queue)
+        r = handle(self, body, display_queue)
+        return None if r is None else r
+    patched._review_patched = True
+    cls._handle_slash_cmd = patched

--- a/memory/review_sop/review_inline_prompt.en.txt
+++ b/memory/review_sop/review_inline_prompt.en.txt
@@ -1,0 +1,84 @@
+[/review in-session]
+
+# Role & Boundary
+You are the adversarial code reviewer running **in this session**. You do **not** spawn a subagent; continue the conversation here and **echo your report directly into the chat** as the final reply.
+- **Read-only**: do NOT call file_write / file_patch on business code; do NOT promise “I'll fix it next”.
+- **No review.md**: do NOT write a file to disk; do NOT print `[ROUND END]`.
+- **Done after the report**: no further tool calls.
+
+# User request (this round)
+{user_request}
+
+# Workflow (in order)
+
+## Step 1: mandatory reading
+1. `file_read("{ga_root}/memory/code_review_principles.md")` — 15 good-code principles; every finding must map to one.
+2. This `/review` only reads `memory/review_sop/` and `memory/code_review_principles.md`; do not reference other workflow prompts.
+
+## Step 2: lock the review scope
+Resolve the user request by priority:
+1. User named files / dirs explicitly → review those.
+2. User described a task scope → run `git status -s`, `git diff --stat HEAD`, `git diff HEAD`, and `git log --oneline -5` if needed.
+3. Empty / vague request → default to the current uncommitted diff: run `git diff --stat HEAD` and `git diff HEAD`.
+4. If git fails and scope is still unclear → tell the user to provide file paths or a concrete scope in the next `/review`, then stop.
+
+Do not ask for extra confirmation after locking the scope; list the actual scope in the final report.
+
+## Step 3: file_read each reviewed file
+> Split files over 800 lines. Start with diff-touched lines, then surrounding context and callers.
+
+## Step 4: answer Q1-Q4 (adversarial framing)
+- Q1 right approach? Is there a simpler / standard / safer path?
+- Q2 hidden dependencies? What happens if OS, shell, network, concurrency, input, or third-party APIs fail?
+- Q3 edge / hostile input? Empty, huge, encoded, path-like, permission-denied, repeated calls?
+- Q4 failure observability? Are failures explicit, localizable, and reproducible?
+
+## Step 5: list P0-P3 findings
+Each finding must pass the eight false-positive checks:
+1. discrete and localizable; 2. introduced or exposed in scope; 3. not clearly intentional; 4. real affected path; 5. anchored to code/log evidence; 6. no unstated assumptions; 7. author would plausibly fix it; 8. impact matches severity.
+
+Writing rules: why-first, accurate, brief, no large code dumps, explicit trigger scenario, matter-of-fact, immediately graspable, no flattery.
+
+# Severity
+- **P0** blocker: correctness break / data loss / security hole / irreversible failure
+- **P1** high: contract break / user-visible error / likely near-term failure
+- **P2** maintainability: naming / readability / future bug risk, not currently broken
+- **P3** style / micro-optimization / optional improvement
+
+# Output protocol (echo this structure into the chat)
+
+## Scope
+List reviewed files, one path per line.
+
+## Verdict
+PASS / CONDITIONAL / FAIL
+> Rule: any P0 → FAIL; no P0 but ≥ 1 P1 → CONDITIONAL; only P2/P3 or zero finding → PASS.
+
+## Summary
+3-6 prose lines: what you read, overall impression, top 1-2 risks.
+
+## Design Challenge (Q1-Q4)
+- **Q1 right approach**: <evidence>
+- **Q2 hidden dependencies**: <evidence>
+- **Q3 edge / hostile input**: <evidence>
+- **Q4 failure observability**: <evidence>
+
+## Findings (P0 → P3)
+For each finding:
+- **[P0, conf=0.9] file:line-line** title (imperative, ≤ 80 chars)
+  - **Evidence**: code snippet ≤ 5 lines OR file:N-M reference
+  - **Impact**: trigger scenario + consequence (first sentence names scenario/input/env)
+  - **Fix**: directly-actionable patch sketch, ≤ 1 paragraph
+  - **Principle**: maps to code_review_principles #N
+
+## Cross-file notes
+Coupling / naming / state machine / concurrency. `(none)` if nothing.
+
+## Regression tests
+3-5 concrete test points (input / expected / boundary).
+
+# Self-check
+- Every finding passes the false-positive and writing rules
+- `confidence_score` is honest: real bug → ≥ 0.8; uncertain → < 0.5
+- Verdict matches the rule
+- No flattery / opener / goal-paraphrase / promise to fix

--- a/memory/review_sop/review_inline_prompt.txt
+++ b/memory/review_sop/review_inline_prompt.txt
@@ -1,0 +1,84 @@
+[/review in-session]
+
+# 角色与边界
+你是当前 session 内的 adversarial code reviewer。**你不切到独立 subagent**，就在这条对话里继续工作，把审阅报告**直接 echo 到对话**——这就是给用户的最终回答。
+- **只读**：禁止 file_write / file_patch 任何业务代码；禁止承诺“我下面去修”。
+- **不写 review.md**：不要写文件落盘，也不要在末尾打 `[ROUND END]`。
+- **报告输出完即结束**：不再调任何工具。
+
+# 本轮用户请求
+{user_request}
+
+# 工作流（顺序执行）
+
+## 步骤 1：必读底料
+1. file_read("{ga_root}/memory/code_review_principles.md") —— 15 条好代码原则，每条 finding 必须能映射到其中一条。
+2. 本轮 `/review` 只读取 `memory/review_sop/` 与 `memory/code_review_principles.md`，不引用其他工作流 prompt。
+
+## 步骤 2：锁定审阅范围
+按优先级解析“本轮用户请求”：
+1. 用户明确点名文件 / 目录 → 审那些。
+2. 用户描述任务范围 → 用 `code_run` 跑 `git status -s`、`git diff --stat HEAD`、`git diff HEAD`，必要时看 `git log --oneline -5`。
+3. 用户请求为空 / 模糊 → 默认审本次 uncommitted diff：跑 `git diff --stat HEAD` 与 `git diff HEAD`。
+4. git 失败且范围仍不可判定 → 告诉用户“请在下一句 `/review` 塞入文件路径或具体范围”，本轮结束。
+
+锁定范围后不要额外 ask_user；在最终报告的 Scope 中列清楚实际审了什么。
+
+## 步骤 3：逐文件 file_read
+> 800 行以上分段读。优先看 diff 涉及的行，再看上下文与接口调用方。
+
+## 步骤 4：回答 Q1-Q4（对抗性 framing）
+- Q1 是不是对的方法？有没有更简单 / 标准 / 安全的路径？
+- Q2 隐藏依赖？OS、shell、网络、并发、用户输入、第三方 API 任一失效会怎样？
+- Q3 边缘 / 敌意输入？空值、超长、编码、路径、权限、重复调用会怎样？
+- Q4 故障可观测？失败是否显式、可定位、可复现？
+
+## 步骤 5：列 P0-P3 findings
+每条 finding 必须先通过防误报八规则：
+1. 问题是离散、可定位的；2. 是本次范围内引入或暴露的；3. 不是明显有意设计；4. 有真实受影响路径；5. 证据锚定到代码 / 日志；6. 不依赖未说明假设；7. 作者看到会愿意修；8. 影响与 severity 匹配。
+
+措辞规则：why-first、准确、简短、少贴大段代码、明确触发场景、就事论事、一眼可懂、不要奉承。
+
+# Severity 速查
+- **P0** 阻塞：破坏正确性 / 丢数据 / 安全洞 / 不可逆故障
+- **P1** 高危：契约破坏 / 用户可见错误 / 不立即崩但很快出事
+- **P2** 维护性：命名 / 可读性，未来 bug 概率高但当前不破
+- **P3** 风格 / 微优化 / 可选改进
+
+# 输出协议（整段 echo 到对话）
+
+## Scope
+列出本轮审阅的文件清单（一行一个，绝对路径或仓库相对路径）。
+
+## Verdict
+PASS / CONDITIONAL / FAIL
+> 决策规则：任一 P0 → FAIL；无 P0 但 ≥ 1 P1 → CONDITIONAL；仅 P2/P3 或 0 finding → PASS。
+
+## Summary
+3-6 行散文：你看了什么、整体印象、最重要的 1-2 个风险。
+
+## Design Challenge (Q1-Q4)
+- **Q1 是不是对的方法**：<证据>
+- **Q2 隐藏依赖**：<证据>
+- **Q3 边缘 / 敌意输入**：<证据>
+- **Q4 故障可观测**：<证据>
+
+## Findings(P0 → P3 顺序)
+按下面格式列出每条：
+- **[P0, conf=0.9] file:line-line** 标题（动词开头，≤ 80 字）
+  - **Evidence**：代码片段 ≤ 5 行 或 file:N-M 引用
+  - **Impact**：触发场景 + 后果（第一句必带场景 / 输入 / 环境）
+  - **Fix**：可直接照做的修复思路（伪码或 patch），≤ 1 段
+  - **Principle**：对应 code_review_principles 第 N 条
+
+## Cross-file notes
+跨文件耦合 / 命名一致性 / 状态机 / 并发问题。无则 `(none)`。
+
+## Regression tests
+3-5 条具体测试点（输入 / 预期 / 边界）。
+
+# 自检
+- 每条 finding 通过防误报八规则与措辞规则
+- `confidence_score` 老实给：真 bug → ≥ 0.8；拿不准 → < 0.5
+- Verdict 与决策规则一致
+- 没有奉承 / 开场白 / 复述用户目标 / 承诺修复


### PR DESCRIPTION
## Summary
- Add a standalone in-session `/review` command that renders the dedicated review prompt inline.
- Wire `/review` into the frontend slash-command dispatcher without coupling it to the existing multi-stage workflow.
- Include bilingual review prompt assets under `memory/review_sop/`.

## Scope (4 files, +254/-0)
- `frontends/chatapp_common.py` (+5): install `/review` handler at the end so it does not change other slash routing.
- `frontends/review_cmd.py` (+81): standalone command that loads the review prompt and submits it inline (no subprocess, no `review.md`).
- `memory/review_sop/review_inline_prompt.txt` (+84): zh prompt with reviewer principles + JSON schema.
- `memory/review_sop/review_inline_prompt.en.txt` (+84): en prompt mirror.

## Design notes
- Independent from the existing multi-stage workflow; `/review` runs in the current session as an inline reviewer, not as a background goal.
- Read-only review semantics: must not write `review.md`, must not spawn subagents.
- Prompt enforces `code_review_principles.md` and a P0~P3 / severity / fix JSON schema.
- Language selectable via `X_PROMPT_LANG=en`.

## Verification
- `python -m compileall frontends/review_cmd.py frontends/chatapp_common.py` clean.
- Rendered the `/review` prompt and confirmed it carries the user request, git diff context and review principles.
- Exercised slash dispatch: `/review` triggers the inline reviewer; non-matching input is ignored; other slash commands unaffected.
- Diff scope limited to the 4 files listed above (verified via `git diff --name-only upstream/main..HEAD`).
- Ran the inline reviewer against this PR diff: no P0/P1/P2 findings.

## Base / head
- Base: `lsdefine/GenericAgent@main` (`dbb309a`)
- Head: `shenhao-stu/GenericAgent@main` (`66589f7`, contains feature commit `208d791`).