### PR TITLE
docs(review): simplify /review SOP

### DIFF
--- a/memory/review_sop.md
+++ b/memory/review_sop.md
@@ -1,0 +1,33 @@
+# /review SOP
+
+## 何时使用
+
+用户输入 `/review`，或要求"审一下这段改动 / 启用监察者 / code review"时。
+触发后主 agent 在**当前 session** 内对抗审阅指定范围，把报告直接 echo 到对话。
+
+## 启动
+
+```
+/review                  # 默认审本次 uncommitted 改动（主 agent 自跑 git diff 取范围）
+/review <自然语言范围>   # 例：/review 关注 review_cmd.py 的 prompt 注入
+/review help             # 用法
+```
+
+`GA_LANG=en` 切英文 prompt。
+
+## 边界
+
+- 只读：禁止 file_write / file_patch 任何业务代码
+- 不开 subagent、不写 `review.md`、不打 `[ROUND END]`
+- 报告 echo 完即结束，不再调任何工具
+
+## 文件
+
+- 入口：`frontends/review_cmd.py`
+- 执行 prompt：`memory/review_sop/review_inline_prompt.txt` / `.en.txt`
+- 评审原则：`memory/code_review_principles.md`（每条 finding 必须能映射其中一条）
+
+## 输出
+
+Verdict 规则：任一 P0 → `FAIL`；无 P0 但 ≥ 1 P1 → `CONDITIONAL`；否则 `PASS`。
+字段细节（severity / location / evidence / fix / principle / confidence_score）见 `review_inline_prompt.txt`。

--- a/memory/review_sop.md
+++ b/memory/review_sop.md
@@ -1,16 +1,18 @@
-# /review SOP
+# Review Mode SOP
 
 ## 何时使用
 
 用户输入 `/review`，或要求"审一下这段改动 / 启用监察者 / code review"时。
-触发后主 agent 在**当前 session** 内对抗审阅指定范围，把报告直接 echo 到对话。
+主 agent 在**当前 session** 内对抗审阅指定范围，把报告直接 echo 到对话。
+
+`/x` 阶段三由 x_runner 另起一个独立 reviewer subagent，走自己的 prompt（见下表）。两条路径互不混。
 
 ## 启动
 
 ```
 /review                  # 默认审本次 uncommitted 改动（主 agent 自跑 git diff 取范围）
 /review <自然语言范围>   # 例：/review 关注 review_cmd.py 的 prompt 注入
-/review help             # 用法
+/review help
 ```
 
 `GA_LANG=en` 切英文 prompt。
@@ -23,11 +25,14 @@
 
 ## 文件
 
-- 入口：`frontends/review_cmd.py`
-- 执行 prompt：`memory/review_sop/review_inline_prompt.txt` / `.en.txt`
-- 评审原则：`memory/code_review_principles.md`（每条 finding 必须能映射其中一条）
+| 用途 | 路径 |
+|---|---|
+| `/review` 入口 | `frontends/review_cmd.py` |
+| `/review` in-session prompt | `memory/review_sop/review_inline_prompt.txt` / `.en.txt` |
+| `/x` 阶段三 reviewer subagent prompt | `memory/x_sop/review_prompt.txt` / `.en.txt` |
+| 评审原则（每条 finding 必须能映射其一） | `memory/code_review_principles.md` |
 
 ## 输出
 
 Verdict 规则：任一 P0 → `FAIL`；无 P0 但 ≥ 1 P1 → `CONDITIONAL`；否则 `PASS`。
-字段细节（severity / location / evidence / fix / principle / confidence_score）见 `review_inline_prompt.txt`。
+字段细节（severity / location / evidence / fix / principle / confidence_score）见对应 prompt 文件。


### PR DESCRIPTION
## Summary
- Replace the oversized review-mode documentation with a short operational SOP.
- Keep one source of truth: `memory/review_sop.md`.
- Align the SOP with the actual in-session `/review` workflow and prompt files.

## Why
The previous PR text still described an outdated walkthrough/entry-card setup. This replacement PR presents the cleaned review-mode change directly: minimal scope, clear runtime boundaries, and no extra topology/comparison sections.

## Verification
- Closed superseded PR #406.
- Confirmed this branch changes only `memory/review_sop.md`.
- Confirmed the diff is a concise 33-line SOP addition.