### PR TITLE
Improve Feishu topic sessions and long-card output

### DIFF
--- a/agentmain.py
+++ b/agentmain.py
@@ -168,6 +168,70 @@ class GenericAgent:
                 self.task_queue.task_done()
                 if self.handler is not None: self.handler.code_stop_signal.append(1)
 
+
+
+class GenericAgentSession:
+    """One isolated task room inside the same GA installation."""
+    def __init__(self, session_id, metadata=None):
+        self.session_id = session_id
+        self.metadata = metadata or {}
+        self.agent = GeneraticAgent()
+        self.agent.peer_hint = True
+        self.documents = []
+        self.created_at = time.time()
+        self.updated_at = self.created_at
+        threading.Thread(target=self.agent.run, daemon=True).start()
+
+    def touch(self):
+        self.updated_at = time.time()
+
+    def put_task(self, query, source="user", images=None):
+        self.touch()
+        return self.agent.put_task(query, source=source, images=images)
+
+    def abort(self):
+        self.touch()
+        return self.agent.abort()
+
+    def add_document(self, path, name=None):
+        if not path:
+            return
+        self.documents.append({"path": path, "name": name or os.path.basename(path), "time": time.time()})
+        self.touch()
+
+
+class GenericAgentRuntime:
+    """Native multi-session runtime for one GA process."""
+    def __init__(self):
+        self.lock = threading.RLock()
+        self.sessions = {}
+
+    def get_or_create(self, session_id, metadata=None):
+        with self.lock:
+            sess = self.sessions.get(session_id)
+            if sess is None:
+                sess = GenericAgentSession(session_id, metadata=metadata)
+                self.sessions[session_id] = sess
+            elif metadata:
+                sess.metadata.update(metadata)
+                sess.touch()
+            return sess
+
+    def get(self, session_id):
+        with self.lock:
+            return self.sessions.get(session_id)
+
+    def abort(self, session_id):
+        sess = self.get(session_id)
+        if sess:
+            sess.abort()
+            return True
+        return False
+
+    def active_sessions(self):
+        with self.lock:
+            return list(self.sessions.values())
+
 GeneraticAgent = GenericAgent    
 
 if __name__ == '__main__':

--- a/frontends/fsapp.py
+++ b/frontends/fsapp.py
@@ -361,6 +361,10 @@ def send_message(receive_id, content, msg_type="text", use_card=False, receive_i
     return _send_raw(receive_id, content, msg_type, receive_id_type)
 
 
+def _reply_text(message_id, content):
+    return _reply_raw(message_id, json.dumps({"text": content}, ensure_ascii=False), "text", reply_in_thread=True)
+
+
 def update_message(message_id, content):
     return _patch_card(message_id, _card(content))
 
@@ -655,51 +659,81 @@ def handle_message(data):
     open_id = sender.sender_id.open_id
     chat_id = message.chat_id
     if not PUBLIC_ACCESS and open_id not in ALLOWED_USERS:
-        print(f"未授权用户: {open_id}")
+        print(f"\u672a\u6388\u6743\u7528\u6237: {open_id}")
         return
     session, is_new_session = resolve_feishu_session(open_id, chat_id, message)
     user_input, image_paths = _build_user_message(message)
     if not user_input:
-        if chat_id:
-            send_message(chat_id, f"⚠️ 暂不支持处理此类飞书消息：{message.message_type}", receive_id_type="chat_id")
-        else:
-            send_message(open_id, f"⚠️ 暂不支持处理此类飞书消息：{message.message_type}")
+        target = chat_id or open_id
+        target_type = "chat_id" if chat_id else "open_id"
+        send_message(target, f"\u26a0\ufe0f \u6682\u4e0d\u652f\u6301\u5904\u7406\u6b64\u7c7b\u98de\u4e66\u6d88\u606f\uff1a{message.message_type}", receive_id_type=target_type)
         return
-    print(f"收到消息 [{open_id}] ({message.message_type}, {len(image_paths)} images): {user_input[:200]}")
+    print(f"received message [{open_id}] session={session.session_id} ({message.message_type}, {len(image_paths)} images): {user_input[:200]}")
     if message.message_type == "text" and user_input.startswith("/"):
         return handle_command(open_id, user_input, chat_id, session=session)
 
+    task_item = {"user_input": user_input, "image_paths": image_paths, "message_id": message.message_id}
+    with session_lock:
+        active_task = user_tasks.get(session.session_id)
+        if active_task:
+            active_task["queue"].put(task_item)
+            active_task["queued"] = active_task.get("queued", 0) + 1
+            _reply_text(message.message_id, "\u5df2\u653e\u5165\u672c\u8bdd\u9898\u961f\u5217\uff0c\u5f53\u524d\u4efb\u52a1\u5b8c\u6210\u540e\u4f1a\u7ee7\u7eed\u5904\u7406\u3002")
+            return
+        task_state = {"running": True, "queued": 0, "queue": Q.Queue()}
+        user_tasks[session.session_id] = task_state
+
     def run_agent():
-        user_tasks[session.session_id] = {"running": True}
         receive_id = chat_id or open_id
         rid_type = "chat_id" if chat_id else "open_id"
-        done_event = threading.Event()
         hook_key = f"fs_{session.session_id}"
-        card = _TaskCard(receive_id, rid_type, reply_to_message_id=message.message_id if is_new_session else None)
-        card.start()
-        bind_feishu_session_message(session, card.msg_id)
         on_final = lambda raw: _send_generated_files(receive_id, raw, receive_id_type=rid_type)
         agent = session.agent
-        if not hasattr(agent, '_turn_end_hooks'): agent._turn_end_hooks = {}
-        agent._turn_end_hooks[hook_key] = _make_task_hook(card, done_event, on_final)
+        current = task_item
         try:
-            session.put_task(user_input, source="feishu", images=image_paths)
-            start = time.time()
-            while not done_event.wait(timeout=3):
-                if not user_tasks.get(session.session_id, {}).get("running", True):
-                    agent.abort()
-                    card.fail("已停止")
-                    break
-                if time.time() - start > AGENT_TIMEOUT_SEC:
-                    agent.abort()
-                    card.fail("任务超时")
-                    break
-        except Exception as e:
-            traceback.print_exc()
-            card.fail(f"错误: {e}")
+            while current:
+                done_event = threading.Event()
+                reply_to_message_id = current.get("message_id") or session.metadata.get("card_message_id") or session.metadata.get("root_message_id")
+                card = _TaskCard(receive_id, rid_type, reply_to_message_id=reply_to_message_id)
+                card.start()
+                bind_feishu_session_message(session, card.msg_id)
+                if not hasattr(agent, '_turn_end_hooks'):
+                    agent._turn_end_hooks = {}
+                agent._turn_end_hooks[hook_key] = _make_task_hook(card, done_event, on_final)
+                try:
+                    session.put_task(current["user_input"], source="feishu", images=current.get("image_paths") or [])
+                    start_time = time.time()
+                    while not done_event.wait(timeout=3):
+                        if not task_state.get("running", True):
+                            agent.abort()
+                            card.fail("\u5df2\u505c\u6b62")
+                            break
+                        if time.time() - start_time > AGENT_TIMEOUT_SEC:
+                            task_state["running"] = False
+                            agent.abort()
+                            card.fail("\u4efb\u52a1\u8d85\u65f6")
+                            break
+                except Exception as e:
+                    traceback.print_exc()
+                    card.fail(f"\u9519\u8bef: {e}")
+                finally:
+                    agent._turn_end_hooks.pop(hook_key, None)
+
+                with session_lock:
+                    if not task_state.get("running", True):
+                        user_tasks.pop(session.session_id, None)
+                        return
+                    try:
+                        current = task_state["queue"].get_nowait()
+                        task_state["queue"].task_done()
+                        task_state["queued"] = max(0, task_state.get("queued", 1) - 1)
+                    except Q.Empty:
+                        user_tasks.pop(session.session_id, None)
+                        return
         finally:
-            agent._turn_end_hooks.pop(hook_key, None)
-            user_tasks.pop(session.session_id, None)
+            with session_lock:
+                if user_tasks.get(session.session_id) is task_state:
+                    user_tasks.pop(session.session_id, None)
 
     threading.Thread(target=run_agent, daemon=True).start()
 

--- a/frontends/fsapp.py
+++ b/frontends/fsapp.py
@@ -3,7 +3,7 @@ import glob, json, os, queue as Q, re, sys, threading, time
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, PROJECT_ROOT)
 os.chdir(PROJECT_ROOT)
-from agentmain import GeneraticAgent
+from agentmain import GeneraticAgent, GenericAgentRuntime
 from frontends.chatapp_common import format_restore
 from frontends.continue_cmd import handle_frontend_command as handle_continue_frontend, reset_conversation
 from llmcore import mykeys
@@ -235,9 +235,52 @@ ALLOWED_USERS = _to_allowed_set(mykeys.get("fs_allowed_users", []))
 PUBLIC_ACCESS = not ALLOWED_USERS or "*" in ALLOWED_USERS
 AGENT_TIMEOUT_SEC = 900
 
-agent = GeneraticAgent()
-threading.Thread(target=agent.run, daemon=True).start()
+runtime = GenericAgentRuntime()
 client, user_tasks = None, {}
+session_aliases = {}
+session_lock = threading.RLock()
+
+
+def _msg_attr(message, name, default=None):
+    value = getattr(message, name, default)
+    return value if value not in (None, "") else default
+
+
+def _message_thread_ids(message):
+    ids = []
+    for name in ("root_id", "parent_id", "thread_id", "message_id"):
+        value = _msg_attr(message, name)
+        if value and value not in ids:
+            ids.append(value)
+    return ids
+
+
+def _session_key(chat_id, message_id):
+    return f"{chat_id or 'direct'}:{message_id}"
+
+
+def resolve_feishu_session(open_id, chat_id, message):
+    with session_lock:
+        for mid in _message_thread_ids(message):
+            sid = session_aliases.get(_session_key(chat_id, mid))
+            if sid:
+                return runtime.get_or_create(sid, metadata={"open_id": open_id, "chat_id": chat_id}), False
+        root = _msg_attr(message, "root_id") or _msg_attr(message, "parent_id") or message.message_id
+        sid = _session_key(chat_id, root)
+        sess = runtime.get_or_create(sid, metadata={"open_id": open_id, "chat_id": chat_id, "root_message_id": root})
+        for mid in _message_thread_ids(message):
+            session_aliases[_session_key(chat_id, mid)] = sid
+        session_aliases[_session_key(chat_id, root)] = sid
+        return sess, True
+
+
+def bind_feishu_session_message(session, message_id):
+    if not message_id:
+        return
+    chat_id = session.metadata.get("chat_id")
+    with session_lock:
+        session_aliases[_session_key(chat_id, message_id)] = session.session_id
+        session.metadata["card_message_id"] = message_id
 
 
 def create_client():
@@ -588,6 +631,7 @@ def handle_message(data):
     if not PUBLIC_ACCESS and open_id not in ALLOWED_USERS:
         print(f"未授权用户: {open_id}")
         return
+    session, is_new_session = resolve_feishu_session(open_id, chat_id, message)
     user_input, image_paths = _build_user_message(message)
     if not user_input:
         if chat_id:
@@ -597,24 +641,26 @@ def handle_message(data):
         return
     print(f"收到消息 [{open_id}] ({message.message_type}, {len(image_paths)} images): {user_input[:200]}")
     if message.message_type == "text" and user_input.startswith("/"):
-        return handle_command(open_id, user_input, chat_id)
+        return handle_command(open_id, user_input, chat_id, session=session)
 
     def run_agent():
-        user_tasks[open_id] = {"running": True}
+        user_tasks[session.session_id] = {"running": True}
         receive_id = chat_id or open_id
         rid_type = "chat_id" if chat_id else "open_id"
         done_event = threading.Event()
-        hook_key = f"fs_{open_id}"
+        hook_key = f"fs_{session.session_id}"
         card = _TaskCard(receive_id, rid_type)
         card.start()
+        bind_feishu_session_message(session, card.msg_id)
         on_final = lambda raw: _send_generated_files(receive_id, raw, receive_id_type=rid_type)
+        agent = session.agent
         if not hasattr(agent, '_turn_end_hooks'): agent._turn_end_hooks = {}
         agent._turn_end_hooks[hook_key] = _make_task_hook(card, done_event, on_final)
         try:
-            agent.put_task(user_input, source="feishu", images=image_paths)
+            session.put_task(user_input, source="feishu", images=image_paths)
             start = time.time()
             while not done_event.wait(timeout=3):
-                if not user_tasks.get(open_id, {}).get("running", True):
+                if not user_tasks.get(session.session_id, {}).get("running", True):
                     agent.abort()
                     card.fail("已停止")
                     break
@@ -627,12 +673,12 @@ def handle_message(data):
             card.fail(f"错误: {e}")
         finally:
             agent._turn_end_hooks.pop(hook_key, None)
-            user_tasks.pop(open_id, None)
+            user_tasks.pop(session.session_id, None)
 
     threading.Thread(target=run_agent, daemon=True).start()
 
 
-def handle_command(open_id, cmd, chat_id=None):
+def handle_command(open_id, cmd, chat_id=None, session=None):
     def _send_cmd_response(content):
         if chat_id:
             send_message(chat_id, content, receive_id_type="chat_id")
@@ -640,12 +686,15 @@ def handle_command(open_id, cmd, chat_id=None):
             send_message(open_id, content)
     parts = (cmd or "").split()
     op = (parts[0] if parts else "").lower()
+    agent = session.agent if session is not None else None
     if op == "/stop":
-        if open_id in user_tasks:
-            user_tasks[open_id]["running"] = False
-        agent.abort()
+        if session is not None:
+            user_tasks.setdefault(session.session_id, {})["running"] = False
+            agent.abort()
         _send_cmd_response("正在停止...")
     elif op == "/new":
+        if agent is None:
+            return _send_cmd_response("No active session")
         _send_cmd_response(reset_conversation(agent))
     elif op == "/help":
         _send_cmd_response("命令列表:\n/stop - 停止当前任务\n/status - 查看状态\n/llm - 查看当前模型列表\n/llm [n] - 切换到第 n 个模型\n/restore - 恢复上次对话历史\n/continue - 列出可恢复会话\n/continue [n] - 恢复第 n 个会话\n/new - 开启新对话并清空当前上下文\n/help - 显示帮助")
@@ -653,7 +702,7 @@ def handle_command(open_id, cmd, chat_id=None):
         llm = agent.get_llm_name() if agent.llmclient else "未配置"
         _send_cmd_response(f"状态: {'🔴 运行中' if agent.is_running else '🟢 空闲'}\nLLM: [{agent.llm_no}] {llm}")
     elif op == "/llm":
-        if not agent.llmclient:
+        if agent is None or not agent.llmclient:
             return _send_cmd_response("❌ 当前没有可用的 LLM 配置")
         if len(parts) > 1:
             try:
@@ -664,6 +713,8 @@ def handle_command(open_id, cmd, chat_id=None):
         lines = [f"{'→' if cur else '  '} [{i}] {name}" for i, name, cur in agent.list_llms()]
         _send_cmd_response("LLMs:\n" + "\n".join(lines))
     elif op == "/restore":
+        if agent is None:
+            return _send_cmd_response("No active session")
         try:
             restored_info, err = format_restore()
             if err:
@@ -675,6 +726,8 @@ def handle_command(open_id, cmd, chat_id=None):
         except Exception as e:
             _send_cmd_response(f"恢复失败: {e}")
     elif op == "/continue" or cmd.startswith("/continue"):
+        if agent is None:
+            return _send_cmd_response("No active session")
         _send_cmd_response(handle_continue_frontend(agent, cmd))
     else:
         _send_cmd_response(f"未知命令: {cmd}")

--- a/frontends/fsapp.py
+++ b/frontends/fsapp.py
@@ -548,6 +548,54 @@ def _build_step_detail(resp, tool_calls):
     return "\n\n".join(parts)
 
 
+def _section_title(text, index):
+    first = next((line.strip() for line in (text or "").splitlines() if line.strip()), "")
+    first = re.sub(r"^[#>*`\s-]+", "", first).strip()
+    first = re.sub(r"^\d+[.)?]\s*", "", first).strip()
+    return (first[:80] if first else f"Section {index}")
+
+
+def _split_card_sections(text, limit=6000):
+    text = (text or "").strip()
+    if not text:
+        return [("Result", "_(empty)_")]
+    heading_re = re.compile(r"(?m)^(#{1,4}\s+.+|\*\*[^*]{2,100}\*\*\s*)$")
+    matches = list(heading_re.finditer(text))
+    sections = []
+    if matches:
+        for i, match in enumerate(matches):
+            end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+            chunk = text[match.start():end].strip()
+            title = re.sub(r"^[#\s]+", "", match.group(1)).strip(" *")
+            sections.append((title or f"Section {i + 1}", chunk))
+    else:
+        paragraphs = re.split(r"\n\s*\n", text)
+        current, current_len = [], 0
+        for para in paragraphs:
+            para = para.strip()
+            if not para:
+                continue
+            if current and current_len + len(para) + 2 > limit:
+                body = "\n\n".join(current)
+                sections.append((_section_title(body, len(sections) + 1), body))
+                current, current_len = [para], len(para)
+            else:
+                current.append(para)
+                current_len += len(para) + 2
+        if current:
+            body = "\n\n".join(current)
+            sections.append((_section_title(body, len(sections) + 1), body))
+    expanded = []
+    for title, body in sections or [("Result", text)]:
+        body = body.strip()
+        if len(body) <= limit:
+            expanded.append((title, body))
+            continue
+        for offset in range(0, len(body), limit):
+            expanded.append((f"{title} ({offset // limit + 1})", body[offset:offset + limit]))
+    return expanded or [("Result", text)]
+
+
 class _TaskCard:
     """飞书任务卡片：单卡片持续 patch；每步一个独立折叠面板（header 显示 summary，展开看详情）。"""
     _DETAIL_LIMIT = 8000
@@ -565,15 +613,23 @@ class _TaskCard:
         self.turn_base = 1
         self.note = None
 
-    def _step_panel(self, idx, summary, detail):
-        detail = detail or "_(无输出)_"
-        if len(detail) > self._DETAIL_LIMIT:
-            detail = detail[:self._DETAIL_LIMIT] + f"\n\n…(已截断,共 {len(detail)} 字符)"
+    def _panel(self, title, content, limit=None):
+        content = content or "_(empty)_"
+        limit = limit or self._DETAIL_LIMIT
+        if len(content) > limit:
+            content = content[:limit] + f"\n\n... truncated, total {len(content)} chars"
         return {
             "tag": "collapsible_panel", "expanded": False,
-            "header": {"title": {"tag": "plain_text", "content": f"Turn {idx} · {summary}"}},
-            "elements": [{"tag": "markdown", "content": detail}],
+            "header": {"title": {"tag": "plain_text", "content": (title or "Section")[:120]}},
+            "elements": [{"tag": "markdown", "content": content}],
         }
+
+    def _step_panel(self, idx, summary, detail):
+        return self._panel(f"Turn {idx} - {summary}", detail or "_(empty)_", self._DETAIL_LIMIT)
+
+    def _final_panels(self):
+        sections = _split_card_sections(self.final or "_(empty)_", self._FINAL_LIMIT)
+        return [self._panel(title, body, self._FINAL_LIMIT) for title, body in sections]
 
     def _build(self):
         header = f"**{self.status}**"
@@ -585,7 +641,8 @@ class _TaskCard:
         for i, (s, d) in enumerate(self.steps, self.turn_base):
             els.append(self._step_panel(i, s, d))
         if self.final:
-            els += [{"tag": "hr"}, {"tag": "markdown", "content": self.final}]
+            els.append({"tag": "hr"})
+            els.extend(self._final_panels())
         return _card_raw(els)
 
     def _push(self):
@@ -625,14 +682,14 @@ class _TaskCard:
             self._push()
 
     def done(self, text):
-        self.status = "✅ 已完成"
-        self.final = (text or "_(无文本输出)_")[:self._FINAL_LIMIT]
+        self.status = "\u2705 \u5df2\u5b8c\u6210"
+        self.final = text or "_(\u65e0\u6587\u672c\u8f93\u51fa)_"
         ok, limit = self._push()
         if limit:
             self._rollover()
             self.steps = []
             self.turn_base = self.turn_no + 1
-            self.final = (text or "_(无文本输出)_")[:self._FINAL_LIMIT]
+            self.final = text or "_(\u65e0\u6587\u672c\u8f93\u51fa)_"
             self._push()
 
     def fail(self, msg):

--- a/frontends/fsapp.py
+++ b/frontends/fsapp.py
@@ -313,6 +313,27 @@ def _send_raw(receive_id, payload, msg_type, rtype):
     return None
 
 
+
+def _reply_raw(message_id, payload, msg_type, reply_in_thread=True):
+    if not message_id:
+        return None
+    try:
+        body = ReplyMessageRequest.builder().message_id(message_id).request_body(
+            ReplyMessageRequestBody.builder()
+            .msg_type(msg_type)
+            .content(payload)
+            .reply_in_thread(reply_in_thread)
+            .build()
+        ).build()
+        r = client.im.v1.message.reply(body)
+        if r.success():
+            return r.data.message_id if r.data else None
+        print(f"reply failed: {r.code}, {r.msg}")
+    except Exception as e:
+        print(f"[ERROR] _reply_raw network error: {e}")
+    return None
+
+
 def _patch_card(message_id, card_json):
     return _patch_card_result(message_id, card_json)[0]
 
@@ -524,8 +545,9 @@ class _TaskCard:
     _DETAIL_LIMIT = 8000
     _FINAL_LIMIT = 6000
 
-    def __init__(self, receive_id, rid_type):
+    def __init__(self, receive_id, rid_type, reply_to_message_id=None):
         self.rid, self.rtype = receive_id, rid_type
+        self.reply_to_message_id = reply_to_message_id
         self.steps = []          # [(summary, detail), ...]
         self.status = "🤔 思考中..."
         self.final = None
@@ -562,9 +584,13 @@ class _TaskCard:
         card = self._build()
         if self.msg_id:
             return _patch_card_result(self.msg_id, card)
-        else:
-            self.msg_id = _send_raw(self.rid, card, "interactive", self.rtype)
-            return bool(self.msg_id), False
+        if self.reply_to_message_id:
+            self.msg_id = _reply_raw(self.reply_to_message_id, card, "interactive", reply_in_thread=True)
+            if self.msg_id:
+                return True, False
+            self.reply_to_message_id = None
+        self.msg_id = _send_raw(self.rid, card, "interactive", self.rtype)
+        return bool(self.msg_id), False
 
     def _rollover(self):
         self.page_no += 1
@@ -649,7 +675,7 @@ def handle_message(data):
         rid_type = "chat_id" if chat_id else "open_id"
         done_event = threading.Event()
         hook_key = f"fs_{session.session_id}"
-        card = _TaskCard(receive_id, rid_type)
+        card = _TaskCard(receive_id, rid_type, reply_to_message_id=message.message_id if is_new_session else None)
         card.start()
         bind_feishu_session_message(session, card.msg_id)
         on_final = lambda raw: _send_generated_files(receive_id, raw, receive_id_type=rid_type)

--- a/frontends/fsapp.py
+++ b/frontends/fsapp.py
@@ -274,6 +274,10 @@ def resolve_feishu_session(open_id, chat_id, message):
         return sess, True
 
 
+def _session_reply_anchor(session, fallback=None):
+    return session.metadata.get("root_message_id") or session.metadata.get("card_message_id") or fallback
+
+
 def bind_feishu_session_message(session, message_id):
     if not message_id:
         return
@@ -672,13 +676,14 @@ def handle_message(data):
     if message.message_type == "text" and user_input.startswith("/"):
         return handle_command(open_id, user_input, chat_id, session=session)
 
-    task_item = {"user_input": user_input, "image_paths": image_paths, "message_id": message.message_id}
+    reply_anchor = _session_reply_anchor(session, message.message_id)
+    task_item = {"user_input": user_input, "image_paths": image_paths, "message_id": message.message_id, "reply_to_message_id": reply_anchor}
     with session_lock:
         active_task = user_tasks.get(session.session_id)
         if active_task:
             active_task["queue"].put(task_item)
             active_task["queued"] = active_task.get("queued", 0) + 1
-            _reply_text(message.message_id, "\u5df2\u653e\u5165\u672c\u8bdd\u9898\u961f\u5217\uff0c\u5f53\u524d\u4efb\u52a1\u5b8c\u6210\u540e\u4f1a\u7ee7\u7eed\u5904\u7406\u3002")
+            _reply_text(_session_reply_anchor(session, message.message_id), "\u5df2\u653e\u5165\u672c\u8bdd\u9898\u961f\u5217\uff0c\u5f53\u524d\u4efb\u52a1\u5b8c\u6210\u540e\u4f1a\u7ee7\u7eed\u5904\u7406\u3002")
             return
         task_state = {"running": True, "queued": 0, "queue": Q.Queue()}
         user_tasks[session.session_id] = task_state
@@ -693,7 +698,7 @@ def handle_message(data):
         try:
             while current:
                 done_event = threading.Event()
-                reply_to_message_id = current.get("message_id") or session.metadata.get("card_message_id") or session.metadata.get("root_message_id")
+                reply_to_message_id = current.get("reply_to_message_id") or _session_reply_anchor(session, current.get("message_id"))
                 card = _TaskCard(receive_id, rid_type, reply_to_message_id=reply_to_message_id)
                 card.start()
                 bind_feishu_session_message(session, card.msg_id)

--- a/tests/test_feishu_card_sections.py
+++ b/tests/test_feishu_card_sections.py
@@ -1,0 +1,35 @@
+
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "frontends")))
+
+import frontends.fsapp as fsapp
+
+
+class FeishuCardSectionTests(unittest.TestCase):
+    def test_final_output_uses_collapsible_sections(self):
+        card = fsapp._TaskCard("chat-1", "chat_id", reply_to_message_id="root-1")
+        card.final = "# ???\n?????????\n\n# ???\n?????????"
+
+        payload = json.loads(card._build())
+        elements = payload["body"]["elements"]
+        panels = [element for element in elements if element.get("tag") == "collapsible_panel"]
+
+        self.assertEqual(len(panels), 2)
+        self.assertEqual([panel["expanded"] for panel in panels], [False, False])
+        self.assertEqual(panels[0]["header"]["title"]["content"], "???")
+        self.assertEqual(panels[1]["header"]["title"]["content"], "???")
+        self.assertNotIn("?????????", [element.get("content", "") for element in elements if element.get("tag") == "markdown"])
+
+    def test_long_plain_final_output_is_chunked(self):
+        sections = fsapp._split_card_sections("???\n\n" + ("x" * 30) + "\n\n???", limit=20)
+
+        self.assertGreaterEqual(len(sections), 2)
+        self.assertTrue(all(len(body) <= 20 for _, body in sections))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_feishu_session_queue.py
+++ b/tests/test_feishu_session_queue.py
@@ -1,0 +1,135 @@
+
+import json
+import os
+import sys
+import threading
+import time
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "frontends")))
+
+import frontends.fsapp as fsapp
+
+
+class _Obj:
+    pass
+
+
+def _event(message_id, text):
+    data = _Obj()
+    data.event = _Obj()
+    data.event.message = _Obj()
+    data.event.sender = _Obj()
+    data.event.sender.sender_id = _Obj()
+    data.event.sender.sender_id.open_id = "user-1"
+    msg = data.event.message
+    msg.chat_id = "chat-1"
+    msg.message_id = message_id
+    msg.message_type = "text"
+    msg.content = json.dumps({"text": text})
+    msg.root_id = "root-1"
+    msg.parent_id = "root-1"
+    msg.thread_id = "root-1"
+    return data
+
+
+class _FakeAgent:
+    def __init__(self):
+        self._turn_end_hooks = {}
+        self.abort_count = 0
+
+    def abort(self):
+        self.abort_count += 1
+
+
+class _FakeSession:
+    def __init__(self, records):
+        self.session_id = "chat:root-1"
+        self.metadata = {"chat_id": "chat-1", "root_message_id": "root-1"}
+        self.agent = _FakeAgent()
+        self.records = records
+        self.calls = 0
+
+    def put_task(self, query, source="feishu", images=None):
+        self.calls += 1
+        call_no = self.calls
+        self.records.append(("put_task", call_no, query))
+
+        def complete():
+            time.sleep(0.2 if call_no == 1 else 0.02)
+            hook = self.agent._turn_end_hooks.get("fs_chat:root-1")
+            if hook:
+                response = type("Resp", (), {"content": f"final {call_no}"})()
+                hook({"exit_reason": "done", "response": response})
+
+        threading.Thread(target=complete, daemon=True).start()
+        return None
+
+
+class _FakeCard:
+    counter = 0
+
+    def __init__(self, receive_id, rid_type, reply_to_message_id=None):
+        type(self).counter += 1
+        self.msg_id = f"card-{type(self).counter}"
+        self.reply_to_message_id = reply_to_message_id
+        self.records.append(("card_init", self.msg_id, reply_to_message_id))
+
+    def start(self):
+        self.records.append(("card_start", self.msg_id, self.reply_to_message_id))
+
+    def step(self, summary, detail=""):
+        self.records.append(("card_step", self.msg_id, summary))
+
+    def done(self, text):
+        self.records.append(("card_done", self.msg_id, text))
+
+    def fail(self, msg):
+        self.records.append(("card_fail", self.msg_id, msg))
+
+
+class FeishuSessionQueueTests(unittest.TestCase):
+    def setUp(self):
+        self.records = []
+        fsapp.PUBLIC_ACCESS = True
+        fsapp.user_tasks.clear()
+        fsapp.session_aliases.clear()
+        self.session = _FakeSession(self.records)
+        self.originals = {
+            "resolve_feishu_session": fsapp.resolve_feishu_session,
+            "_reply_text": fsapp._reply_text,
+            "_TaskCard": fsapp._TaskCard,
+            "bind_feishu_session_message": fsapp.bind_feishu_session_message,
+            "_send_generated_files": fsapp._send_generated_files,
+        }
+        fsapp.resolve_feishu_session = lambda open_id, chat_id, message: (self.session, self.session.calls == 0)
+        fsapp._reply_text = lambda message_id, content: self.records.append(("ack", message_id, content))
+        fsapp.bind_feishu_session_message = lambda session, message_id: self.records.append(("bind", message_id))
+        fsapp._send_generated_files = lambda *args, **kwargs: None
+        _FakeCard.counter = 0
+        _FakeCard.records = self.records
+        fsapp._TaskCard = _FakeCard
+
+    def tearDown(self):
+        for name, value in self.originals.items():
+            setattr(fsapp, name, value)
+        fsapp.user_tasks.clear()
+        fsapp.session_aliases.clear()
+
+    def test_active_topic_message_waits_for_current_card(self):
+        fsapp.handle_message(_event("msg-1", "first task"))
+        time.sleep(0.05)
+        fsapp.handle_message(_event("msg-2", "second task"))
+        time.sleep(0.5)
+
+        self.assertIn(("ack", "msg-2", "\u5df2\u653e\u5165\u672c\u8bdd\u9898\u961f\u5217\uff0c\u5f53\u524d\u4efb\u52a1\u5b8c\u6210\u540e\u4f1a\u7ee7\u7eed\u5904\u7406\u3002"), self.records)
+        self.assertEqual(
+            [record for record in self.records if record[0] == "put_task"],
+            [("put_task", 1, "first task"), ("put_task", 2, "second task")],
+        )
+        self.assertLess(self.records.index(("card_done", "card-1", "final 1")), self.records.index(("card_start", "card-2", "msg-2")))
+        self.assertEqual([record for record in self.records if record[0] == "card_start"], [("card_start", "card-1", "msg-1"), ("card_start", "card-2", "msg-2")])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_feishu_session_queue.py
+++ b/tests/test_feishu_session_queue.py
@@ -122,13 +122,13 @@ class FeishuSessionQueueTests(unittest.TestCase):
         fsapp.handle_message(_event("msg-2", "second task"))
         time.sleep(0.5)
 
-        self.assertIn(("ack", "msg-2", "\u5df2\u653e\u5165\u672c\u8bdd\u9898\u961f\u5217\uff0c\u5f53\u524d\u4efb\u52a1\u5b8c\u6210\u540e\u4f1a\u7ee7\u7eed\u5904\u7406\u3002"), self.records)
+        self.assertIn(("ack", "root-1", "\u5df2\u653e\u5165\u672c\u8bdd\u9898\u961f\u5217\uff0c\u5f53\u524d\u4efb\u52a1\u5b8c\u6210\u540e\u4f1a\u7ee7\u7eed\u5904\u7406\u3002"), self.records)
         self.assertEqual(
             [record for record in self.records if record[0] == "put_task"],
             [("put_task", 1, "first task"), ("put_task", 2, "second task")],
         )
-        self.assertLess(self.records.index(("card_done", "card-1", "final 1")), self.records.index(("card_start", "card-2", "msg-2")))
-        self.assertEqual([record for record in self.records if record[0] == "card_start"], [("card_start", "card-1", "msg-1"), ("card_start", "card-2", "msg-2")])
+        self.assertLess(self.records.index(("card_done", "card-1", "final 1")), self.records.index(("card_start", "card-2", "root-1")))
+        self.assertEqual([record for record in self.records if record[0] == "card_start"], [("card_start", "card-1", "root-1"), ("card_start", "card-2", "root-1")])
 
 
 if __name__ == "__main__":

--- a/tests/test_multisession_runtime.py
+++ b/tests/test_multisession_runtime.py
@@ -1,0 +1,34 @@
+import os
+import unittest
+
+from agentmain import GenericAgentRuntime
+
+
+class MultiSessionRuntimeTests(unittest.TestCase):
+    def test_runtime_isolates_session_state(self):
+        runtime = GenericAgentRuntime()
+        a = runtime.get_or_create("chat:root-a", metadata={"chat_id": "chat", "root_message_id": "root-a"})
+        b = runtime.get_or_create("chat:root-b", metadata={"chat_id": "chat", "root_message_id": "root-b"})
+
+        self.assertIs(a, runtime.get_or_create("chat:root-a"))
+        self.assertIsNot(a, b)
+
+        a.agent.history.append("A only")
+        b.agent.history.append("B only")
+        a.add_document(__file__)
+
+        self.assertEqual(a.agent.history, ["A only"])
+        self.assertEqual(b.agent.history, ["B only"])
+        self.assertEqual(len(a.documents), 1)
+        self.assertEqual(b.documents, [])
+
+    def test_runtime_uses_same_ga_installation_assets(self):
+        runtime = GenericAgentRuntime()
+        session = runtime.get_or_create("chat:root")
+        root = os.path.dirname(os.path.dirname(__file__))
+        self.assertTrue(os.path.isdir(os.path.join(root, "memory")))
+        self.assertIsNotNone(session.agent.task_queue)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary
- keep separate Feishu topic sessions inside one frontend process
- queue follow-up messages in the same topic until the current run finishes
- split long final card output into collapsed sections
- add unit tests for session isolation, topic queueing, and card sectioning

## Validation
- git diff --check main...HEAD
- python -m py_compile agentmain.py frontends/fsapp.py tests/test_feishu_card_sections.py tests/test_feishu_session_queue.py tests/test_multisession_runtime.py
- python -m unittest tests.test_multisession_runtime tests.test_feishu_session_queue tests.test_feishu_card_sections -v

## Not tested
- live Feishu desktop/mobile rendering
