### PR TITLE
fix(conductor): surface LLM error to user when conductor falls silent (#342)

### DIFF
--- a/frontends/conductor.py
+++ b/frontends/conductor.py
@@ -288,13 +288,14 @@ def _auto_cleanup_loop():
         if to_abort:
             push_cards()
 
-def monitor_conductor_queue(dq: "queue.Queue"):
-    """Conductor output is discarded. Visible reply must go through POST /chat only."""
+def monitor_conductor_queue(dq: "queue.Queue") -> str:
+    """Block until done. Conductor output is not surfaced to users; the returned
+    text is for caller-side error detection only (#342)."""
     while True:
         item = dq.get()
         if "done" in item:
             print(f"Conductor task done")
-            break
+            return item.get("done", "") or ""
 
 def conductor_loop():
     global conductor_agent, conductor_started
@@ -321,7 +322,18 @@ def conductor_loop():
             prompt = conductor_prompt_from_events(events)
             dq = conductor_agent.put_task(prompt, source="conductor")
             # Block here until conductor finishes — serializes execution
-            monitor_conductor_queue(dq)
+            done_text = monitor_conductor_queue(dq)
+            # Fallback: if conductor's last turn ended with an LLM error (yielded as
+            # text by MixinSession instead of raised), surface it directly (#342).
+            # Use tail-window substring check (same style as ga.do_no_tool's
+            # content[-100:]); window covers the error line plus any decoration
+            # (fence + "[Info] Final response to user.") appended by do_no_tool.
+            tail = (done_text or '')[-1000:]
+            if '!!!Error:' in tail:
+                last = chat_messages[-1] if chat_messages else None
+                if not (last and last.get('role') == 'system' and last.get('msg', '').startswith('⚠ LLM')):
+                    err = next((l for l in reversed(tail.splitlines()) if l.startswith('!!!Error:')), '')
+                    add_chat(f"⚠ LLM 暂不可用：{err[:200]}", role="system")
         except Exception as e:
             add_chat(f"Conductor error: {e}", role="system")
 


### PR DESCRIPTION
跟踪 #342 时发现 conductor 这一侧也存在类似的静默死亡路径：用户共享同一个 LLM 供应商时，subagent 跑到一半挂了（401 / 超时 / 限额），conductor 被唤醒去回报，但它自己的 LLM 也已不可用——无法主动调用 POST /chat 与用户沟通。结果是浏览器完全静默，没有任何反馈。

排查结果：\`MixinSession._raw_ask\` 在所有重试耗尽后并不抛异常，而是将 \`!!!Error: HTTP 401: ...\` 作为普通文本 chunk yield 出去，因此 conductor_loop 外层的 try/except 永远拦不到。conductor 的唯一发声途径是它自己 LLM 决定调用 POST /chat——LLM 不可用时这条路径同时失效。旧版 \`monitor_conductor_queue\` 又只是消费掉 done 事件，没有向调用方传递任何信号。

改动仅 \`frontends/conductor.py\`，+16 -4：

- \`monitor_conductor_queue\` 返回 conductor 最终 done text；docstring 明确该返回值仅供 caller 做错误检测，不外露 conductor 输出。
- \`conductor_loop\` 在 done text 末尾 1000 字符窗口中查找 \`!!!Error:\`，命中即推一条 \`role=\"system\"\` 的 \`⚠ LLM 暂不可用：...\` 提示。
- 采用字符窗口而非\"最后一行 startswith\"，是为了与 \`ga.do_no_tool\` 中 \`content[-100:]\` 的现有风格保持一致；且 do_no_tool 在错误 chunk 之后还会追加 fence + \`[Info] Final response to user.\` 装饰行，错误行不一定落在最末。
- 复用既有 \`add_chat(role=\"system\")\` 通道，与相邻的 \`Conductor error: {e}\` 出于同一机制。
- 增加 dedup 检查，避免连续多次失败时刷屏。

不涉及 \`llmcore.py\` / \`agent_loop.py\` / \`agentmain.py\`；其他 frontend（chatapp、TUI）不受影响。

本地用 mock proxy 复现：透传 ollama.com，检测到 flag 文件后切回 401。流程为启动 conductor → 派一个 subagent → 在 subagent 执行期间创建 flag → subagent 完成唤醒 conductor → conductor 调用 LLM 失败。修复前完全静默；修复后浏览器收到 \`⚠ LLM 暂不可用：!!!Error: HTTP 401: {...}\` 系统消息。

附注：底层 \`ga.py:461\` 的 \`content[-100:]\` 窗口过短，长错误字符串会被截断导致 do_no_tool 误判为正常响应。这是一个独立 bug，本 PR 仅在 conductor 层做兜底，不在此处合并修复。