### PR TITLE
fix(tui): use pbcopy on macOS for clipboard copy

### DIFF
--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -2084,6 +2084,20 @@ class GenericAgentTUI(App[None]):
         self.current_id = ids[(i + 1) % len(ids)]
         self._refresh_all()
 
+    def copy_to_clipboard(self, text: str) -> None:
+        """Override Textual's OSC 52 clipboard (broken on macOS Terminal.app).
+        Use pbcopy on macOS, fall back to OSC 52 on other platforms."""
+        import sys, subprocess as _sp
+        if sys.platform == "darwin":
+            try:
+                _sp.Popen(["pbcopy"], stdin=_sp.PIPE, stdout=_sp.DEVNULL, stderr=_sp.DEVNULL).communicate(text.encode("utf-8"))
+                self._clipboard = text
+                return
+            except Exception:
+                pass
+        # Non-macOS or pbcopy failed: fall back to Textual default (OSC 52)
+        super().copy_to_clipboard(text)
+
     def action_handle_ctrl_c(self) -> None:
         # Two-stage quit: when no task is running, first press clears input and arms;
         # second press within 2s exits.


### PR DESCRIPTION
## Problem

Ctrl+C copy in TUI v2 silently fails on macOS Terminal.app.

Textual's built-in `copy_to_clipboard` uses OSC 52 escape sequence which is not supported by macOS Terminal.app (acknowledged in Textual source comments).

## Fix

Override `copy_to_clipboard` in the App class to use `pbcopy` on macOS, with fallback to the default OSC 52 for other platforms.

## Testing

- Verified syntax passes
- Only 1 file changed, 14 insertions
- No existing behavior altered for non-macOS platforms
