### PR TITLE
docs: 修复安装文档中的链接路径

### DIFF
--- a/docs/installation_zh.md
+++ b/docs/installation_zh.md
@@ -204,7 +204,7 @@ uv pip install -e ".[ui]"
 > **重要：用 `curl` 获取本文，不要依赖会摘要网页的读取器。** 摘要常会丢掉环境变量、命令引号和安全规则。
 >
 > ```bash
-> curl -fsSL https://raw.githubusercontent.com/lsdefine/GenericAgent/refs/heads/main/installation.zh.md
+> curl -fsSL https://raw.githubusercontent.com/lsdefine/GenericAgent/refs/heads/main/docs/installation.md
 > ```
 
 你正在替人类用户安装 **GenericAgent**。请直接执行、逐步验证；除非用户明确授权，不要做破坏性清理。


### PR DESCRIPTION
## 修改说明

原安装文档 `docs/installation_zh.md` 中的 curl 下载链接使用了错误的路径 `installation.zh.md`，已更正为 `docs/installation.md`。

### 修改内容

```diff
- curl -fsSL https://raw.githubusercontent.com/lsdefine/GenericAgent/refs/heads/main/installation.zh.md
+ curl -fsSL https://raw.githubusercontent.com/lsdefine/GenericAgent/refs/heads/main/docs/installation.md
```

### 原因

原链接指向 `installation.zh.md`（无 `docs/` 前缀），该路径在仓库中不存在，导致下载失败。更正后的链接指向 `docs/installation.md`，为仓库中实际存在的文件路径。

请合并，谢谢！
