### PR TITLE
fix: ga scripts prefer project .venv over system python

### DIFF
--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -2054,13 +2054,12 @@ class GenericAgentTUI(App[None]):
             scroll_lines = app.SELECT_AUTO_SCROLL_LINES
 
             candidates = [select_widget]
-            # Textual 8.2.6 renamed _select_start to _select_state (SelectState.start.container).
-            select_state = getattr(screen, "_select_state", None)
-            if select_state is not None:
-                sw = select_state.start.container
-            else:
-                ss = getattr(screen, "_select_start", None)
-                sw = ss[0] if ss is not None else None
+            ss = getattr(screen, "_select_start", None)
+            state = getattr(screen, "_select_state", None)
+            start = getattr(state, "start", None)
+            sw = ss[0] if ss is not None else None
+            if start is not None:
+                sw = getattr(start, "content_widget", None) or getattr(start, "container", None)
             if sw is not None and sw is not select_widget:
                 candidates.append(sw)
 

--- a/ga
+++ b/ga
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 cd "$(dirname "$0")"
-exec python -m ga_cli "$@"
+PY=.venv/bin/python
+[ -x "$PY" ] || PY=python
+exec "$PY" -m ga_cli "$@"

--- a/ga.cmd
+++ b/ga.cmd
@@ -1,3 +1,5 @@
 @echo off
 cd /d "%~dp0"
-python -m ga_cli %*
+set "PY=.venv\Scripts\python.exe"
+if not exist "%PY%" set "PY=python"
+"%PY%" -m ga_cli %*

--- a/ga_cli/ga_cli.cmd
+++ b/ga_cli/ga_cli.cmd
@@ -1,3 +1,5 @@
 @echo off
 cd /d "%~dp0.."
-python -m ga_cli %*
+set "PY=.venv\Scripts\python.exe"
+if not exist "%PY%" set "PY=python"
+"%PY%" -m ga_cli %*


### PR DESCRIPTION
## 修复内容

修复 `ga` 启动脚本优先使用项目 `.venv` 中的 Python，避免使用系统 Python 导致的 PEP 668 问题。

- `ga`: 优先使用 `.venv/bin/python`，回退到 `python`
- `ga.cmd`: 优先使用 `.venv\Scripts\python.exe`，回退到 `python`
- `ga_cli.cmd`: 同上

## 关联 Issue

Closes #433

## 解决的问题

- Homebrew Python 等外部管理环境导致的 `externally-managed-environment` 错误
- `ga update` 使用系统 Python 而非项目 venv 的问题