### PR TITLE
fix(tui): throttle sidebar refresh to eliminate ANSI artifacts during streaming

### DIFF
--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -6688,6 +6688,11 @@ class GenericAgentTUI(App[None]):
 
     def _refresh_sidebar(self):
         if not self.is_mounted: return
+        now = time.monotonic()
+        if hasattr(self, '_last_sidebar_refresh'):
+            if now - self._last_sidebar_refresh < 1.0:
+                return
+        self._last_sidebar_refresh = now
         self.query_one("#sidebar", Static).update(render_sidebar(self.sessions, self.current_id))
         self._scroll_active_session_into_view()
 


### PR DESCRIPTION
During streaming output, every token chunk triggered a full sidebar
refresh via `_refresh_sidebar()`. The rapid re-renders caused transient
ANSI escape sequence fragments to appear in the gap between the main
content and sidebar — visible as random digits/characters flickering
in the border region.

**Root cause:** The sidebar is re-rendered on every streaming chunk,
but its content (session list, status) barely changes during streaming.
The rapid successive `Static.update()` calls cause Textual's screen
diff algorithm to emit ANSI positioning/SGR sequences that transiently
leak into the adjacent gap cells.

**Fix:** Throttle `_refresh_sidebar()` to at most once per second.
This has no visible impact on content freshness (sidebar content is
stable during streaming) while eliminating the rendering artifacts.

Closes #423
