### PR TITLE
fix: Python <3.10 compat for cost_tracker.py

### DIFF
--- a/frontends/cost_tracker.py
+++ b/frontends/cost_tracker.py
@@ -8,6 +8,7 @@ runs its agent on `ga-tui-agent-<id>`, so `/cost` is a thread lookup.
 Subagent processes are out-of-process, so `scan_subagent_logs` parses the
 same `[Cache]` / `[Output]` print lines from `temp/*/stdout.log`.
 """
+from __future__ import annotations
 import glob, os, re, threading, time
 from dataclasses import dataclass, field
 


### PR DESCRIPTION
## Summary

- Add `from __future__ import annotations` to `frontends/cost_tracker.py`
- Fixes `TypeError` on Python 3.9 caused by `dict[str, X]` and `str | None` type hint syntax that is only natively supported in 3.10+

## Details

The future import defers annotation evaluation (PEP 563), so new-style type hints are stored as strings rather than evaluated at runtime. Zero behavior change, one line fix.