### PR TITLE
feat(tui): add Ctrl+S stash/restore for input draft

### DIFF
--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -1282,6 +1282,8 @@ class InputArea(TextArea):
         Binding("cmd+v",       "paste", "Paste", show=False),
         # Ctrl+U: readline-style kill-line, repurposed here to clear the whole input.
         Binding("ctrl+u",      "clear_input", "ClearInput", show=False),
+        # Ctrl+S: stash/restore input draft (Claude Code muscle-memory alias).
+        Binding("ctrl+s",      "stash", "Stash", show=False),
     ]
 
     def action_noop(self) -> None:
@@ -1299,6 +1301,36 @@ class InputArea(TextArea):
             self.app._resize_input(self)
         except Exception:
             pass
+
+    def action_stash(self) -> None:
+        """Stash/restore input draft: press once to save and clear, press again
+        (when input is empty) to restore the saved draft. Mirrors Claude Code's
+        Ctrl+S chat:stash behaviour."""
+        current = self.text
+        if current:
+            # Stash current text and clear the input.
+            self._draft_stash = current
+            self.reset()
+            self._history_index = -1
+            self._history_stash = ""
+            try:
+                self.app._hide_palette()
+            except Exception:
+                pass
+            try:
+                self.app._resize_input(self)
+            except Exception:
+                pass
+        elif self._draft_stash:
+            # Input is empty — restore the stashed draft.
+            self.text = self._draft_stash
+            self._draft_stash = ""
+            self._history_index = -1
+            self._suppress_palette_next_change()
+            try:
+                self.app._resize_input(self)
+            except Exception:
+                pass
 
     def _insert_via_keyboard(self, text: str) -> None:
         result = self._replace_via_keyboard(text, *self.selection)
@@ -1398,6 +1430,7 @@ class InputArea(TextArea):
         self._input_history: list[str] = []
         self._history_index: int = -1         # -1 means not browsing
         self._history_stash: str = ""
+        self._draft_stash: str = ""           # Ctrl+S stash for scratch input
         self._HISTORY_MAX = 200
 
     def expand_placeholders(self, text: str) -> str:


### PR DESCRIPTION
## Summary

在 TUI 输入框中新增 `Ctrl+S` 快捷键，实现"暂存草稿 / 恢复草稿"功能，对齐 Claude Code 的 `chat:stash` 交互模式。

## Motivation

在 TUI 中与 agent 对话时，用户经常遇到这种情况：正在输入框里写一段比较长的提示词，还没写完，突然想到需要先问另一个问题（比如查一个文件、确认一个前置信息），但又不希望丢失当前已经打好的草稿。

目前只能手动复制粘贴到别处，或者硬着头皮先发出去再追加补充，体验不好。

## Changes

- **`InputArea.BINDINGS`**：新增 `Binding("ctrl+s", "stash", "Stash", show=False)`
- **`InputArea.__init__`**：新增 `self._draft_stash: str = ""` 实例变量
- **`InputArea.action_stash`**：新增方法，实现：
  - 输入框有内容时：将当前内容保存到 `_draft_stash`，清空输入框，重置历史状态
  - 输入框为空时（且有暂存内容）：将 `_draft_stash` 内容恢复到输入框
  - 输入框为空且无暂存内容时：无操作

## Behavior

| 操作 | 效果 |
|------|------|
| Ctrl+S（有内容） | 保存草稿 → 清空输入框 |
| Ctrl+S（空输入） | 恢复上次暂存的草稿 |
| Ctrl+S（空输入 + 无草稿） | 无操作 |

Note: `Ctrl+S` 在 v2 中未被占用，老版 tuiapp.py 中曾用作 Stop，但 v2 已改为 `Ctrl+C`。