### PR TITLE
fix(tui): improve Done Annotation spacing and tipbar visual weight

### DIFF
--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -887,8 +887,8 @@ Screen { background: $ga-bg; color: $ga-fg; }
 #tipbar {
     height: 1;
     background: $ga-bg;
-    padding: 0 2;
-    color: $ga-dim;
+    padding: 0 1;
+    color: $ga-border;
 }
 
 /* Pickers — used by both ChoiceList (OptionList) and MultiChoiceList
@@ -926,7 +926,10 @@ SelectionList.picker > .selection-list--button-highlighted { background: transpa
     margin-bottom: 0;
 }
 .fold-header:hover { background: $ga-sel-bg; }
-.spinner { height: 1; }
+.spinner {
+    height: 1;
+    margin-top: 1;
+}
 
 #palette {
     height: auto;


### PR DESCRIPTION
## Summary

Fix two visual layout issues reported in Issue #422:

1. **Done Annotation too cramped**: Add `margin-top: 1` to `.spinner` CSS class so the `⠿ {Verb} for Xm Ys · ↑ N · ↓ M` line has visual breathing room from the last character of the assistant reply body.

2. **Tip bar too visually prominent**: Reduce `#tipbar` padding from `0 2` to `0 1` and switch color from `$ga-dim` to `$ga-border` — a much lighter shade that feels like a subtle helper hint rather than a feature banner.

## Changes

| Element | Before | After |
|---------|--------|-------|
| `.spinner` | `height: 1;` | `height: 1; margin-top: 1;` |
| `#tipbar` padding | `0 2` | `0 1` |
| `#tipbar` color | `$ga-dim` | `$ga-border` |

## Testing

Verified with `python3 -m py_compile frontends/tuiapp_v2.py` — no syntax errors.

Requires visual confirmation in TUI session: the Done Annotation should be clearly separated from reply content, and the tip bar should be noticeably lighter in visual weight.