### PR TITLE
fix: replace remaining bare except clauses with except Exception

### DIFF
--- a/frontends/stapp.py
+++ b/frontends/stapp.py
@@ -4,9 +4,9 @@ from urllib.parse import quote
 if sys.stdout is None: sys.stdout = open(os.devnull, "w")
 if sys.stderr is None: sys.stderr = open(os.devnull, "w")
 try: sys.stdout.reconfigure(errors='replace')
-except: pass
+except Exception: pass
 try: sys.stderr.reconfigure(errors='replace')
-except: pass
+except Exception: pass
 script_dir = os.path.dirname(__file__)
 sys.path.append(os.path.abspath(os.path.join(script_dir, '..')))
 sys.path.append(os.path.abspath(script_dir))

--- a/frontends/stapp2.py
+++ b/frontends/stapp2.py
@@ -3,9 +3,9 @@ import html
 if sys.stdout is None: sys.stdout = open(os.devnull, "w")
 if sys.stderr is None: sys.stderr = open(os.devnull, "w")
 try: sys.stdout.reconfigure(errors='replace')
-except: pass
+except Exception: pass
 try: sys.stderr.reconfigure(errors='replace')
-except: pass
+except Exception: pass
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import streamlit as st

--- a/frontends/tgapp.py
+++ b/frontends/tgapp.py
@@ -9,7 +9,7 @@ try:
     from telegram.ext import ApplicationBuilder, CallbackQueryHandler, MessageHandler, filters, ContextTypes
     from telegram.helpers import escape_markdown
     from telegram.request import HTTPXRequest
-except:
+except Exception:
     print("Please ask the agent install python-telegram-bot to use telegram module.")
     sys.exit(1)
 from chatapp_common import (

--- a/frontends/wechatapp.py
+++ b/frontends/wechatapp.py
@@ -348,7 +348,7 @@ def on_message(bot, msg):
             if not ticket: return
             while not _typing_stop.is_set():
                 try: bot.send_typing(uid, ticket)
-                except: pass
+                except Exception: pass
                 _typing_stop.wait(2.0)
         threading.Thread(target=_keep_typing, daemon=True).start()
         result = ''; sent = 0; mi = 0; last_send = 0; item = {}


### PR DESCRIPTION
## Summary

Replace bare `except:` clauses with `except Exception:` in four frontend files that were not covered by PR #463 (`fix/issue-463-bare-except-clauses`).

## Changes

| File | Line | Change |
|------|------|--------|
| frontends/stapp.py | 7,9 | `except:` → `except Exception:` (stdout/stderr reconfigure fallback) |
| frontends/stapp2.py | 6,8 | `except:` → `except Exception:` (stdout/stderr reconfigure fallback) |
| frontends/tgapp.py | 12 | `except:` → `except Exception:` (telegram import fallback) |
| frontends/wechatapp.py | 351 | `except:` → `except Exception:` (send_typing loop) |

## Motivation

Bare `except:` catches all exceptions including `KeyboardInterrupt` and `SystemExit`, which can mask serious bugs and prevent clean shutdown. Using `except Exception:` allows system-exiting exceptions to propagate normally.

All changes pass `python3 -m py_compile` syntax validation.