### PR TITLE
feat: prefer pwsh (PowerShell 7) over powershell in code_run on Windows

### DIFF
--- a/ga.py
+++ b/ga.py
@@ -1,7 +1,7 @@
 import sys, os, re, json, time, threading, importlib
 from datetime import datetime
 from pathlib import Path
-import tempfile, traceback, subprocess, itertools, collections, difflib
+import tempfile, traceback, subprocess, itertools, collections, difflib, shutil
 if sys.stdout is None: sys.stdout = open(os.devnull, "w")
 if sys.stderr is None: sys.stderr = open(os.devnull, "w")
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -26,7 +26,9 @@ def code_run(code, code_type="python", timeout=60, cwd=None, code_cwd=None, stop
         tmp_file.close()
         cmd = [sys.executable, "-X", "utf8", "-u", tmp_path]   
     elif code_type in ["powershell", "bash", "sh", "shell", "ps1", "pwsh"]:
-        if os.name == 'nt': cmd = ["powershell", "-NoProfile", "-NonInteractive", "-Command", code]
+        if os.name == 'nt':
+            _ps = "pwsh" if shutil.which("pwsh") else "powershell"
+            cmd = [_ps, "-NoProfile", "-NonInteractive", "-Command", code]
         else: cmd = ["bash", "-c", code]
     else:
         return {"status": "error", "msg": f"不支持的类型: {code_type}"}


### PR DESCRIPTION
Use shutil.which('pwsh') to detect PowerShell 7 availability, falling back to legacy powershell if not found. PS7 has better UTF-8 support, modern syntax, and is the recommended shell for Windows development.