### PR TITLE
fix: wrap _turn_end_hooks iteration with list() to prevent RuntimeError

### DIFF
--- a/ga.py
+++ b/ga.py
@@ -573,7 +573,7 @@ class GenericAgentHandler(BaseHandler):
         injprompt = consume_file(self.parent.task_dir, '_intervene')
         if injkeyinfo: self.working['key_info'] = self.working.get('key_info', '') + f"\n[MASTER] {injkeyinfo}"
         if injprompt: next_prompt += f"\n\n[MASTER] {injprompt}\n"
-        for hook in getattr(self.parent, '_turn_end_hooks', {}).values(): hook(locals())  # current readonly
+        for hook in list(getattr(self.parent, '_turn_end_hooks', {}).values()): hook(locals())  # current readonly
         return next_prompt
 
 def get_global_memory():


### PR DESCRIPTION
When a hook modifies `_turn_end_hooks` dict during iteration in `turn_end_callback`, Python raises `RuntimeError: dictionary changed size during iteration`.

This fix wraps the `.values()` call with `list()` to create a snapshot of the hooks before iterating, preventing the RuntimeError.

**Changes:**
- `ga.py` line 576: `for hook in getattr(self.parent, '_turn_end_hooks', {}).values()` → `for hook in list(getattr(self.parent, '_turn_end_hooks', {}).values())`