### PR TITLE
feat(conductor): inherit model selection when spawning subagents

### DIFF
--- a/frontends/conductor.py
+++ b/frontends/conductor.py
@@ -177,6 +177,9 @@ def start_subagent(prompt: str) -> dict:
     agent = GenericAgent()
     agent.inc_out = True
     agent.verbose = False
+    # Inherit model selection from conductor agent
+    if conductor_agent is not None:
+        agent.next_llm(conductor_agent.llm_no)
 
     start_agent_runner(agent, f"subagent-{sid}")
     state = SubAgentState(id=sid, agent=agent, prompt=prompt, status="running")


### PR DESCRIPTION
## Summary

Subagents spawned by the conductor now inherit the conductor agent's current model selection instead of always defaulting to model index 0.

## Problem

When the user switches models via `/llms` in the conductor session, spawned subagents still used model 0 (the default). This causes inconsistency between the conductor and subagent capabilities, costs, and fallback strategies.

## Solution

Added a 3-line check in `start_subagent()`: if the conductor agent is initialized, call `agent.next_llm(conductor_agent.llm_no)` on the new subagent before starting its runner thread.

The guard `if conductor_agent is not None` ensures backward compatibility — if subagents are created before the conductor agent is ready, they still fall back to model 0.

## Testing

- `python3 -m py_compile frontends/conductor.py` — passes
- Behavior verified: `conductor_agent.llm_no` is an integer attribute on `GenericAgent` instances, `next_llm()` accepts integers

Closes #456
