### PR TITLE
fix: replace bare except clauses with except Exception in ga.py

### DIFF
--- a/ga.py
+++ b/ga.py
@@ -45,8 +45,8 @@ def code_run(code, code_type="python", timeout=60, cwd=None, code_cwd=None, stop
                 except UnicodeDecodeError: line = line_bytes.decode('gbk', errors='ignore')
                 logs.append(line)
                 try: print(line, end="") 
-                except: pass
-        except: pass
+                except Exception: pass
+        except Exception: pass
 
     try:
         process = subprocess.Popen(
@@ -156,7 +156,7 @@ def log_memory_access(path):
     stats_file = os.path.join(script_dir, 'memory/file_access_stats.json')
     try:
         with open(stats_file, 'r', encoding='utf-8') as f: stats = json.load(f)
-    except: stats = {}
+    except Exception: stats = {}
     fname = os.path.basename(path)
     stats[fname] = {'count': stats.get(fname, {}).get('count', 0) + 1, 'last': datetime.now().strftime('%Y-%m-%d')}
     with open(stats_file, 'w', encoding='utf-8') as f: json.dump(stats, f, indent=2, ensure_ascii=False)
@@ -286,7 +286,7 @@ class GenericAgentHandler(BaseHandler):
             code = self._extract_code_block(response, code_type)
             if not code: return StepOutcome("[Error] Code missing. Must use reply code block or 'script' arg.", next_prompt="\n")
         try: timeout = int(args.get("timeout", 60))
-        except: timeout = 60
+        except Exception: timeout = 60
         raw_path = os.path.join(self.cwd, args.get("cwd", './'))
         cwd = os.path.normpath(os.path.abspath(raw_path))
         code_cwd = os.path.normpath(self.cwd)
@@ -345,10 +345,10 @@ class GenericAgentHandler(BaseHandler):
             try:
                 with open(abs_path, 'w', encoding='utf-8') as f: f.write(str(content))
                 result["js_return"] += f"\n\n[已保存完整内容到 {abs_path}]"
-            except: result['js_return'] += f"\n\n[保存失败，无法写入文件 {abs_path}]"
+            except Exception: result['js_return'] += f"\n\n[保存失败，无法写入文件 {abs_path}]"
         show = smart_format(json.dumps(result, ensure_ascii=False, indent=2, default=json_default), max_str_len=300)
         try: print("Web Execute JS Result:", show)
-        except: pass
+        except Exception: pass
         yield f"JS 执行结果:\n{show}\n"
         next_prompt = self._get_anchor_prompt(skip=args.get('_index', 0) > 0)
         result = json.dumps(result, ensure_ascii=False, default=json_default)
@@ -430,7 +430,7 @@ class GenericAgentHandler(BaseHandler):
     def _check_plan_completion(self):
         if not os.path.isfile(p:=self._in_plan_mode() or ''): return None
         try: return len(re.findall(r'\[ \]', open(p, encoding='utf-8', errors='replace').read()))
-        except: return None
+        except Exception: return None
     
     def do_update_working_checkpoint(self, args, response):
         '''为整个任务设定后续需要临时记忆的重点。'''
@@ -541,7 +541,7 @@ class GenericAgentHandler(BaseHandler):
         if self.working.get('related_sop'): prompt += f"\n有不清晰的地方请再次读取{self.working.get('related_sop')}"
         if getattr(self.parent, 'verbose', False):
             try: print(prompt)
-            except: pass
+            except Exception: pass
         return prompt
     
     def turn_end_callback(self, response, tool_calls, tool_results, turn, next_prompt, exit_reason):


### PR DESCRIPTION
## Summary

Replace all 8 bare `except:` clauses in `ga.py` with `except Exception:`.

## Why

Bare `except:` catches everything including `SystemExit` and `KeyboardInterrupt`, which can:
- Prevent the agent from being stopped with Ctrl+C
- Mask critical failures like out-of-memory errors
- Make debugging harder by swallowing all exceptions silently

## Changes

All 8 bare `except:` → `except Exception:` in `ga.py`:

| Line | Context |
|------|---------|
| 48-49 | code_run output printing fallback |
| 159 | file access stats JSON loading |
| 289 | timeout argument parsing |
| 348 | web_execute_js file save error |
| 351 | web_execute_js result printing |
| 433 | plan completion check |
| 544 | verbose prompt printing |

## Testing

- `python3 -m py_compile ga.py` — passes
- No behavior change — `Exception` covers the same error types these handlers were meant to catch
