### PR TITLE
fix: use OSC52 clipboard for remote macOS TUI

### DIFF
--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -2170,17 +2170,18 @@ class GenericAgentTUI(App[None]):
         self._refresh_all()
 
     def copy_to_clipboard(self, text: str) -> None:
-        """Override Textual's OSC 52 clipboard (broken on macOS Terminal.app).
-        Use pbcopy on macOS, fall back to OSC 52 on other platforms."""
-        import sys, subprocess as _sp
-        if sys.platform == "darwin":
+        """Copy locally on macOS, and use OSC 52 when the UI may be remote."""
+        import subprocess as _sp
+        prefer_osc52 = os.environ.get("GA_TUI_CLIPBOARD", "").lower() in {"osc52", "terminal"}
+        remote_tty = any(os.environ.get(k) for k in ("SSH_TTY", "SSH_CONNECTION", "SSH_CLIENT", "TMUX"))
+        if sys.platform == "darwin" and not prefer_osc52:
             try:
                 _sp.Popen(["pbcopy"], stdin=_sp.PIPE, stdout=_sp.DEVNULL, stderr=_sp.DEVNULL).communicate(text.encode("utf-8"))
                 self._clipboard = text
-                return
+                if not remote_tty:
+                    return
             except Exception:
                 pass
-        # Non-macOS or pbcopy failed: fall back to Textual default (OSC 52)
         super().copy_to_clipboard(text)
 
     def action_handle_ctrl_c(self) -> None:


### PR DESCRIPTION
## Summary
- keep the existing macOS `pbcopy` path for local Terminal.app sessions
- fall back to Textual/OSC52 when the TUI appears to be running through SSH or tmux
- add a `GA_TUI_CLIPBOARD=osc52` escape hatch for users who need to force terminal clipboard output

## Why
`frontends/tuiapp_v2.py` currently returns immediately after `pbcopy` succeeds on macOS. When the TUI runs on a remote Mac over SSH/tmux, that copies to the remote Mac clipboard instead of the user's visible terminal clipboard. Allowing OSC52 in remote/tmux sessions lets compatible terminals/tmux propagate the copy to the local clipboard.

Refs #351.

## Testing
- `PYTHONPYCACHEPREFIX=/tmp/ga-pr-pycache python -m py_compile frontends/tuiapp_v2.py`
- `python frontends/tuiapp_v2.py --help`
- `git diff --check`
- monkeypatch smoke test for local macOS, SSH, tmux, and `GA_TUI_CLIPBOARD=osc52` paths
