### PR TITLE
fix(tui): remove Ctrl+C clearing draft in idle state

### DIFF
--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -4374,9 +4374,6 @@ class SB:
             if time.time() - self._cc_t < 1:      # idle: arm-to-quit; second press
                 return False                       # within the window actually exits
             with self._lk:
-                if self.buf:                      # v2: first press clears the draft
-                    self._snap()
-                    self.buf = ''; self.pos = 0; self._sel = None
                 self._cc_t = time.time()          # arm: second press quits + shows hint
                 self._render_live()
             return True


### PR DESCRIPTION
## Bug Description
在TUI v3输入框中输入文字后，按下Ctrl+C（无论是否选中文字）会清空已输入的所有文字。

## Root Cause
`_feed`方法第4538行有v2遗留逻辑——idle状态下首次Ctrl+C会**清空整个draft**（`self.buf = ''`）。注释甚至写了"v2: first press clears the draft"。这个行为不合理：
- 有选区时 → 正确复制（第4522-4528行）✅
- 无选区时 → **错误地清空整个输入框** ❌

## Fix
移除清空draft的3行代码（`self._snap()` + `self.buf = ''; self.pos = 0; self._sel = None`），改为首次Ctrl+C仅arm退出计时器并显示"Press Ctrl+C again to quit"提示。

## After Fix
| 场景 | 行为 |
|------|------|
| 有文字选区 | 复制选区文字 ✅ |
| 任务运行中 | abort任务 ✅ |
| idle + 首次Ctrl+C | 显示退出提示（**不再清空输入**）✅ |
| idle + 1秒内第二次Ctrl+C | 退出程序 ✅ |

## Changed Files
- `frontends/tui_v3.py`: 删除3行（行4377-4379）

## Testing
- [ ] 输入文字后按Ctrl+C（无选区）→ 文字保留
- [ ] 输入文字后选中部分按Ctrl+C → 复制选区
- [ ] 连续按两次Ctrl+C → 退出程序