### PR TITLE
feat(tui): add shared slash-command bundle with hub-aligned /scheduler launcher

### DIFF
--- a/frontends/slash_cmds.py
+++ b/frontends/slash_cmds.py
@@ -134,6 +134,105 @@ def list_reflect_tasks() -> list[dict]:
     return out
 
 
+# ----- hub.pyw parity: every launchable service ---------------------------
+
+_HUB_EXCLUDES = {"goal_mode.py", "chatapp_common.py", "tuiapp.py"}
+
+
+def _sniff_doc(p) -> str:
+    """Best-effort first line of a module docstring (cheap ~40-line read)."""
+    try:
+        head = p.read_text(encoding="utf-8", errors="ignore").splitlines()[:40]
+        joined = "\n".join(head)
+        for q in ('"""', "'''"):
+            i = joined.find(q)
+            if i != -1:
+                j = joined.find(q, i + 3)
+                if j != -1:
+                    body = joined[i + 3:j].strip()
+                    if body:
+                        return body.splitlines()[0].strip()
+    except Exception:
+        pass
+    return ""
+
+
+def list_launchable_services() -> list[dict]:
+    """Mirror hub.pyw's discover_services() so `/scheduler` shows the *same*
+    set of launchable services as the GUI launcher.
+
+    Sources (hub.pyw EXCLUDES = goal_mode.py / chatapp_common.py / tuiapp.py):
+      • reflect/*.py   (not '_'-prefixed, not excluded)
+          → cmd = [python, agentmain.py, --reflect, reflect/<f>]
+      • frontends/*app*.py (not excluded)
+          → 'stapp' → `python -m streamlit run … --server.headless=true`
+            others   → `python frontends/<f>`
+
+    Returns [{name, cmd, doc, kind}] where `name` is the hub-style path
+    ('reflect/foo.py' / 'frontends/bar.py') and doubles as the picker value.
+    """
+    out: list[dict] = []
+    refl = _ROOT / "reflect"
+    if refl.is_dir():
+        for p in sorted(refl.glob("*.py")):
+            if p.name.startswith("_") or p.name in _HUB_EXCLUDES:
+                continue
+            rel = "reflect/" + p.name
+            out.append({
+                "name": rel,
+                "cmd": [sys.executable, "agentmain.py", "--reflect", rel],
+                "doc": _sniff_doc(p),
+                "kind": "reflect",
+            })
+    fe = _ROOT / "frontends"
+    if fe.is_dir():
+        for p in sorted(fe.glob("*.py")):
+            if "app" not in p.name or p.name in _HUB_EXCLUDES:
+                continue
+            rel = "frontends/" + p.name
+            if "stapp" in p.name:
+                cmd = [sys.executable, "-m", "streamlit", "run", rel,
+                       "--server.headless=true"]
+            else:
+                cmd = [sys.executable, rel]
+            out.append({"name": rel, "cmd": cmd, "doc": _sniff_doc(p),
+                        "kind": "frontend"})
+    return out
+
+
+def start_service(name: str) -> tuple[bool, str]:
+    """Launch a service from list_launchable_services(), detached & window-less
+    (CONSTITUTION rule 14: creationflags at the launch layer only, never via
+    subprocess.Popen monkeypatch).
+
+    `name` accepts the hub-style path ('reflect/foo.py') or a bare reflect stem
+    ('foo') for backward-compat with `/scheduler start <stem>`.
+    """
+    svcs = list_launchable_services()
+    svc = next((s for s in svcs if s["name"] == name), None)
+    if svc is None:  # bare reflect stem fallback
+        cand = "reflect/" + name + ".py"
+        svc = next((s for s in svcs if s["name"] == cand), None)
+    if svc is None:
+        return False, f"未知服务: {name}"
+    try:
+        flags = 0
+        if os.name == "nt":
+            flags = 0x00000200 | 0x08000000  # NEW_PROCESS_GROUP | NO_WINDOW
+        subprocess.Popen(
+            svc["cmd"],
+            cwd=str(_ROOT),
+            creationflags=flags,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+        )
+        return True, f"已启动 {svc['name']}"
+    except Exception as e:
+        return False, f"启动失败: {type(e).__name__}: {e}"
+
+
 def list_scheduler_tasks() -> list[dict]:
     """Return [{name, path, schedule, enabled}] for every sche_tasks/*.json.
 

--- a/frontends/slash_cmds.py
+++ b/frontends/slash_cmds.py
@@ -1,0 +1,216 @@
+"""Slash-command prompt builders + scheduler-task discovery.
+
+Goal of this module: keep TUI files (tuiapp_v2.py / tui_v3.py) thin. They only
+need to forward `/update`, `/autorun`, `/morphling`, `/goal`, `/hive`
+to the corresponding `build_*_prompt(args)` here, and ask
+`list_scheduler_tasks()` / `start_scheduler_task()` for the `/scheduler` picker.
+
+Design (per user 2026-05-27):
+- All non-/scheduler commands are *prompt injection*: we craft a system-style
+  request and feed it to the main agent as a normal user message (the TUI is
+  free to display the raw `/cmd ...` as the visible bubble).  This keeps the
+  agent in-session, lets it use every tool/SOP it normally would, and means
+  this file owns zero LLM logic.
+- `/scheduler` is the only exception — it touches local FS state directly via
+  `sche_tasks/*.json` and the existing scheduler daemon, no LLM needed.
+- All prompts deliberately *name* the relevant SOP file so the agent re-reads
+  it before acting (per CONSTITUTION rule 2: SOP-first).
+
+This module has zero TUI imports — both frontends can depend on it without
+either depending on the other.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+
+# Repo root = parent of frontends/.  Avoid hard-coding; both TUIs live next to
+# this file and share the same anchor.
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ----- prompt builders (pure functions, no I/O) ---------------------------
+# SOP paths are written inline as literal strings in each builder below: a
+# literal is self-documenting and locally readable, and a stale path is a
+# zero-radius failure (the prompt is a hint to an intelligent agent, which
+# re-reads the dir / asks if a SOP moved) — so we deliberately do NOT wrap it
+# in a registry + existence-check machinery.
+
+def _tail(args_text: str, label: str = "额外指示") -> str:
+    """Append user-supplied args after a slash command as a free-form suffix.
+
+    User pattern (2026-05-27): the base prompt is a fixed injection that names
+    the SOP path; anything the user types after `/cmd ` is appended verbatim so
+    they can add per-invocation hints (e.g. `/morphling https://github.com/...`
+    or `/goal 调研 X，预算 50k token`).
+    """
+    extra = (args_text or "").strip()
+    return f"\n\n{label}: {extra}" if extra else ""
+
+
+def build_update_prompt(args_text: str = "") -> str:
+    # Faithfully follow the user's own wording (2026-05-27):
+    # "git pull 更新一下 GA 你自己，官方渠道 https://github.com/Lsdefine/GenericAgent,
+    #  自动合并解决冲突,优先上游分支,本地修改代码也进行保留但不进行 commit."
+    return (
+        "请你 git pull 更新一下 GA 你自己，官方渠道 "
+        "https://github.com/Lsdefine/GenericAgent ，"
+        "自动合并解决冲突，优先上游分支，本地修改代码也进行保留但不进行 commit。"
+        f"{_tail(args_text)}"
+    )
+
+
+def build_autorun_prompt(args_text: str = "") -> str:
+    return (
+        "请进入「自主探索 / autonomous 模式」：先读 "
+        "memory/autonomous_operation_sop.md。"
+        "全程自驱，不可逆 / 高风险动作先 ask_user ，"
+        "结案给一份简明回执（做了什么 / 产物在哪 / 下一步）。"
+        f"{_tail(args_text, '任务种子')}"
+    )
+
+
+def build_morphling_prompt(args_text: str = "") -> str:
+    return (
+        "请启用 Morphling 模式吞噬 / 蒸馏外部项目到本仓库：先读 "
+        "memory/morphling_sop.md。"
+        "没有目标先 ask_user 取 GitHub 仓库 / 本地路径 / 能力描述。"
+        f"{_tail(args_text, '目标技能/仓库')}"
+    )
+
+
+def build_goal_prompt(args_text: str = "") -> str:
+    return (
+        "请进入 Goal 模式：先读 memory/goal_mode_sop.md。"
+        "若未给目标，先 ask_user 一次性问清：一句话目标 + condition 约束。"
+        f"{_tail(args_text, '用户目标')}"
+    )
+
+
+def build_hive_prompt(args_text: str = "") -> str:
+    return (
+        "请进入 Goal Hive 模式（多 worker 协作版 goal）：先读 "
+        "memory/goal_hive_sop.md。"
+        "集群目标 / worker 配额 / 终止条件未明确时先 ask_user 补齐再启动。"
+        f"{_tail(args_text, '集群目标')}"
+    )
+
+
+# ----- /scheduler reflect-task discovery + launch -------------------------
+
+def list_reflect_tasks() -> list[dict]:
+    """Return [{name, path, doc}] for every reflect/*.py task script.
+
+    `doc` is the module docstring's first line (best-effort) so the picker can
+    show a one-liner next to each name.  Empty list if reflect/ doesn't exist.
+    """
+    out: list[dict] = []
+    refl = _ROOT / "reflect"
+    if not refl.is_dir():
+        return out
+    for p in sorted(refl.glob("*.py")):
+        if p.name.startswith("_"):
+            continue
+        doc = ""
+        try:
+            # Cheap docstring sniff: read first ~40 lines, look for """...""".
+            head = p.read_text(encoding="utf-8", errors="ignore").splitlines()[:40]
+            joined = "\n".join(head)
+            for q in ('"""', "'''"):
+                i = joined.find(q)
+                if i != -1:
+                    j = joined.find(q, i + 3)
+                    if j != -1:
+                        doc = joined[i + 3:j].strip().splitlines()[0].strip()
+                        break
+        except Exception:
+            pass
+        out.append({"name": p.stem, "path": str(p), "doc": doc})
+    return out
+
+
+def list_scheduler_tasks() -> list[dict]:
+    """Return [{name, path, schedule, enabled}] for every sche_tasks/*.json.
+
+    Used by the /scheduler picker so users can also toggle traditional cron
+    tasks, not just reflect.* scripts.
+    """
+    out: list[dict] = []
+    sd = _ROOT / "sche_tasks"
+    if not sd.is_dir():
+        return out
+    for p in sorted(sd.glob("*.json")):
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+        except Exception:
+            data = {}
+        out.append({
+            "name": p.stem,
+            "path": str(p),
+            "schedule": data.get("schedule") or data.get("cron") or data.get("every") or "",
+            "enabled": bool(data.get("enabled", True)),
+        })
+    return out
+
+
+def start_reflect_task(name: str) -> tuple[bool, str]:
+    """Spawn `python reflect/<name>.py` detached.  Returns (ok, message).
+
+    Detached because reflect tasks are long-running; we don't want them to die
+    with the TUI.  On Windows we use CREATE_NEW_PROCESS_GROUP|CREATE_NO_WINDOW
+    so no console pops up (per CONSTITUTION rule 14: only at launch layer, no
+    monkeypatching subprocess.Popen).
+    """
+    script = _ROOT / "reflect" / f"{name}.py"
+    if not script.is_file():
+        return False, f"reflect/{name}.py 不存在"
+    try:
+        flags = 0
+        if os.name == "nt":
+            flags = 0x00000200 | 0x08000000  # NEW_PROCESS_GROUP | NO_WINDOW
+        subprocess.Popen(
+            [sys.executable, str(script)],
+            cwd=str(_ROOT),
+            creationflags=flags,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+        )
+        return True, f"已启动 reflect/{name}.py"
+    except Exception as e:
+        return False, f"启动失败: {type(e).__name__}: {e}"
+
+
+# ----- dispatch table for the TUI to register against ---------------------
+
+# (cmd, arg_hint, desc)  — kept identical between v2 and v3 so the palette
+# stays consistent across frontends.
+PALETTE_ENTRIES: list[tuple[str, str, str]] = [
+    ("/update",    "[note]",    "git pull 更新 GA 仓库并报告影响面"),
+    ("/autorun",   "[seed]",    "进入 autonomous_operation 自主模式"),
+    ("/morphling", "[target]",  "启用 Morphling 蒸馏 / 吞噬外部技能"),
+    ("/goal",      "[goal]",    "进入 Goal 模式（需 condition 约束）"),
+    ("/hive",      "[target]",  "进入 Hive 多 worker 协作模式"),
+    ("/scheduler", "",          "多选启动 reflect 任务 / 查看 cron"),
+]
+
+
+def prompt_for(cmd: str, args_text: str) -> Optional[str]:
+    """Return the injected user-message for a given slash command, or None if
+    the command isn't one of ours (e.g. /scheduler — handled by TUI directly).
+    """
+    table = {
+        "/update":    build_update_prompt,
+        "/autorun":   build_autorun_prompt,
+        "/morphling": build_morphling_prompt,
+        "/goal":      build_goal_prompt,
+        "/hive":      build_hive_prompt,
+    }
+    fn = table.get(cmd)
+    return fn(args_text) if fn else None

--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -94,6 +94,10 @@ _TIPS = {
         "Tip: /new [name] starts a fresh session; /language switches the interface language.",
         "Tip: /export clip copies the last reply to your system clipboard; /export all prints the log path.",
         "Tip: Ctrl+O folds / unfolds all completed tool chips — each fold collapses to one line.",
+        "Tip: /update auto-runs git pull and audits the impact; /autorun seeds an autonomous run.",
+        "Tip: /morphling <target> absorbs an external skill.",
+        "Tip: /goal <goal> enters Goal mode (will ask for budget / worker cap); /hive <target> for multi-worker.",
+        "Tip: /scheduler lists reflect tasks and starts them via `/scheduler start a,b,c`.",
     ],
     'zh': [
         "Tip: 按 / 唤起命令面板 —— 方向键选择，Enter 落入输入框。",
@@ -1538,6 +1542,16 @@ def _cmds() -> list[tuple[str, str, str]]:
         ('/llm',      _t('cmd.llm.arg'),        _t('cmd.llm.desc')),
         ('/btw',      _t('cmd.btw.arg'),        _t('cmd.btw.desc')),
         ('/review',   _t('cmd.review.arg'),     _t('cmd.review.desc')),
+        # ── slash_cmds bundle (same set as v2; descriptions kept inline
+        # rather than going through _t() so a missing translation key never
+        # blanks the row).  /scheduler stays as an interactive multi-pick
+        # menu; the rest fold into prompt-injection turns.
+        ('/update',    '[note]',           'git pull GA & report impact'),
+        ('/autorun',   '[seed]',           'enter autonomous operation mode'),
+        ('/morphling', '[target]',         'distill / absorb external skills'),
+        ('/goal',      '[goal]',           'enter Goal mode (needs condition)'),
+        ('/hive',      '[target]',         'enter Hive multi-worker mode'),
+        ('/scheduler', '',                 'multi-pick reflect tasks / show cron'),
         ('/rewind',   _t('cmd.rewind.arg'),     _t('cmd.rewind.desc')),
         ('/continue', _t('cmd.continue.arg'),   _t('cmd.continue.desc')),
         ('/new',      _t('cmd.new.arg'),        _t('cmd.new.desc')),
@@ -1967,8 +1981,13 @@ class SB:
         self._menu_hint: str = ''
         self._menu_sel: int = 0
         self._menu_scroll: int = 0          # index of the first visible row in the viewport
-        self._menu_on_submit = None        # Callable[[int], None] | None
+        self._menu_on_submit = None        # Callable[[int|list[int]], None] | None
         self._menu_on_cancel = None        # Callable[[], None] | None
+        # Multi-select menus: Space toggles _menu_checked[i]; Enter calls
+        # on_submit(sorted(_menu_checked)).  Single-select (default) calls
+        # on_submit(_menu_sel) and ignores _menu_checked.
+        self._menu_multi: bool = False
+        self._menu_checked: set[int] = set()
         # Interactive command palette: index into _cmd_matches output when
         # buf starts with `/`.  ↑↓ steer the highlight, Tab completes the
         # highlighted command, Enter still executes whatever is in buf.
@@ -2227,23 +2246,38 @@ class SB:
         self._picker_checked = set()
 
     def _show_menu(self, title: str, options: list[str], on_submit,
-                   hint: str | None = None, on_cancel=None) -> None:
+                   hint: str | None = None, on_cancel=None,
+                   multi_select: bool = False) -> None:
         """Open a modal arrow-key menu in place of the input box.
 
         The menu takes over the live region; ↑↓ move the highlight, Enter
         invokes `on_submit(idx)`, Esc invokes `on_cancel()` (if provided).
         Submission auto-closes the menu before invoking the callback so the
-        callback is free to open another menu / commit / start a task."""
+        callback is free to open another menu / commit / start a task.
+
+        `multi_select=True` switches to checkbox mode: Space toggles the
+        highlighted row, the per-row prefix becomes `[x]/[ ]`, and Enter
+        delivers a sorted `list[int]` of all checked indices (may be empty
+        if the user submits with nothing ticked)."""
         if not options:
             return
         self._menu_active = True
         self._menu_options = list(options)
         self._menu_title = title
-        self._menu_hint = hint if hint is not None else _t('menu.hint')
+        # In multi-select mode show a Space-aware hint by default so the user
+        # discovers the toggle key without reading the docstring.
+        if hint is not None:
+            self._menu_hint = hint
+        elif multi_select:
+            self._menu_hint = _t('menu.hint.multi', default='Space toggle · ↑↓ move · Enter submit · Esc cancel')
+        else:
+            self._menu_hint = _t('menu.hint')
         self._menu_sel = 0
         self._menu_scroll = 0
         self._menu_on_submit = on_submit
         self._menu_on_cancel = on_cancel
+        self._menu_multi = bool(multi_select)
+        self._menu_checked = set()
         self._render_live()
 
     def _close_menu(self) -> None:
@@ -2255,6 +2289,8 @@ class SB:
         self._menu_scroll = 0
         self._menu_on_submit = None
         self._menu_on_cancel = None
+        self._menu_multi = False
+        self._menu_checked = set()
 
     @staticmethod
     def _scroll_window(sel: int, total: int, visible: int, scroll: int) -> int:
@@ -2271,12 +2307,17 @@ class SB:
     def _menu_submit(self) -> None:
         cb = self._menu_on_submit
         sel = self._menu_sel
+        multi = self._menu_multi
+        checked = sorted(self._menu_checked) if multi else None
         if not self._menu_active:
             return
         self._close_menu()
         if cb is not None:
             try:
-                cb(sel)
+                # Multi-select delivers a sorted list[int] (possibly empty)
+                # so callers can `if not picked: return` cleanly.  Single-
+                # select keeps the legacy `int` contract.
+                cb(checked if multi else sel)
             except Exception as e:
                 self.commit([_t('err.menu_cb', err=str(e))])
 
@@ -2544,7 +2585,15 @@ class SB:
             rows = [_clip_cells(self._menu_title, w)]
             for i in range(start, end):
                 marker = '▌' if i == self._menu_sel else ' '
-                rows.append(_clip_cells(f'{marker} {self._menu_options[i]}', w))
+                # In multi-select narrow mode prepend [x]/[ ] so the user can
+                # still tell what is ticked even when the box is too narrow
+                # for the bordered card.
+                if self._menu_multi:
+                    box = '[x]' if i in self._menu_checked else '[ ]'
+                    label_i = f'{marker} {box} {self._menu_options[i]}'
+                else:
+                    label_i = f'{marker} {self._menu_options[i]}'
+                rows.append(_clip_cells(label_i, w))
             return rows, 0, 1
         inner = max(8, w)
         content_w = max(1, inner - 4)
@@ -2573,7 +2622,14 @@ class SB:
         # signals position, so no "N more" indicator rows.
         for i in range(start, end):
             style = (_ACCENT + _BOLD) if i == self._menu_sel else ''
-            rows.extend(row(self._menu_options[i], style))
+            # Multi-select rows get a `[x]`/`[ ]` prefix so the user sees what
+            # is currently ticked.  Single-select keeps the legacy clean look
+            # (bold accent on the highlighted row is enough).
+            if self._menu_multi:
+                box = '[x]' if i in self._menu_checked else '[ ]'
+                rows.extend(row(f'{box} {self._menu_options[i]}', style))
+            else:
+                rows.extend(row(self._menu_options[i], style))
         rows.extend(row(''))
         rows.extend(row(self._menu_hint or _t('menu.hint'), _DIM))
         rows.append(bot)
@@ -3598,6 +3654,56 @@ class SB:
                     self.commit(Block('assistant', text))   # markdown re-renders on resize
                 except queue.Empty:
                     self.commit([_t('msg.review_empty')])
+        elif name in ('update', 'autorun', 'morphling', 'goal', 'hive'):
+            # slash_cmds bundle — build a long prompt and feed it back through
+            # _submit so the agent sees an ordinary user turn.  Keeps the
+            # frontend ignorant of SOP details; see frontends/slash_cmds.py.
+            from frontends import slash_cmds
+            prompt = slash_cmds.prompt_for('/' + name, arg or '')
+            if prompt:
+                self._submit(prompt, [])
+            else:
+                self.commit([f'❌ unknown command /{name}'])
+        elif name == 'scheduler':
+            from frontends import slash_cmds
+            parts = (arg or '').split(None, 1)
+            head = parts[0].lower() if parts else ''
+            if head in ('start', 'run'):
+                names = (parts[1] if len(parts) > 1 else '').replace(',', ' ').split()
+                if not names:
+                    self.commit(['Usage: /scheduler start <reflect>[,<reflect2>...]'])
+                else:
+                    lines = []
+                    for n in names:
+                        ok, msg = slash_cmds.start_reflect_task(n)
+                        lines.append(('✅ ' if ok else '❌ ') + msg)
+                    self.commit(lines)
+            else:
+                reflects = slash_cmds.list_reflect_tasks()
+                if not reflects:
+                    self.commit(['(reflect/ 目录下没有 *.py)']); return
+                options = []
+                for r in reflects:
+                    doc = f"  — {r['doc']}" if r['doc'] else ''
+                    options.append(f"{r['name']}{doc}")
+
+                # Multi-select menu: Space ticks, Enter starts every ticked
+                # task back-to-back.  Empty submit is a no-op (user pressed
+                # Enter without ticking anything).
+                def _pick_reflects(idxs: list[int]) -> None:
+                    if not idxs:
+                        self.commit(['(no reflect task picked)']); return
+                    lines = []
+                    for i in idxs:
+                        nm = reflects[i]['name']
+                        ok, msg = slash_cmds.start_reflect_task(nm)
+                        lines.append(('✅ ' if ok else '❌ ') + msg)
+                    self.commit(lines)
+
+                self._show_menu(
+                    'Pick reflect tasks to start  [Space toggle · Enter run · or /scheduler start a,b,c]',
+                    options, _pick_reflects, multi_select=True,
+                )
         elif name == 'llm':
             if arg:
                 self._bridge.switch_llm(int(arg) if arg.isdigit() else -1)
@@ -4211,6 +4317,16 @@ class SB:
                 if o == 0x0e:                                # ↓
                     if n:
                         self._menu_sel = min(n - 1, self._menu_sel + 1)
+                    self._render_live(); continue
+                if self._menu_multi and ch == ' ':            # Space toggles
+                    # Only meaningful in multi-select mode; in single mode we
+                    # swallow Space to keep "modal, no free-text" invariant.
+                    if n:
+                        i = self._menu_sel
+                        if i in self._menu_checked:
+                            self._menu_checked.discard(i)
+                        else:
+                            self._menu_checked.add(i)
                     self._render_live(); continue
                 if ch == '\r':                               # Enter
                     self._menu_submit(); continue

--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -3671,38 +3671,50 @@ class SB:
             if head in ('start', 'run'):
                 names = (parts[1] if len(parts) > 1 else '').replace(',', ' ').split()
                 if not names:
-                    self.commit(['Usage: /scheduler start <reflect>[,<reflect2>...]'])
+                    self.commit(['Usage: /scheduler start <service>[,<service2>...]'])
                 else:
                     lines = []
                     for n in names:
-                        ok, msg = slash_cmds.start_reflect_task(n)
+                        ok, msg = slash_cmds.start_service(n)
                         lines.append(('✅ ' if ok else '❌ ') + msg)
                     self.commit(lines)
             else:
-                reflects = slash_cmds.list_reflect_tasks()
-                if not reflects:
-                    self.commit(['(reflect/ 目录下没有 *.py)']); return
+                # Mirror hub.pyw discover_services(): reflect tasks + frontend
+                # apps, so the picker shows the same set as the GUI launcher.
+                services = slash_cmds.list_launchable_services()
+                if not services:
+                    self.commit(['(没有可启动的服务: reflect/*.py 与 frontends/*app*.py 均为空)']); return
+                ordered = ([s for s in services if s['kind'] == 'reflect'] +
+                           [s for s in services if s['kind'] == 'frontend'])
                 options = []
-                for r in reflects:
-                    doc = f"  — {r['doc']}" if r['doc'] else ''
-                    options.append(f"{r['name']}{doc}")
+                for s in ordered:
+                    doc = f"  — {s['doc']}" if s['doc'] else ''
+                    options.append(f"{s['name']}{doc}")
 
-                # Multi-select menu: Space ticks, Enter starts every ticked
-                # task back-to-back.  Empty submit is a no-op (user pressed
-                # Enter without ticking anything).
-                def _pick_reflects(idxs: list[int]) -> None:
+                # Two-step: Space ticks → Enter → commit-answer confirm → run.
+                # Empty submit is a no-op (Enter without ticking anything).
+                def _pick_services(idxs: list[int]) -> None:
                     if not idxs:
-                        self.commit(['(no reflect task picked)']); return
-                    lines = []
-                    for i in idxs:
-                        nm = reflects[i]['name']
-                        ok, msg = slash_cmds.start_reflect_task(nm)
-                        lines.append(('✅ ' if ok else '❌ ') + msg)
-                    self.commit(lines)
+                        self.commit(['(no service picked)']); return
+                    chosen = [ordered[i]['name'] for i in idxs]
+
+                    def _confirm(ci: int) -> None:
+                        if ci != 0:
+                            self.commit(['已取消，未启动任何服务']); return
+                        lines = []
+                        for nm in chosen:
+                            ok, msg = slash_cmds.start_service(nm)
+                            lines.append(('✅ ' if ok else '❌ ') + msg)
+                        self.commit(lines)
+
+                    self._show_menu(
+                        f'确认启动这 {len(chosen)} 个服务？  ' + '、'.join(chosen),
+                        ['✅ 确认启动', '取消'], _confirm, multi_select=False,
+                    )
 
                 self._show_menu(
-                    'Pick reflect tasks to start  [Space toggle · Enter run · or /scheduler start a,b,c]',
-                    options, _pick_reflects, multi_select=True,
+                    'Pick services to start  [Space toggle · Enter next · or /scheduler start a,b,c]',
+                    options, _pick_services, multi_select=True,
                 )
         elif name == 'llm':
             if arg:

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -143,6 +143,10 @@ _TIPS = (
     "Tip: /branch [name] 从当前历史分裂出新会话，互不污染。",
     "Tip: ask_user 题目里写 [多选] 自动切到 SelectionList；任何 picker 都有 \"Type something\" 走自由输入。",
     "Tip: plan 模式下的 todo 会渲染在消息区与输入框之间的 📋 Plan 卡片，完成后自动消失。",
+    "Tip: /update 让主 agent 自动 git pull 并核查影响面；/autorun 进入 autonomous 自主模式。",
+    "Tip: /morphling <目标> 启用蒸馏吞噬外部技能。",
+    "Tip: /goal <目标> 进入 Goal 模式（缺 condition 时会回头问你预算 / worker 上限）。",
+    "Tip: /hive <目标> 进入 Hive 多 worker 协作；/scheduler 调出 reflect 任务多选启动器。",
 )
 
 
@@ -1075,6 +1079,14 @@ COMMANDS = [
     ("/llm",      "[n]",              "查看 / 切换模型"),
     ("/btw",      "<question>",       "side question — 不打断主 agent"),
     ("/review",   "[request]",         "in-session 代码审查（直接输出报告）"),
+    # ── slash_cmds bundle (prompt-injection + /scheduler picker).  Kept in
+    # the same table so /-completion + the palette pick them up for free.
+    ("/update",    "[note]",           "git pull 更新 GA 仓库并报告影响面"),
+    ("/autorun",   "[seed]",           "进入 autonomous_operation 自主模式"),
+    ("/morphling", "[target]",         "启用 Morphling 蒸馏 / 吞噬外部技能"),
+    ("/goal",      "[goal]",           "进入 Goal 模式（需 condition 约束）"),
+    ("/hive",      "[target]",         "进入 Hive 多 worker 协作模式"),
+    ("/scheduler", "",                 "多选启动 reflect 任务 / 查看 cron"),
     ("/continue", "[n|name]",         "列出 / 恢复历史会话"),
     ("/cost",     "[all]",            "显示当前会话 token 用量（all = 所有会话）"),
     ("/export",   "clip|<file>|all",  "导出最后回复"),
@@ -1966,6 +1978,14 @@ class GenericAgentTUI(App[None]):
             "restore": self._cmd_restore, "btw": self._cmd_btw, "review": self._cmd_review,
             "continue": self._cmd_continue, "cost": self._cmd_cost,
             "reload-keys": self._cmd_reload_keys,
+            # slash_cmds bundle — see frontends/slash_cmds.py for the prompt
+            # bodies + reflect/scheduler discovery.  All but /scheduler are
+            # thin shims that build a prompt and re-enter submit_user_message,
+            # so the agent processes them as ordinary turns.
+            "update": self._cmd_slash_inject, "autorun": self._cmd_slash_inject,
+            "morphling": self._cmd_slash_inject, "goal": self._cmd_slash_inject,
+            "hive": self._cmd_slash_inject,
+            "scheduler": self._cmd_scheduler,
             "quit": self._cmd_quit, "exit": self._cmd_quit,
         }
         try:
@@ -3393,6 +3413,98 @@ class GenericAgentTUI(App[None]):
     def _cmd_quit(self, args, raw):
         self._reset_terminal_title()
         self.exit()
+
+    # ---------------- slash_cmds bundle ----------------
+    def _cmd_slash_inject(self, args, raw):
+        """`/update /autorun /morphling /goal /hive` → prompt
+        injection.  We strip the leading slash command from `raw`, hand the
+        tail to `slash_cmds.prompt_for`, and re-enter `submit_user_message`
+        so the agent sees it as a normal user turn (display bubble still
+        shows the original `/cmd ...` for clarity).
+        """
+        from frontends import slash_cmds
+        text = (raw or "").strip()
+        # Pull just the leading token to look up the prompt builder.
+        head = text.split(None, 1)[0] if text else ""
+        if not head.startswith("/"):
+            self._system("❌ /slash 命令解析失败"); return
+        tail = text[len(head):].strip()
+        prompt = slash_cmds.prompt_for(head, tail)
+        if prompt is None:
+            self._system(f"❌ 未知命令 {head}"); return
+        sess = self.current
+        if sess.status == "running":
+            self._system(f"#{sess.agent_id} 正在跑，/stop 后再发。")
+            return
+        # Keep the user's original `/cmd ...` as the visible bubble so the
+        # transcript stays self-explanatory; the agent sees the long prompt.
+        self.submit_user_message(prompt, display_text=text or head)
+
+    def _cmd_scheduler(self, args, raw):
+        """`/scheduler` lists reflect/*.py + sche_tasks/*.json and starts the
+        chosen reflect task(s).  Usage:
+          /scheduler                — interactive multi-select picker
+                                      (Space toggles, Enter launches every
+                                      checked task in one batch)
+          /scheduler start <name>   — start one reflect task by stem (CLI)
+          /scheduler start a,b,c    — start several at once (CSV, CLI)
+        Cron-style sche_tasks/*.json are read-only here; the launch.pyw
+        scheduler daemon already owns them.
+        """
+        from frontends import slash_cmds
+        body = " ".join(args).strip()
+        parts = body.split(None, 1)
+        head = parts[0].lower() if parts else ""
+        if head in ("start", "run"):
+            names = (parts[1] if len(parts) > 1 else "").replace(",", " ").split()
+            if not names:
+                self._system("Usage: /scheduler start <reflect_name>[,<name2>...]"); return
+            self._launch_reflect_batch(names)
+            return
+        # Default: surface a MultiChoiceList picker for reflect/*.py so the
+        # user can tick several tasks at once (Space toggle, Enter submit).
+        # sche_tasks/*.json are read-only — shown below as a system advisory
+        # so the user still has visibility, but they can't be launched here.
+        reflects = slash_cmds.list_reflect_tasks()
+        sched = slash_cmds.list_scheduler_tasks()
+        if not reflects:
+            self._system("📋 reflect/ 目录下没有 *.py，无可启动任务"); return
+        choices = []
+        for r in reflects:
+            doc = f"  — {r['doc']}" if r['doc'] else ""
+            choices.append((f"{r['name']}{doc}", r['name']))
+        sess = self.current
+        msg = ChatMessage(
+            role="system",
+            content=("📋 选择要启动的 reflect 任务（Space 勾选 · Enter 提交 · Esc 取消）"
+                     "    多选支持 — 提交后批量启动并显示结果"),
+            kind="multi_choice",
+            choices=choices,
+            on_select=lambda names: self._launch_reflect_batch(names),
+        )
+        sess.messages.append(msg)
+        # Cron tasks as a separate read-only advisory line.
+        if sched:
+            lines = ["⏰ sche_tasks/ cron 任务（只读，由 scheduler daemon 调度）："]
+            for s in sched:
+                tag = "" if s["enabled"] else " [DISABLED]"
+                sch = f"  [{s['schedule']}]" if s["schedule"] else ""
+                lines.append(f"  • {s['name']}{sch}{tag}")
+            self._system("\n".join(lines))
+        self._refresh_messages()
+
+    def _launch_reflect_batch(self, names: list[str]) -> None:
+        """Shared by `/scheduler start ...` and the multi_choice picker.
+        Launches every requested reflect/<name>.py via slash_cmds and prints
+        a single ✅/❌ summary block."""
+        from frontends import slash_cmds
+        if not names:
+            self._system("（未选择任何 reflect 任务）"); return
+        lines = [f"🚀 批量启动 {len(names)} 个 reflect 任务："]
+        for n in names:
+            ok, msg = slash_cmds.start_reflect_task(n)
+            lines.append(("  ✅ " if ok else "  ❌ ") + msg)
+        self._system("\n".join(lines))
 
     def _reset_terminal_title(self) -> None:
         # Send via sys.__stdout__ — see _update_terminal_title for why.

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -3459,28 +3459,31 @@ class GenericAgentTUI(App[None]):
             names = (parts[1] if len(parts) > 1 else "").replace(",", " ").split()
             if not names:
                 self._system("Usage: /scheduler start <reflect_name>[,<name2>...]"); return
-            self._launch_reflect_batch(names)
+            self._launch_service_batch(names)
             return
         # Default: surface a MultiChoiceList picker for reflect/*.py so the
         # user can tick several tasks at once (Space toggle, Enter submit).
         # sche_tasks/*.json are read-only — shown below as a system advisory
         # so the user still has visibility, but they can't be launched here.
-        reflects = slash_cmds.list_reflect_tasks()
+        services = slash_cmds.list_launchable_services()
         sched = slash_cmds.list_scheduler_tasks()
-        if not reflects:
-            self._system("📋 reflect/ 目录下没有 *.py，无可启动任务"); return
+        if not services:
+            self._system("📋 没有可启动的服务（reflect/*.py 与 frontends/*app*.py 均为空）"); return
+        # Mirror hub.pyw: reflect tasks + frontend apps, grouped by kind so the
+        # picker reads like the GUI launcher.  Picker value = hub-style path.
         choices = []
-        for r in reflects:
-            doc = f"  — {r['doc']}" if r['doc'] else ""
-            choices.append((f"{r['name']}{doc}", r['name']))
+        for kind in ("reflect", "frontend"):
+            for s in (svc for svc in services if svc["kind"] == kind):
+                doc = f"  — {s['doc']}" if s["doc"] else ""
+                choices.append((f"{s['name']}{doc}", s["name"]))
         sess = self.current
         msg = ChatMessage(
             role="system",
-            content=("📋 选择要启动的 reflect 任务（Space 勾选 · Enter 提交 · Esc 取消）"
-                     "    多选支持 — 提交后批量启动并显示结果"),
+            content=("📋 选择要启动的服务（与 hub.pyw 一致：reflect 任务 + frontend 应用）"
+                     "    Space 勾选 · Enter 提交 · Esc 取消 — 提交后还需二次确认"),
             kind="multi_choice",
             choices=choices,
-            on_select=lambda names: self._launch_reflect_batch(names),
+            on_select=lambda names: self._scheduler_confirm(names),
         )
         sess.messages.append(msg)
         # Cron tasks as a separate read-only advisory line.
@@ -3493,16 +3496,43 @@ class GenericAgentTUI(App[None]):
             self._system("\n".join(lines))
         self._refresh_messages()
 
-    def _launch_reflect_batch(self, names: list[str]) -> None:
-        """Shared by `/scheduler start ...` and the multi_choice picker.
-        Launches every requested reflect/<name>.py via slash_cmds and prints
-        a single ✅/❌ summary block."""
+    def _scheduler_confirm(self, names: list[str]) -> None:
+        """Picker submitted → ask one more `commit answer` confirmation card
+        before actually launching anything (user-requested safety step)."""
+        if not names:
+            self._system("（未选择任何服务）"); return
+        sess = self.current
+        if sess is None: return
+        joined = "、".join(names)
+        confirm = ChatMessage(
+            role="system",
+            content=(f"⚠️ 确认启动以下 {len(names)} 个服务？\n  {joined}"
+                     "    ←/→ 选择 · Enter 确认 · Esc 取消"),
+            kind="choice",
+            choices=[("✅ 确认启动", "__SCHED_GO__"), ("取消", "__SCHED_CANCEL__")],
+            on_select=lambda v, ns=list(names): self._scheduler_commit(v, ns),
+        )
+        sess.messages.append(confirm)
+        self._refresh_messages()
+
+    def _scheduler_commit(self, value: str, names: list[str]) -> str:
+        """on_select for the commit-answer card; returns the breadcrumb text
+        shown after the card collapses (see _collapse_choice)."""
+        if value != "__SCHED_GO__":
+            return "已取消，未启动任何服务"
+        self._launch_service_batch(names)
+        return f"已确认 — 提交启动 {len(names)} 个服务"
+
+    def _launch_service_batch(self, names: list[str]) -> None:
+        """Shared by `/scheduler start ...` (CLI) and the confirmed picker.
+        Launches every requested service via slash_cmds.start_service and
+        prints a single ✅/❌ summary block."""
         from frontends import slash_cmds
         if not names:
-            self._system("（未选择任何 reflect 任务）"); return
-        lines = [f"🚀 批量启动 {len(names)} 个 reflect 任务："]
+            self._system("（未选择任何服务）"); return
+        lines = [f"🚀 批量启动 {len(names)} 个服务："]
         for n in names:
-            ok, msg = slash_cmds.start_reflect_task(n)
+            ok, msg = slash_cmds.start_service(n)
             lines.append(("  ✅ " if ok else "  ❌ ") + msg)
         self._system("\n".join(lines))
 


### PR DESCRIPTION
## Summary

Introduces a **shared slash-command bundle** (`frontends/slash_cmds.py`) and wires it into both Textual TUIs (`tuiapp_v2.py` & `tui_v3.py`). The bundle centralizes prompt builders and launcher helpers so the two front-ends no longer duplicate logic, and it makes the `/scheduler` service picker the single source-of-truth aligned with `hub.pyw discover_services()`.

Also fixes the `/scheduler` picker which previously **did not list all launchable services** and used an inconsistent launch command, and adds a **commit-answer confirmation step** before anything is actually started.

## What's included

### `frontends/slash_cmds.py` (new, shared module)
- **Prompt builders** for slash commands: `build_update_prompt`, `build_autorun_prompt`, `build_morphling_prompt`, `build_goal_prompt`, `build_hive_prompt`, dispatched via `prompt_for(cmd, args_text)`.
- **Launcher helpers**:
  - `list_launchable_services()` — the unified, `hub.pyw`-aligned service list.
  - `start_service(name)` — single entry point that launches a service the same way `hub.pyw` does.
  - `list_reflect_tasks()`, `list_scheduler_tasks()`, `start_reflect_task(name)`.

### `frontends/tuiapp_v2.py` & `frontends/tui_v3.py`
- Wire the shared bundle into both TUIs.
- Rework the `/scheduler` flow into a **multi-select picker** whose entries are produced by `list_launchable_services()`.
- Add a final **commit-answer confirmation menu**: after selecting services and pressing Enter, the user must explicitly confirm before any service is started.

## Fixes (commit `align /scheduler picker with hub.pyw + add commit-answer confirm`)

The previous `/scheduler` helper diverged from `hub.pyw discover_services()`:

| Issue | Before | After |
|---|---|---|
| Service list | Only skipped `_`-prefixed files → leaked `goal_mode` / `scheduler` / `agent_persona` and **missed all `frontends/*app*.py`** | Mirrors `hub.pyw`: `EXCLUDES = {goal_mode, chatapp_common, tuiapp}`, includes both reflect tasks and frontend apps |
| Launch command | `python reflect/X.py` (inconsistent) | `reflect/*.py` via `agentmain.py --reflect reflect/X.py`; `frontends/*app*.py` run directly (`stapp` via `streamlit run`) |
| Confirmation | Started immediately on Enter | Adds an explicit **commit-answer** confirm step before launching |

## Source-of-truth alignment

`list_launchable_services()` is verified to be in **parity with `hub.pyw discover_services()`** (same set of services, same launch commands). Future edits to `/scheduler` should keep `slash_cmds.py` and `hub.pyw` in sync.

## Verification
- All three files compile cleanly (`py_compile`).
- Runtime parity check: `list_launchable_services()` set == `hub.pyw discover_services()` set ✅.
- Diff is scoped strictly to the slash-command bundle + the two TUIs' scheduler flow (no unrelated churn).

## Files changed
```
frontends/slash_cmds.py | 315 +++++++++  (new)
frontends/tui_v3.py     | 142 ++++++--
frontends/tuiapp_v2.py  | 142 ++++++++++
3 files changed, 592 insertions(+), 7 deletions(-)
```
