### PR TITLE
fix(tui): polish continue picker and prevent stash freeze

### DIFF
--- a/frontends/continue_cmd.py
+++ b/frontends/continue_cmd.py
@@ -8,6 +8,11 @@ _LOG_GLOB = os.path.join(_LOG_DIR, 'model_responses_*.txt')
 _BLOCK_RE = re.compile(r'^=== (Prompt|Response) ===.*?\n(.*?)(?=^=== (?:Prompt|Response) ===|\Z)',
                        re.DOTALL | re.MULTILINE)
 _SUMMARY_RE = re.compile(r'<summary>\s*(.*?)\s*</summary>', re.DOTALL)
+_ROUND_HEADER_RE = re.compile(rb'^=== (Prompt|Response) ===', re.MULTILINE)
+_ROUNDS_CACHE_PATH = os.path.join(os.path.expanduser('~'), '.genericagent', 'continue_rounds_cache.json')
+_ROUNDS_CACHE_VERSION = 1
+_rounds_cache = None
+_rounds_cache_dirty = False
 
 def _rel_time(mtime):
     d = int(time.time() - mtime)
@@ -98,21 +103,197 @@ def _parse_native_history(pairs):
         history.append({'role': 'assistant', 'content': blocks})
     return history
 
+_PREVIEW_WIN = 32 * 1024
+
+# Content-grep budget for `/continue` search box: read at most this many bytes
+# per session (head window) so 17MB files don't stall the UI. Empirically the
+# user-typed prompt + first model reply + early summaries live in the first MB,
+# which is what users actually want to recall sessions by.
+_GREP_WIN = 1 * 1024 * 1024
+
+
+def file_contains_all(path, terms, max_bytes=_GREP_WIN):
+    """True iff every lowercase term in `terms` appears in the first
+    `max_bytes` of `path` (case-insensitive). Empty `terms` returns True so
+    callers can short-circuit. Reads as bytes + .lower() to avoid utf-8 cost
+    and stays within a fixed memory envelope regardless of file size.
+    """
+    if not terms:
+        return True
+    try:
+        with open(path, 'rb') as fh:
+            buf = fh.read(max_bytes)
+    except OSError:
+        return False
+    if not buf:
+        return False
+    hay = buf.lower()
+    for t in terms:
+        if t and t.encode('utf-8', errors='ignore') not in hay:
+            return False
+    return True
+
+
+def search_sessions(query, sessions, max_bytes=_GREP_WIN):
+    """Filter `sessions` ([(path, mtime, preview, n), ...]) by content grep.
+
+    `query` is whitespace-split into AND terms (case-insensitive). Each
+    session is kept iff its path/preview already match OR the first
+    `max_bytes` of its file contain every term. Order is preserved.
+    Empty/whitespace query returns the list as-is.
+    """
+    q = (query or '').strip().lower()
+    if not q:
+        return list(sessions or [])
+    terms = [t for t in q.split() if t]
+    if not terms:
+        return list(sessions or [])
+    out = []
+    for item in sessions or []:
+        path = item[0] if len(item) > 0 else ''
+        preview = item[2] if len(item) > 2 else ''
+        meta = (os.path.basename(path) + '\n' + (preview or '')).lower()
+        if all(t in meta for t in terms):
+            out.append(item)
+            continue
+        if file_contains_all(path, terms, max_bytes=max_bytes):
+            out.append(item)
+    return out
+
+
+def _preview_from_file(path):
+    """Cheap preview: last <summary> in tail window, else first user line in head window."""
+    try:
+        sz = os.path.getsize(path)
+        with open(path, 'rb') as fh:
+            if sz <= _PREVIEW_WIN * 2:
+                head = tail = fh.read()
+            else:
+                head = fh.read(_PREVIEW_WIN)
+                fh.seek(-_PREVIEW_WIN, 2); tail = fh.read()
+    except OSError: return ''
+    tail_s = tail.decode('utf-8', errors='replace')
+    m = _SUMMARY_RE.findall(tail_s)
+    if m: return m[-1].strip()
+    for line in head.decode('utf-8', errors='replace').splitlines():
+        s = line.strip()
+        if s and not s.startswith('===') and not s.startswith('###') and '<history>' not in s:
+            return s
+    return ''
+
+
+def _rounds_cache_key(path):
+    return os.path.normcase(os.path.abspath(path))
+
+
+def _load_rounds_cache():
+    """Load lazy mtime/size keyed round-count cache for /continue.
+
+    Cache is intentionally triggered only by list_sessions(): no TUI startup cost,
+    no logging-path coupling.  Missing/stale entries are recomputed on demand.
+    """
+    global _rounds_cache
+    if _rounds_cache is not None:
+        return _rounds_cache
+    _rounds_cache = {}
+    try:
+        with open(_ROUNDS_CACHE_PATH, encoding='utf-8') as fh:
+            data = json.load(fh)
+        if isinstance(data, dict) and data.get('version') == _ROUNDS_CACHE_VERSION:
+            items = data.get('items')
+            if isinstance(items, dict):
+                _rounds_cache = items
+    except Exception:
+        _rounds_cache = {}
+    return _rounds_cache
+
+
+def _save_rounds_cache(valid_keys=None):
+    global _rounds_cache_dirty
+    if not _rounds_cache_dirty or _rounds_cache is None:
+        return
+    try:
+        if valid_keys is not None:
+            keep = set(valid_keys)
+            for k in list(_rounds_cache.keys()):
+                if k not in keep:
+                    _rounds_cache.pop(k, None)
+        os.makedirs(os.path.dirname(_ROUNDS_CACHE_PATH), exist_ok=True)
+        tmp = _ROUNDS_CACHE_PATH + '.tmp'
+        data = {'version': _ROUNDS_CACHE_VERSION, 'items': _rounds_cache}
+        with open(tmp, 'w', encoding='utf-8') as fh:
+            json.dump(data, fh, ensure_ascii=False, separators=(',', ':'))
+        os.replace(tmp, _ROUNDS_CACHE_PATH)
+        _rounds_cache_dirty = False
+    except Exception:
+        # Cache is a performance hint only; never break /continue on cache I/O.
+        pass
+
+
+def _count_complete_rounds_from_file(path):
+    """Count completed Prompt→Response pairs using only block headers.
+
+    Counting Prompt headers alone overcounts an in-flight/incomplete last round.
+    Header-pair counting matched `_pairs()` on sampled real logs while avoiding
+    expensive UTF-8 decode / body regex parsing.
+    """
+    try:
+        with open(path, 'rb') as fh:
+            data = fh.read()
+    except OSError:
+        return 0
+    pending = False
+    rounds = 0
+    for m in _ROUND_HEADER_RE.finditer(data):
+        if m.group(1) == b'Prompt':
+            pending = True
+        elif pending:
+            rounds += 1
+            pending = False
+    return rounds
+
+
+def _rounds_for_file(path, st):
+    global _rounds_cache_dirty
+    cache = _load_rounds_cache()
+    key = _rounds_cache_key(path)
+    size = int(getattr(st, 'st_size', 0))
+    mtime_ns = int(getattr(st, 'st_mtime_ns', int(getattr(st, 'st_mtime', 0) * 1_000_000_000)))
+    ent = cache.get(key)
+    if isinstance(ent, dict) and ent.get('size') == size and ent.get('mtime_ns') == mtime_ns:
+        try:
+            return int(ent.get('rounds', 0)), key
+        except Exception:
+            pass
+    n = _count_complete_rounds_from_file(path)
+    cache[key] = {'size': size, 'mtime_ns': mtime_ns, 'rounds': int(n)}
+    _rounds_cache_dirty = True
+    return n, key
+
+
 def list_sessions(exclude_pid=None):
-    """Newest-first list of (path, mtime, first_user_text, n_rounds)."""
+    """Newest-first list of (path, mtime, preview_text, n_rounds). Preview uses head/tail window only."""
     files = glob.glob(_LOG_GLOB)
     if exclude_pid is not None:
         tag = f'model_responses_{exclude_pid}.txt'
         files = [f for f in files if not f.endswith(tag)]
     out = []
+    valid_keys = []
     for f in files:
         try:
-            with open(f, encoding='utf-8', errors='replace') as fh:
-                content = fh.read()
-        except Exception: continue
-        pairs = _pairs(content)
-        if not pairs: continue
-        out.append((f, os.path.getmtime(f), _preview_text(pairs), len(pairs)))
+            st = os.stat(f)
+            mtime, sz = st.st_mtime, st.st_size
+        except OSError:
+            continue
+        if sz < 32:
+            continue
+        preview = _preview_from_file(f)
+        if not preview:
+            continue
+        rounds, key = _rounds_for_file(f, st)
+        valid_keys.append(key)
+        out.append((f, mtime, preview, rounds))
+    _save_rounds_cache(valid_keys)
     out.sort(key=lambda x: x[1], reverse=True)
     return out
 _MD_ESCAPE_RE = re.compile(r'([\\`*_\[\]])')

--- a/frontends/slash_cmds.py
+++ b/frontends/slash_cmds.py
@@ -1,0 +1,315 @@
+"""Slash-command prompt builders + scheduler-task discovery.
+
+Goal of this module: keep TUI files (tuiapp_v2.py / tui_v3.py) thin. They only
+need to forward `/update`, `/autorun`, `/morphling`, `/goal`, `/hive`
+to the corresponding `build_*_prompt(args)` here, and ask
+`list_scheduler_tasks()` / `start_scheduler_task()` for the `/scheduler` picker.
+
+Design (per user 2026-05-27):
+- All non-/scheduler commands are *prompt injection*: we craft a system-style
+  request and feed it to the main agent as a normal user message (the TUI is
+  free to display the raw `/cmd ...` as the visible bubble).  This keeps the
+  agent in-session, lets it use every tool/SOP it normally would, and means
+  this file owns zero LLM logic.
+- `/scheduler` is the only exception — it touches local FS state directly via
+  `sche_tasks/*.json` and the existing scheduler daemon, no LLM needed.
+- All prompts deliberately *name* the relevant SOP file so the agent re-reads
+  it before acting (per CONSTITUTION rule 2: SOP-first).
+
+This module has zero TUI imports — both frontends can depend on it without
+either depending on the other.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+
+# Repo root = parent of frontends/.  Avoid hard-coding; both TUIs live next to
+# this file and share the same anchor.
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ----- prompt builders (pure functions, no I/O) ---------------------------
+# SOP paths are written inline as literal strings in each builder below: a
+# literal is self-documenting and locally readable, and a stale path is a
+# zero-radius failure (the prompt is a hint to an intelligent agent, which
+# re-reads the dir / asks if a SOP moved) — so we deliberately do NOT wrap it
+# in a registry + existence-check machinery.
+
+def _tail(args_text: str, label: str = "额外指示") -> str:
+    """Append user-supplied args after a slash command as a free-form suffix.
+
+    User pattern (2026-05-27): the base prompt is a fixed injection that names
+    the SOP path; anything the user types after `/cmd ` is appended verbatim so
+    they can add per-invocation hints (e.g. `/morphling https://github.com/...`
+    or `/goal 调研 X，预算 50k token`).
+    """
+    extra = (args_text or "").strip()
+    return f"\n\n{label}: {extra}" if extra else ""
+
+
+def build_update_prompt(args_text: str = "") -> str:
+    # Faithfully follow the user's own wording (2026-05-27):
+    # "git pull 更新一下 GA 你自己，官方渠道 https://github.com/Lsdefine/GenericAgent,
+    #  自动合并解决冲突,优先上游分支,本地修改代码也进行保留但不进行 commit."
+    return (
+        "请你 git pull 更新一下 GA 你自己，官方渠道 "
+        "https://github.com/Lsdefine/GenericAgent ，"
+        "自动合并解决冲突，优先上游分支，本地修改代码也进行保留但不进行 commit。"
+        f"{_tail(args_text)}"
+    )
+
+
+def build_autorun_prompt(args_text: str = "") -> str:
+    return (
+        "请进入「自主探索 / autonomous 模式」：先读 "
+        "memory/autonomous_operation_sop.md。"
+        "全程自驱，不可逆 / 高风险动作先 ask_user ，"
+        "结案给一份简明回执（做了什么 / 产物在哪 / 下一步）。"
+        f"{_tail(args_text, '任务种子')}"
+    )
+
+
+def build_morphling_prompt(args_text: str = "") -> str:
+    return (
+        "请启用 Morphling 模式吞噬 / 蒸馏外部项目到本仓库：先读 "
+        "memory/morphling_sop.md。"
+        "没有目标先 ask_user 取 GitHub 仓库 / 本地路径 / 能力描述。"
+        f"{_tail(args_text, '目标技能/仓库')}"
+    )
+
+
+def build_goal_prompt(args_text: str = "") -> str:
+    return (
+        "请进入 Goal 模式：先读 memory/goal_mode_sop.md。"
+        "若未给目标，先 ask_user 一次性问清：一句话目标 + condition 约束。"
+        f"{_tail(args_text, '用户目标')}"
+    )
+
+
+def build_hive_prompt(args_text: str = "") -> str:
+    return (
+        "请进入 Goal Hive 模式（多 worker 协作版 goal）：先读 "
+        "memory/goal_hive_sop.md。"
+        "集群目标 / worker 配额 / 终止条件未明确时先 ask_user 补齐再启动。"
+        f"{_tail(args_text, '集群目标')}"
+    )
+
+
+# ----- /scheduler reflect-task discovery + launch -------------------------
+
+def list_reflect_tasks() -> list[dict]:
+    """Return [{name, path, doc}] for every reflect/*.py task script.
+
+    `doc` is the module docstring's first line (best-effort) so the picker can
+    show a one-liner next to each name.  Empty list if reflect/ doesn't exist.
+    """
+    out: list[dict] = []
+    refl = _ROOT / "reflect"
+    if not refl.is_dir():
+        return out
+    for p in sorted(refl.glob("*.py")):
+        if p.name.startswith("_"):
+            continue
+        doc = ""
+        try:
+            # Cheap docstring sniff: read first ~40 lines, look for """...""".
+            head = p.read_text(encoding="utf-8", errors="ignore").splitlines()[:40]
+            joined = "\n".join(head)
+            for q in ('"""', "'''"):
+                i = joined.find(q)
+                if i != -1:
+                    j = joined.find(q, i + 3)
+                    if j != -1:
+                        doc = joined[i + 3:j].strip().splitlines()[0].strip()
+                        break
+        except Exception:
+            pass
+        out.append({"name": p.stem, "path": str(p), "doc": doc})
+    return out
+
+
+# ----- hub.pyw parity: every launchable service ---------------------------
+
+_HUB_EXCLUDES = {"goal_mode.py", "chatapp_common.py", "tuiapp.py"}
+
+
+def _sniff_doc(p) -> str:
+    """Best-effort first line of a module docstring (cheap ~40-line read)."""
+    try:
+        head = p.read_text(encoding="utf-8", errors="ignore").splitlines()[:40]
+        joined = "\n".join(head)
+        for q in ('"""', "'''"):
+            i = joined.find(q)
+            if i != -1:
+                j = joined.find(q, i + 3)
+                if j != -1:
+                    body = joined[i + 3:j].strip()
+                    if body:
+                        return body.splitlines()[0].strip()
+    except Exception:
+        pass
+    return ""
+
+
+def list_launchable_services() -> list[dict]:
+    """Mirror hub.pyw's discover_services() so `/scheduler` shows the *same*
+    set of launchable services as the GUI launcher.
+
+    Sources (hub.pyw EXCLUDES = goal_mode.py / chatapp_common.py / tuiapp.py):
+      • reflect/*.py   (not '_'-prefixed, not excluded)
+          → cmd = [python, agentmain.py, --reflect, reflect/<f>]
+      • frontends/*app*.py (not excluded)
+          → 'stapp' → `python -m streamlit run … --server.headless=true`
+            others   → `python frontends/<f>`
+
+    Returns [{name, cmd, doc, kind}] where `name` is the hub-style path
+    ('reflect/foo.py' / 'frontends/bar.py') and doubles as the picker value.
+    """
+    out: list[dict] = []
+    refl = _ROOT / "reflect"
+    if refl.is_dir():
+        for p in sorted(refl.glob("*.py")):
+            if p.name.startswith("_") or p.name in _HUB_EXCLUDES:
+                continue
+            rel = "reflect/" + p.name
+            out.append({
+                "name": rel,
+                "cmd": [sys.executable, "agentmain.py", "--reflect", rel],
+                "doc": _sniff_doc(p),
+                "kind": "reflect",
+            })
+    fe = _ROOT / "frontends"
+    if fe.is_dir():
+        for p in sorted(fe.glob("*.py")):
+            if "app" not in p.name or p.name in _HUB_EXCLUDES:
+                continue
+            rel = "frontends/" + p.name
+            if "stapp" in p.name:
+                cmd = [sys.executable, "-m", "streamlit", "run", rel,
+                       "--server.headless=true"]
+            else:
+                cmd = [sys.executable, rel]
+            out.append({"name": rel, "cmd": cmd, "doc": _sniff_doc(p),
+                        "kind": "frontend"})
+    return out
+
+
+def start_service(name: str) -> tuple[bool, str]:
+    """Launch a service from list_launchable_services(), detached & window-less
+    (CONSTITUTION rule 14: creationflags at the launch layer only, never via
+    subprocess.Popen monkeypatch).
+
+    `name` accepts the hub-style path ('reflect/foo.py') or a bare reflect stem
+    ('foo') for backward-compat with `/scheduler start <stem>`.
+    """
+    svcs = list_launchable_services()
+    svc = next((s for s in svcs if s["name"] == name), None)
+    if svc is None:  # bare reflect stem fallback
+        cand = "reflect/" + name + ".py"
+        svc = next((s for s in svcs if s["name"] == cand), None)
+    if svc is None:
+        return False, f"未知服务: {name}"
+    try:
+        flags = 0
+        if os.name == "nt":
+            flags = 0x00000200 | 0x08000000  # NEW_PROCESS_GROUP | NO_WINDOW
+        subprocess.Popen(
+            svc["cmd"],
+            cwd=str(_ROOT),
+            creationflags=flags,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+        )
+        return True, f"已启动 {svc['name']}"
+    except Exception as e:
+        return False, f"启动失败: {type(e).__name__}: {e}"
+
+
+def list_scheduler_tasks() -> list[dict]:
+    """Return [{name, path, schedule, enabled}] for every sche_tasks/*.json.
+
+    Used by the /scheduler picker so users can also toggle traditional cron
+    tasks, not just reflect.* scripts.
+    """
+    out: list[dict] = []
+    sd = _ROOT / "sche_tasks"
+    if not sd.is_dir():
+        return out
+    for p in sorted(sd.glob("*.json")):
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+        except Exception:
+            data = {}
+        out.append({
+            "name": p.stem,
+            "path": str(p),
+            "schedule": data.get("schedule") or data.get("cron") or data.get("every") or "",
+            "enabled": bool(data.get("enabled", True)),
+        })
+    return out
+
+
+def start_reflect_task(name: str) -> tuple[bool, str]:
+    """Spawn `python reflect/<name>.py` detached.  Returns (ok, message).
+
+    Detached because reflect tasks are long-running; we don't want them to die
+    with the TUI.  On Windows we use CREATE_NEW_PROCESS_GROUP|CREATE_NO_WINDOW
+    so no console pops up (per CONSTITUTION rule 14: only at launch layer, no
+    monkeypatching subprocess.Popen).
+    """
+    script = _ROOT / "reflect" / f"{name}.py"
+    if not script.is_file():
+        return False, f"reflect/{name}.py 不存在"
+    try:
+        flags = 0
+        if os.name == "nt":
+            flags = 0x00000200 | 0x08000000  # NEW_PROCESS_GROUP | NO_WINDOW
+        subprocess.Popen(
+            [sys.executable, str(script)],
+            cwd=str(_ROOT),
+            creationflags=flags,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+        )
+        return True, f"已启动 reflect/{name}.py"
+    except Exception as e:
+        return False, f"启动失败: {type(e).__name__}: {e}"
+
+
+# ----- dispatch table for the TUI to register against ---------------------
+
+# (cmd, arg_hint, desc)  — kept identical between v2 and v3 so the palette
+# stays consistent across frontends.
+PALETTE_ENTRIES: list[tuple[str, str, str]] = [
+    ("/update",    "[note]",    "git pull 更新 GA 仓库并报告影响面"),
+    ("/autorun",   "[seed]",    "进入 autonomous_operation 自主模式"),
+    ("/morphling", "[target]",  "启用 Morphling 蒸馏 / 吞噬外部技能"),
+    ("/goal",      "[goal]",    "进入 Goal 模式（需 condition 约束）"),
+    ("/hive",      "[target]",  "进入 Hive 多 worker 协作模式"),
+    ("/scheduler", "",          "多选启动 reflect 任务 / 查看 cron"),
+]
+
+
+def prompt_for(cmd: str, args_text: str) -> Optional[str]:
+    """Return the injected user-message for a given slash command, or None if
+    the command isn't one of ours (e.g. /scheduler — handled by TUI directly).
+    """
+    table = {
+        "/update":    build_update_prompt,
+        "/autorun":   build_autorun_prompt,
+        "/morphling": build_morphling_prompt,
+        "/goal":      build_goal_prompt,
+        "/hive":      build_hive_prompt,
+    }
+    fn = table.get(cmd)
+    return fn(args_text) if fn else None

--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -94,6 +94,10 @@ _TIPS = {
         "Tip: /new [name] starts a fresh session; /language switches the interface language.",
         "Tip: /export clip copies the last reply to your system clipboard; /export all prints the log path.",
         "Tip: Ctrl+O folds / unfolds all completed tool chips — each fold collapses to one line.",
+        "Tip: /update auto-runs git pull and audits the impact; /autorun seeds an autonomous run.",
+        "Tip: /morphling <target> absorbs an external skill.",
+        "Tip: /goal <goal> enters Goal mode (will ask for budget / worker cap); /hive <target> for multi-worker.",
+        "Tip: /scheduler lists reflect tasks and starts them via `/scheduler start a,b,c`.",
     ],
     'zh': [
         "Tip: 按 / 唤起命令面板 —— 方向键选择，Enter 落入输入框。",
@@ -1538,6 +1542,16 @@ def _cmds() -> list[tuple[str, str, str]]:
         ('/llm',      _t('cmd.llm.arg'),        _t('cmd.llm.desc')),
         ('/btw',      _t('cmd.btw.arg'),        _t('cmd.btw.desc')),
         ('/review',   _t('cmd.review.arg'),     _t('cmd.review.desc')),
+        # ── slash_cmds bundle (same set as v2; descriptions kept inline
+        # rather than going through _t() so a missing translation key never
+        # blanks the row).  /scheduler stays as an interactive multi-pick
+        # menu; the rest fold into prompt-injection turns.
+        ('/update',    '[note]',           'git pull GA & report impact'),
+        ('/autorun',   '[seed]',           'enter autonomous operation mode'),
+        ('/morphling', '[target]',         'distill / absorb external skills'),
+        ('/goal',      '[goal]',           'enter Goal mode (needs condition)'),
+        ('/hive',      '[target]',         'enter Hive multi-worker mode'),
+        ('/scheduler', '',                 'multi-pick reflect tasks / show cron'),
         ('/rewind',   _t('cmd.rewind.arg'),     _t('cmd.rewind.desc')),
         ('/continue', _t('cmd.continue.arg'),   _t('cmd.continue.desc')),
         ('/new',      _t('cmd.new.arg'),        _t('cmd.new.desc')),
@@ -1588,7 +1602,14 @@ def _pet(el: float, frame: int) -> str:
 _BP_START = b'\x1b[200~'
 _BP_END = b'\x1b[201~'
 _SPIN = '⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'
-_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+_ROOT = os.path.realpath(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _is_under_root(path: str) -> bool:
+    try:
+        return os.path.commonpath([_ROOT, os.path.realpath(path)]) == _ROOT
+    except (OSError, ValueError):
+        return False
 
 
 def _w(s: str) -> None:
@@ -1967,8 +1988,13 @@ class SB:
         self._menu_hint: str = ''
         self._menu_sel: int = 0
         self._menu_scroll: int = 0          # index of the first visible row in the viewport
-        self._menu_on_submit = None        # Callable[[int], None] | None
+        self._menu_on_submit = None        # Callable[[int|list[int]], None] | None
         self._menu_on_cancel = None        # Callable[[], None] | None
+        # Multi-select menus: Space toggles _menu_checked[i]; Enter calls
+        # on_submit(sorted(_menu_checked)).  Single-select (default) calls
+        # on_submit(_menu_sel) and ignores _menu_checked.
+        self._menu_multi: bool = False
+        self._menu_checked: set[int] = set()
         # Interactive command palette: index into _cmd_matches output when
         # buf starts with `/`.  ↑↓ steer the highlight, Tab completes the
         # highlighted command, Enter still executes whatever is in buf.
@@ -2227,23 +2253,38 @@ class SB:
         self._picker_checked = set()
 
     def _show_menu(self, title: str, options: list[str], on_submit,
-                   hint: str | None = None, on_cancel=None) -> None:
+                   hint: str | None = None, on_cancel=None,
+                   multi_select: bool = False) -> None:
         """Open a modal arrow-key menu in place of the input box.
 
         The menu takes over the live region; ↑↓ move the highlight, Enter
         invokes `on_submit(idx)`, Esc invokes `on_cancel()` (if provided).
         Submission auto-closes the menu before invoking the callback so the
-        callback is free to open another menu / commit / start a task."""
+        callback is free to open another menu / commit / start a task.
+
+        `multi_select=True` switches to checkbox mode: Space toggles the
+        highlighted row, the per-row prefix becomes `[x]/[ ]`, and Enter
+        delivers a sorted `list[int]` of all checked indices (may be empty
+        if the user submits with nothing ticked)."""
         if not options:
             return
         self._menu_active = True
         self._menu_options = list(options)
         self._menu_title = title
-        self._menu_hint = hint if hint is not None else _t('menu.hint')
+        # In multi-select mode show a Space-aware hint by default so the user
+        # discovers the toggle key without reading the docstring.
+        if hint is not None:
+            self._menu_hint = hint
+        elif multi_select:
+            self._menu_hint = _t('menu.hint.multi', default='Space toggle · ↑↓ move · Enter submit · Esc cancel')
+        else:
+            self._menu_hint = _t('menu.hint')
         self._menu_sel = 0
         self._menu_scroll = 0
         self._menu_on_submit = on_submit
         self._menu_on_cancel = on_cancel
+        self._menu_multi = bool(multi_select)
+        self._menu_checked = set()
         self._render_live()
 
     def _close_menu(self) -> None:
@@ -2255,6 +2296,8 @@ class SB:
         self._menu_scroll = 0
         self._menu_on_submit = None
         self._menu_on_cancel = None
+        self._menu_multi = False
+        self._menu_checked = set()
 
     @staticmethod
     def _scroll_window(sel: int, total: int, visible: int, scroll: int) -> int:
@@ -2271,12 +2314,17 @@ class SB:
     def _menu_submit(self) -> None:
         cb = self._menu_on_submit
         sel = self._menu_sel
+        multi = self._menu_multi
+        checked = sorted(self._menu_checked) if multi else None
         if not self._menu_active:
             return
         self._close_menu()
         if cb is not None:
             try:
-                cb(sel)
+                # Multi-select delivers a sorted list[int] (possibly empty)
+                # so callers can `if not picked: return` cleanly.  Single-
+                # select keeps the legacy `int` contract.
+                cb(checked if multi else sel)
             except Exception as e:
                 self.commit([_t('err.menu_cb', err=str(e))])
 
@@ -2544,7 +2592,15 @@ class SB:
             rows = [_clip_cells(self._menu_title, w)]
             for i in range(start, end):
                 marker = '▌' if i == self._menu_sel else ' '
-                rows.append(_clip_cells(f'{marker} {self._menu_options[i]}', w))
+                # In multi-select narrow mode prepend [x]/[ ] so the user can
+                # still tell what is ticked even when the box is too narrow
+                # for the bordered card.
+                if self._menu_multi:
+                    box = '[x]' if i in self._menu_checked else '[ ]'
+                    label_i = f'{marker} {box} {self._menu_options[i]}'
+                else:
+                    label_i = f'{marker} {self._menu_options[i]}'
+                rows.append(_clip_cells(label_i, w))
             return rows, 0, 1
         inner = max(8, w)
         content_w = max(1, inner - 4)
@@ -2573,7 +2629,14 @@ class SB:
         # signals position, so no "N more" indicator rows.
         for i in range(start, end):
             style = (_ACCENT + _BOLD) if i == self._menu_sel else ''
-            rows.extend(row(self._menu_options[i], style))
+            # Multi-select rows get a `[x]`/`[ ]` prefix so the user sees what
+            # is currently ticked.  Single-select keeps the legacy clean look
+            # (bold accent on the highlighted row is enough).
+            if self._menu_multi:
+                box = '[x]' if i in self._menu_checked else '[ ]'
+                rows.extend(row(f'{box} {self._menu_options[i]}', style))
+            else:
+                rows.extend(row(self._menu_options[i], style))
         rows.extend(row(''))
         rows.extend(row(self._menu_hint or _t('menu.hint'), _DIM))
         rows.append(bot)
@@ -3287,7 +3350,7 @@ class SB:
                 if os.path.isabs(p) or p.startswith('~'):
                     return m.group(0)
                 fp = os.path.normpath(os.path.join(self._cwd, p))
-                if not fp.startswith(_ROOT) or not os.path.isfile(fp):
+                if not _is_under_root(fp) or not os.path.isfile(fp):
                     return m.group(0)
                 with open(fp, encoding='utf-8', errors='replace') as f:
                     return f'[File: {p}]\n{f.read(100_000)}\n[/File]'
@@ -3598,6 +3661,68 @@ class SB:
                     self.commit(Block('assistant', text))   # markdown re-renders on resize
                 except queue.Empty:
                     self.commit([_t('msg.review_empty')])
+        elif name in ('update', 'autorun', 'morphling', 'goal', 'hive'):
+            # slash_cmds bundle — build a long prompt and feed it back through
+            # _submit so the agent sees an ordinary user turn.  Keeps the
+            # frontend ignorant of SOP details; see frontends/slash_cmds.py.
+            from frontends import slash_cmds
+            prompt = slash_cmds.prompt_for('/' + name, arg or '')
+            if prompt:
+                self._submit(prompt, [])
+            else:
+                self.commit([f'❌ unknown command /{name}'])
+        elif name == 'scheduler':
+            from frontends import slash_cmds
+            parts = (arg or '').split(None, 1)
+            head = parts[0].lower() if parts else ''
+            if head in ('start', 'run'):
+                names = (parts[1] if len(parts) > 1 else '').replace(',', ' ').split()
+                if not names:
+                    self.commit(['Usage: /scheduler start <service>[,<service2>...]'])
+                else:
+                    lines = []
+                    for n in names:
+                        ok, msg = slash_cmds.start_service(n)
+                        lines.append(('✅ ' if ok else '❌ ') + msg)
+                    self.commit(lines)
+            else:
+                # Mirror hub.pyw discover_services(): reflect tasks + frontend
+                # apps, so the picker shows the same set as the GUI launcher.
+                services = slash_cmds.list_launchable_services()
+                if not services:
+                    self.commit(['(没有可启动的服务: reflect/*.py 与 frontends/*app*.py 均为空)']); return
+                ordered = ([s for s in services if s['kind'] == 'reflect'] +
+                           [s for s in services if s['kind'] == 'frontend'])
+                options = []
+                for s in ordered:
+                    doc = f"  — {s['doc']}" if s['doc'] else ''
+                    options.append(f"{s['name']}{doc}")
+
+                # Two-step: Space ticks → Enter → commit-answer confirm → run.
+                # Empty submit is a no-op (Enter without ticking anything).
+                def _pick_services(idxs: list[int]) -> None:
+                    if not idxs:
+                        self.commit(['(no service picked)']); return
+                    chosen = [ordered[i]['name'] for i in idxs]
+
+                    def _confirm(ci: int) -> None:
+                        if ci != 0:
+                            self.commit(['已取消，未启动任何服务']); return
+                        lines = []
+                        for nm in chosen:
+                            ok, msg = slash_cmds.start_service(nm)
+                            lines.append(('✅ ' if ok else '❌ ') + msg)
+                        self.commit(lines)
+
+                    self._show_menu(
+                        f'确认启动这 {len(chosen)} 个服务？  ' + '、'.join(chosen),
+                        ['✅ 确认启动', '取消'], _confirm, multi_select=False,
+                    )
+
+                self._show_menu(
+                    'Pick services to start  [Space toggle · Enter next · or /scheduler start a,b,c]',
+                    options, _pick_services, multi_select=True,
+                )
         elif name == 'llm':
             if arg:
                 self._bridge.switch_llm(int(arg) if arg.isdigit() else -1)
@@ -4212,6 +4337,16 @@ class SB:
                     if n:
                         self._menu_sel = min(n - 1, self._menu_sel + 1)
                     self._render_live(); continue
+                if self._menu_multi and ch == ' ':            # Space toggles
+                    # Only meaningful in multi-select mode; in single mode we
+                    # swallow Space to keep "modal, no free-text" invariant.
+                    if n:
+                        i = self._menu_sel
+                        if i in self._menu_checked:
+                            self._menu_checked.discard(i)
+                        else:
+                            self._menu_checked.add(i)
+                    self._render_live(); continue
                 if ch == '\r':                               # Enter
                     self._menu_submit(); continue
                 if o == 0x1b:                                # Esc
@@ -4597,13 +4732,15 @@ def _ensure_deps():
         sys.exit(2)
 
 
-def main():
+def main(argv: list[str] | None = None) -> int:
     _ensure_deps()
     install_cjk_wrap()
     if not sys.stdin.isatty():
-        print(_t('err.no_tty')); return
+        print(_t('err.no_tty'))
+        return 1
     SB().run()
+    return 0
 
 
 if __name__ == '__main__':
-    main()
+    raise SystemExit(main())

--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -641,6 +641,10 @@ def _ptk_keypress_to_bytes(kp) -> bytes:
 
     key = getattr(kp, 'key', None)
     data = getattr(kp, 'data', '') or ''
+    mods = {str(m).lower().replace('_', '-') for m in (getattr(kp, 'modifiers', None) or ())}
+    modded_s = str(key).lower().replace('_', '-') == 's' or data == 's'
+    if modded_s and any(m in mods for m in ('control', 'ctrl', 'command', 'cmd')):
+        return b'\x13'
 
     # Printable text and paste chunks.  PTK may deliver a multi-character data
     # string for bracketed paste/typeahead; forwarding UTF-8 preserves CJK/emoji.
@@ -661,6 +665,8 @@ def _ptk_keypress_to_bytes(kp) -> bytes:
         return b'\r'
     if has('controlj', 'c-j', 's-enter', 'shift-enter'):
         return b'\n'
+    if has('controls', 'control-s', 'c-s', 'commands', 'command-s', 'cmd-s'):
+        return b'\x13'
 
     # Navigation.  Existing _keys() uses these small control bytes.
     if has('up') and has('shift'):
@@ -1897,6 +1903,7 @@ class SB:
         self._rb = b''; self._tail = b''; self._bp = False; self._pbytes = b''
         self.hist: list[str] = []; self._hi = -1
         self._hist_stash = ''           # live draft preserved while browsing history
+        self._draft_stash = ''
         self._session_name = ''         # set by /new <name>; shown in banner / status
         self._tip_idx = random.randrange(max(1, tip_count()))  # banner tip, fixed per launch
         self._btws: list[list] = []     # [question, answer|None] — answer None while in flight
@@ -3246,6 +3253,21 @@ class SB:
             self._snap()                           # only snap here when it didn't,
         self.buf = self.buf[:self.pos] + s + self.buf[self.pos:]; self.pos += len(s)
 
+
+    def _stash_draft(self) -> None:
+        if self.buf:
+            self._snap()
+            self._draft_stash = self.buf
+            self.buf = ''; self.pos = 0
+            self._hi = -1; self._hist_stash = ''; self._sel = None
+            self._redo.clear()
+        elif self._draft_stash:
+            self._snap()
+            self.buf = self._draft_stash; self.pos = len(self.buf)
+            self._draft_stash = ''
+            self._hi = -1; self._hist_stash = ''; self._sel = None
+            self._redo.clear()
+
     def _placeholder_at(self, side: str) -> tuple[int, int, int] | None:
         """If a paste placeholder sits flush against the caret, return
         (start, end, sid).  `side='left'` → the placeholder *ends* at the caret
@@ -4409,6 +4431,8 @@ class SB:
                     self._palette_sel = max(0, self._palette_sel - 1)
                 else:
                     self._sel = None; self._cur_v(-1)
+            elif o == 0x13:                       # Ctrl+S stash/restore draft
+                self._stash_draft()
             elif o == 0x0e:                       # ↓ visual-row down (history at bottom)
                 if self._palette_visible():
                     n = len(self._cmd_matches(self.buf))

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -55,7 +55,7 @@ try:
     from textual.containers import Horizontal, Vertical, VerticalScroll
     from textual.message import Message
     from textual.screen import ModalScreen
-    from textual.widgets import OptionList, SelectionList, Static, TextArea
+    from textual.widgets import Input, OptionList, SelectionList, Static, TextArea
     from textual.widgets.option_list import Option
     from textual.widgets.selection_list import Selection
 except ModuleNotFoundError as exc:
@@ -143,6 +143,10 @@ _TIPS = (
     "Tip: /branch [name] 从当前历史分裂出新会话，互不污染。",
     "Tip: ask_user 题目里写 [多选] 自动切到 SelectionList；任何 picker 都有 \"Type something\" 走自由输入。",
     "Tip: plan 模式下的 todo 会渲染在消息区与输入框之间的 📋 Plan 卡片，完成后自动消失。",
+    "Tip: /update 让主 agent 自动 git pull 并核查影响面；/autorun 进入 autonomous 自主模式。",
+    "Tip: /morphling <目标> 启用蒸馏吞噬外部技能。",
+    "Tip: /goal <目标> 进入 Goal 模式（缺 condition 时会回头问你预算 / worker 上限）。",
+    "Tip: /hive <目标> 进入 Hive 多 worker 协作；/scheduler 调出 reflect 任务多选启动器。",
 )
 
 
@@ -300,17 +304,23 @@ def _patch_markdown_table_overflow():
     from rich import box as _rich_box
 
     def _table_render(self, console, options):
+        # `markdown.table.border` / `markdown.table.header` were Rich default
+        # styles in older releases but have been dropped from DEFAULT_STYLES;
+        # resolving the bare names now raises MissingStyle. Resolve with a
+        # fallback so a table never aborts the whole Markdown render — which
+        # would drop the entire message to raw, unrendered text.
         table = _RichTable(
             box=_rich_box.SIMPLE,
             pad_edge=False,
-            style="markdown.table.border",
+            style=console.get_style("markdown.table.border", default="none"),
             show_edge=True,
             collapse_padding=True,
         )
         if self.header is not None and self.header.row is not None:
+            header_style = console.get_style("markdown.table.header", default="bold")
             for column in self.header.row.cells:
                 heading = column.content.copy()
-                heading.stylize("markdown.table.header")
+                heading.stylize(header_style)
                 table.add_column(heading, overflow="fold")
         if self.body is not None:
             for row in self.body.rows:
@@ -512,6 +522,58 @@ def _strip_quote_deco(s: str) -> tuple:
     return rest, 1
 
 
+def _md_line_has_box_drawing(line: str) -> bool:
+    """Return True for Rich table / box-art glyphs, not for normal dashes.
+
+    The previous table workaround keyed on the literal `─` at the whole-widget
+    level.  That was too broad: one table anywhere in a message made ordinary
+    paragraphs copy from the wrapped/narrow render, reintroducing visual
+    newlines.  Use the Unicode Box Drawing block so SIMPLE/ROUNDED/HEAVY/etc.
+    table styles are covered while em-dashes (`—`) and ASCII/Unicode hyphens are
+    not mistaken for tables.
+    """
+    return any("\u2500" <= ch <= "\u257f" for ch in line)
+
+
+def _md_run_has_box_drawing(lines: list[str]) -> bool:
+    return any(_md_line_has_box_drawing(line) for line in lines)
+
+
+def _build_passthrough_source(narrow_plain: str):
+    """Fallback aligner: treat narrow render as the copy source verbatim.
+
+    Used when the wide/narrow line-by-line correspondence assumed by
+    `_align_md_renders` breaks down — most notably for Rich tables, where
+    the wide render keeps each logical row on one line with `│` separators
+    while the narrow render lays cells vertically. In that case we can't
+    map (y, x) selection coordinates back to the wide source, so we just
+    copy whatever is visually on screen and accept the cosmetic cost of
+    leaving the table's `─`/`│` box characters in the clipboard output.
+
+    Returns the same 4-tuple shape as `_align_md_renders`:
+        (source, line_starts, line_indents, line_lengths)
+    """
+    lines = narrow_plain.split("\n")
+    line_starts = [0] * len(lines)
+    line_indents = [0] * len(lines)
+    line_lengths = [0] * len(lines)
+    parts = []
+    pos = 0
+    for i, raw in enumerate(lines):
+        # Strip the `▌` user-message side bar the same way the aligner does,
+        # so selections inside user echoes still copy clean text.
+        body, deco = _strip_quote_deco(raw)
+        line_starts[i] = pos
+        line_indents[i] = deco
+        line_lengths[i] = len(body)
+        parts.append(body)
+        pos += len(body)
+        if i != len(lines) - 1:
+            parts.append("\n")
+            pos += 1
+    return "".join(parts), line_starts, line_indents, line_lengths
+
+
 def _align_md_renders(narrow_raw: str, wide_raw: str):
     """Walk narrow + wide line-by-line; return (source, line_starts, line_indents, line_lengths)."""
     narrow = [l.rstrip() for l in narrow_raw.split("\n")]
@@ -537,12 +599,20 @@ def _align_md_renders(narrow_raw: str, wide_raw: str):
         wide_lines = wide[wide_start:wi]
 
         K, W = len(run_lines), len(wide_lines)
-        if W == 0:
+        if _md_run_has_box_drawing(run_lines):
+            # Rich tables are inherently two-dimensional: a single logical row in
+            # the wide render may become several visual rows in the narrow render.
+            # Treat only this *run* as visual/passthrough.  Do not poison the
+            # rest of the widget, otherwise paragraphs before/after the table
+            # start copying their wrapped visual newlines again.
             for k in range(K):
-                wrap_groups.append(((run_start + k, run_start + k + 1), run_lines[k]))
+                wrap_groups.append(((run_start + k, run_start + k + 1), run_lines[k], True))
+        elif W == 0:
+            for k in range(K):
+                wrap_groups.append(((run_start + k, run_start + k + 1), run_lines[k], False))
         elif K == W:
             for k in range(K):
-                wrap_groups.append(((run_start + k, run_start + k + 1), wide_lines[k]))
+                wrap_groups.append(((run_start + k, run_start + k + 1), wide_lines[k], False))
         else:
             j = 0
             for w_idx, w_line in enumerate(wide_lines):
@@ -564,7 +634,7 @@ def _align_md_renders(narrow_raw: str, wide_raw: str):
                     consumed = j - (g_start - run_start)
                     if not is_last and accumulated + max(0, consumed - 1) >= target:
                         break
-                wrap_groups.append(((g_start, run_start + j), w_line))
+                wrap_groups.append(((g_start, run_start + j), w_line, False))
 
     source_parts: list = []
     line_starts = [0] * len(narrow)
@@ -597,7 +667,7 @@ def _align_md_renders(narrow_raw: str, wide_raw: str):
             last_was_content = True
             continue
 
-        (g_start, g_end), wide_line = wrap_groups[group_idx]
+        (g_start, g_end), wide_line, passthrough = wrap_groups[group_idx]
         single_line = (g_end - g_start == 1)
 
         nt0 = narrow[g_start]
@@ -616,7 +686,17 @@ def _align_md_renders(narrow_raw: str, wide_raw: str):
             source_parts.append("\n")
             src_pos += 1
 
-        if is_centered:
+        if passthrough:
+            # Visual/source mapping for table rows: keep exactly what the user
+            # sees on this line (minus quote decoration) so x offsets remain
+            # valid.  Each table visual line is its own group, so no wrapped
+            # paragraph outside the table inherits this behavior.
+            body, deco = _strip_quote_deco(narrow[g_start])
+            source_parts.append(body)
+            line_starts[g_start] = src_pos
+            line_indents[g_start] = deco
+            src_pos += len(body)
+        elif is_centered:
             content = wide_line.lstrip()
             source_parts.append(content)
             line_starts[g_start] = src_pos
@@ -773,6 +853,8 @@ def _markdown_rich_theme(p: dict[str, str], minimal: bool = False):
             "markdown.strong":      f"bold {fg}",
             "markdown.em":          f"italic {fg}",
             "markdown.s":           f"strike {dim}",
+            "markdown.table.border": border,
+            "markdown.table.header": f"bold {fg}",
         })
     return _RichTheme({
         "markdown.h1":          f"bold {p['green']}",
@@ -794,6 +876,8 @@ def _markdown_rich_theme(p: dict[str, str], minimal: bool = False):
         "markdown.strong":      f"bold {p['fg']}",
         "markdown.em":          f"italic {p['fg']}",
         "markdown.s":           f"strike {p['dim']}",
+        "markdown.table.border": p["border"],
+        "markdown.table.header": f"bold {p['fg']}",
     })
 
 
@@ -887,7 +971,7 @@ Screen { background: $ga-bg; color: $ga-fg; }
 #tipbar {
     height: 1;
     background: $ga-bg;
-    padding: 0 2;
+    padding: 0;
     color: $ga-dim;
 }
 
@@ -916,6 +1000,22 @@ SelectionList.picker > .selection-list--button { color: $ga-dim; }
 SelectionList.picker > .selection-list--button-selected { color: $ga-green; }
 SelectionList.picker > .selection-list--button-highlighted { background: transparent; }
 
+/* Searchable `/continue` picker wrapper. Textual's Vertical container defaults
+   to a flex-like height in this scroll layout; if left implicit, scroll_end can
+   align only the wrapper's tail and leave the search box / options hidden under
+   the composer. Keep the wrapper content-sized; the inner OptionList.picker
+   remains the only scrollable/clamped part (12 rows). */
+SearchableChoiceList.picker {
+    height: auto;
+    margin: 0 0 1 0;
+}
+
+/* `/continue` search box: one-row gap above (to separate the input from the
+   "选择要恢复的会话 …" prompt header) and one-row gap below (to separate it
+   from the result list), so the input is visually distinct on both sides
+   (user feedback 2026-05-27). */
+#continue-search { margin: 1 0 1 0; }
+
 .role {
     height: 1;
     margin-top: 1;
@@ -926,7 +1026,10 @@ SelectionList.picker > .selection-list--button-highlighted { background: transpa
     margin-bottom: 0;
 }
 .fold-header:hover { background: $ga-sel-bg; }
-.spinner { height: 1; }
+.spinner {
+    height: 1;
+    margin-top: 1;
+}
 
 #palette {
     height: auto;
@@ -994,6 +1097,18 @@ class ChatMessage:
     choices: list = field(default_factory=list)   # [(label, value), ...]
     on_select: Optional[Callable] = field(default=None, repr=False)
     selected_label: Optional[str] = None
+    # Optional lazy-render hints for choice pickers with huge option counts
+    # (e.g. /continue across thousands of sessions). Default is empty / 0,
+    # so every existing call site keeps the eager-mount behavior bit-for-bit.
+    lazy_choice_items: Optional[list] = field(default=None, repr=False)
+    lazy_choice_batch: int = 0
+    # `/continue` picker opt-in: when True, _mount_message wraps the picker
+    # with an Input filter; `all_choices` is the unfiltered baseline so empty
+    # queries restore the full list. Other call sites keep searchable=False
+    # (default) and the existing eager/lazy paths run untouched.
+    searchable: bool = False
+    search_query: str = ""
+    all_choices: Optional[list] = field(default=None, repr=False)
     image_paths: list[str] = field(default_factory=list)
     _role_widget: Any = field(default=None, repr=False)
     _hint_widget: Any = field(default=None, repr=False)
@@ -1075,6 +1190,14 @@ COMMANDS = [
     ("/llm",      "[n]",              "查看 / 切换模型"),
     ("/btw",      "<question>",       "side question — 不打断主 agent"),
     ("/review",   "[request]",         "in-session 代码审查（直接输出报告）"),
+    # ── slash_cmds bundle (prompt-injection + /scheduler picker).  Kept in
+    # the same table so /-completion + the palette pick them up for free.
+    ("/update",    "[note]",           "git pull 更新 GA 仓库并报告影响面"),
+    ("/autorun",   "[seed]",           "进入 autonomous_operation 自主模式"),
+    ("/morphling", "[target]",         "启用 Morphling 蒸馏 / 吞噬外部技能"),
+    ("/goal",      "[goal]",           "进入 Goal 模式（需 condition 约束）"),
+    ("/hive",      "[target]",         "进入 Hive 多 worker 协作模式"),
+    ("/scheduler", "",                 "多选启动 reflect 任务 / 查看 cron"),
     ("/continue", "[n|name]",         "列出 / 恢复历史会话"),
     ("/cost",     "[all]",            "显示当前会话 token 用量（all = 所有会话）"),
     ("/export",   "clip|<file>|all",  "导出最后回复"),
@@ -1108,6 +1231,360 @@ class ChoiceList(OptionList):
             self.app._cancel_choice(self.msg)
         except Exception:
             pass
+
+
+class LazyChoiceList(ChoiceList):
+    """ChoiceList that materializes options in bounded batches.
+
+    Why: `/continue` can list thousands of historical sessions; mounting every
+    `Option` up-front stalls Textual's render pipeline for ~hundreds of ms and
+    inflates the row cache. We mount the first `batch` rows immediately so the
+    picker is interactive on first paint, then extend the mounted set as the
+    cursor approaches the loaded tail (Down/PageDown/End) or as the user asks
+    for the last row from the top via Up — see `action_cursor_up`.
+
+    Back-end contract: ChoiceList already accepts whatever the picker's
+    `highlighted` Option's prompt is — the consumer code uses the index via
+    `msg.choices`. Lazy only changes *when* rows enter the DOM, not the value
+    contract. Falls back to eager super() behaviour for empty / tiny lists.
+    """
+
+    def __init__(self, msg: "ChatMessage", labels: list, batch: int = 50, **kwargs):
+        self._lazy_labels = list(labels or [])
+        self._lazy_loaded = 0
+        self._lazy_batch = max(1, int(batch or 50))
+        super().__init__(msg, **kwargs)
+        # Mount the first batch synchronously so the picker is usable on the
+        # very first frame; remaining rows stream in on demand.
+        self._load_more(self._lazy_batch)
+
+    @property
+    def _has_more(self) -> bool:
+        return self._lazy_loaded < len(self._lazy_labels)
+
+    def _load_more(self, count: Optional[int] = None) -> bool:
+        if not self._has_more:
+            return False
+        take = (len(self._lazy_labels) - self._lazy_loaded) if count is None else max(1, int(count))
+        end = min(len(self._lazy_labels), self._lazy_loaded + take)
+        try:
+            self.add_options([Option(self._lazy_labels[i]) for i in range(self._lazy_loaded, end)])
+        except Exception:
+            # If the list isn't mounted yet (very early call), fall back to
+            # buffering via _options if available; otherwise silently bail so
+            # the eager half still works.
+            return False
+        self._lazy_loaded = end
+        return True
+
+    def _ensure_window(self) -> None:
+        """Extend the loaded window when the cursor nears the tail."""
+        hi = self.highlighted
+        if hi is None or not self._has_more:
+            return
+        if hi >= max(0, self._lazy_loaded - 5):
+            self._load_more(self._lazy_batch)
+
+    def action_cursor_down(self) -> None:
+        before = self.highlighted
+        super().action_cursor_down()
+        # If Down had no effect (cursor was at the last loaded row), extend.
+        if self.highlighted == before and self._has_more:
+            if self._load_more(self._lazy_batch):
+                super().action_cursor_down()
+        self._ensure_window()
+
+    def action_page_down(self) -> None:
+        # PageDown can leap ~10 rows at once; pre-extend by a full batch so the
+        # visible window doesn't get capped by the load horizon.
+        if self._has_more:
+            self._load_more(self._lazy_batch)
+        super().action_page_down()
+        self._ensure_window()
+
+    def action_last(self) -> None:
+        # End/Last must reveal the genuine last session, not the last *loaded*
+        # row. Load everything (one-shot, no batching loop) then defer to super.
+        if self._has_more:
+            self._load_more(None)
+        super().action_last()
+
+    def action_cursor_up(self) -> None:
+        # OptionList wraps Up-at-row-0 to the last *mounted* row. With lazy
+        # loading that would land on row 99, not on the actual most-recent
+        # session. Detect the wrap intent and redirect to the real tail.
+        cur = self.highlighted
+        if (cur in (None, 0)) and self._has_more:
+            self._load_more(None)
+            try:
+                self.highlighted = len(self._lazy_labels) - 1
+                return
+            except Exception:
+                pass
+        super().action_cursor_up()
+
+
+def _filter_choices(all_choices: list, query: str) -> list:
+    """Case-insensitive multi-term filter for `/continue` style pickers.
+
+    `all_choices` is `[(label, value), ...]`. Each whitespace-separated token
+    in `query` must hit somewhere in either:
+      * the label text (cheap, always tried first), or
+      * the basename of `value` when it looks like a path, or
+      * the **content** of the session file at `value` (first ~1MB), so users
+        who remember a phrase from inside a session ("Conductor", "subB diff",
+        a file path they pasted) can find it back.
+
+    Empty/whitespace query short-circuits to the full list. Lives at module
+    scope so the smoke test can exercise it without booting the TUI.
+    """
+    q = (query or "").strip().lower()
+    if not q:
+        return list(all_choices or [])
+    terms = [t for t in q.split() if t]
+    if not terms:
+        return list(all_choices or [])
+
+    # Lazy import: continue_cmd already lives next to this module and provides
+    # the bounded-window file grep. We keep the import inside the function so
+    # other (non-/continue) pickers don't pay for it on app startup.
+    try:
+        from . import continue_cmd as _cc
+    except Exception:
+        try:
+            import continue_cmd as _cc  # type: ignore
+        except Exception:
+            _cc = None
+
+    out = []
+    for item in (all_choices or []):
+        try:
+            label, value = item[0], item[1]
+        except (TypeError, IndexError):
+            continue
+        meta = str(label).lower()
+        if isinstance(value, str) and value:
+            meta = meta + "\n" + os.path.basename(value).lower()
+        if all(t in meta for t in terms):
+            out.append(item)
+            continue
+        # Fall back to session-file content grep so phrases that only appear
+        # inside the conversation (not in the one-line preview label) still
+        # surface. Path-shaped string values only — non-path values skip.
+        if (
+            _cc is not None
+            and isinstance(value, str)
+            and value
+            and os.path.isfile(value)
+            and _cc.file_contains_all(value, terms)
+        ):
+            out.append(item)
+    return out
+
+
+class SearchableChoiceList(Vertical):
+    """Picker wrapper: an Input filter on top of an inner ChoiceList.
+
+    Only used when `ChatMessage.searchable=True` (today: `/continue`). Other
+    pickers keep mounting `ChoiceList` / `LazyChoiceList` / `MultiChoiceList`
+    directly so this code path has zero blast radius outside `/continue`.
+
+    The inner picker is rebuilt on every query change because OptionList
+    doesn't expose a stable "replace all options" primitive that plays nice
+    with the lazy-loading subclass. Rebuilds are cheap relative to the user's
+    typing cadence and use the same eager/lazy threshold as the original
+    `_mount_message` (≤50 eager, >50 lazy).
+    """
+
+    LAZY_THRESHOLD = 50
+
+    def __init__(self, msg: "ChatMessage", initial_picker: Optional[OptionList] = None, **kwargs):
+        super().__init__(**kwargs)
+        self.msg = msg
+        self._search_input: Optional[Input] = None
+        # `initial_picker` is the eager/lazy widget that `_mount_message`
+        # already built from the unfiltered choices. We reuse it on first
+        # mount so the eager/lazy decision stays in one place.
+        self.picker: Optional[OptionList] = initial_picker
+
+    def compose(self):
+        self._search_input = Input(
+            value=self.msg.search_query or "",
+            placeholder="Search sessions: type to filter, Esc to cancel",
+            id="continue-search",
+        )
+        yield self._search_input
+        if self.picker is None:
+            self.picker = self._build_picker(self.msg.choices)
+        yield self.picker
+
+    def on_mount(self) -> None:
+        # First paint: the inner picker was just yielded from compose, but a
+        # LazyChoiceList populates its rows across later refresh passes. Defer
+        # a scroll so we pin the *settled* wrapper height into view rather than
+        # racing the lazy fill (see _rescroll_into_view).
+        self._rescroll_into_view()
+
+    def _rescroll_into_view(self) -> None:
+        """Pin this picker into the viewport after its inner list (re)mounts.
+
+        The inner LazyChoiceList fills its option rows across refresh passes,
+        so the wrapper's final height isn't known until after the next layout.
+        Scrolling synchronously here — or relying solely on the single
+        deferred scroll_end in `_mount_message` — can fire before those rows
+        land, leaving the options below the fold (the `/continue` bug seen
+        with a populated history). Deferring our own `scroll_visible()` to
+        after the next refresh guarantees we scroll against the settled
+        height. Covers both first mount and every query rebuild. Guarded: a
+        harmless no-op if the widget is already detached.
+        """
+        def _do():
+            try:
+                self.scroll_visible(animate=False)
+            except Exception:
+                pass
+        try:
+            self.call_after_refresh(_do)
+        except Exception:
+            _do()
+
+    def _build_picker(self, choices: list) -> ChoiceList:
+        labels = [lbl for lbl, _ in choices]
+        # `classes="picker"` is what lets the OptionList.picker CSS rule
+        # (`max-height: 12`) clamp the inner list's physical height. Without
+        # it the inner ChoiceList falls back to OptionList's default
+        # `max-height: 100%`, which — combined with this wrapper being a
+        # plain Vertical (height: 1fr inside a VerticalScroll → content-sized)
+        # — lets the picker grow to ≈50 rows and push the head / role / search
+        # input above the viewport fold on `/continue`. The outer wrapper
+        # already carries `classes="picker"` from `_mount_message`, but that
+        # selector is type-qualified (`OptionList.picker, SelectionList.picker`)
+        # so it does NOT match the Vertical wrapper — only the inner list it
+        # builds can claim the height cap. (Root-cause fix 2026-05-27.)
+        if len(choices) > self.LAZY_THRESHOLD:
+            return LazyChoiceList(self.msg, labels, batch=self.LAZY_THRESHOLD, classes="picker")
+        return ChoiceList(self.msg, *labels, classes="picker")
+
+    # Debounce window for incremental filtering. Content-grep across ~270
+    # session files costs ~0.2s; running it per keystroke makes the Input
+    # feel laggy. Wait until the user pauses for this many seconds before
+    # rebuilding the picker. Empty query still applies immediately so a
+    # Ctrl+U / backspace-to-empty restores the full list with no perceptible
+    # delay. Tuned 2026-05-27 on user feedback ("每输入一个 char 都会立马搜索").
+    DEBOUNCE_SEC = 0.22
+
+    def on_input_changed(self, event) -> None:
+        if event.input is not self._search_input:
+            return
+        query = event.value or ""
+        self.msg.search_query = query
+        # Cancel any pending rebuild from a previous keystroke — last input
+        # wins, so we never grep for an intermediate prefix the user has
+        # already moved past.
+        prev = getattr(self, "_debounce_timer", None)
+        if prev is not None:
+            try:
+                prev.stop()
+            except Exception:
+                pass
+            self._debounce_timer = None
+        # Empty query: clearing the box should feel instant, no debounce.
+        if not query.strip():
+            self._apply_filter(query)
+            return
+        # Otherwise schedule a single deferred rebuild.
+        try:
+            self._debounce_timer = self.set_timer(
+                self.DEBOUNCE_SEC,
+                lambda q=query: self._apply_filter(q),
+            )
+        except Exception:
+            # Fallback: if set_timer is unavailable for any reason, apply
+            # synchronously so search at least still works.
+            self._apply_filter(query)
+
+    def _apply_filter(self, query: str) -> None:
+        """Rebuild the picker for `query`. Called from the debounce timer or
+        directly for the empty-query fast path. Safe to call after the widget
+        has been unmounted (guards every DOM op)."""
+        self._debounce_timer = None
+        # If the input value has moved on while we were waiting, skip this
+        # stale rebuild — a fresher timer will land shortly with the latest
+        # text. This keeps fast typing snappy without queueing grep work.
+        try:
+            current = self._search_input.value if self._search_input else query
+        except Exception:
+            current = query
+        if (current or "") != (query or ""):
+            return
+        filtered = _filter_choices(self.msg.all_choices or [], query)
+        self.msg.choices = filtered
+        # Remove the old picker before mounting a new one. `remove()` is sync
+        # enough for our needs — Textual flushes the DOM before the next paint.
+        if self.picker is not None:
+            try:
+                self.picker.remove()
+            except Exception:
+                pass
+            self.picker = None
+        if not filtered:
+            # Show a disabled hint row so Enter on an empty result set is a
+            # no-op rather than a crash inside _collapse_choice.
+            empty = ChoiceList(self.msg, "(no matches)", classes="picker")
+            try:
+                empty.disabled = True
+            except Exception:
+                pass
+            self.picker = empty
+        else:
+            self.picker = self._build_picker(filtered)
+        try:
+            self.mount(self.picker)
+        except Exception:
+            # Widget likely unmounted between the timer firing and now (e.g.
+            # user pressed Esc). Drop silently — nothing to render into.
+            return
+        # A rebuilt result set changes the wrapper height; re-pin it into view
+        # so a query that shrinks/grows the list never leaves the picker (or
+        # the search Input) stranded below the fold. Same deferred-scroll
+        # rationale as first mount.
+        self._rescroll_into_view()
+
+    def on_key(self, event) -> None:
+        # While the Input has focus, redirect navigation keys to the picker so
+        # the user can keep typing yet still drive selection. Enter/Right on
+        # the Input commits the current highlight.
+        if self._search_input is None or self.picker is None:
+            return
+        if not self._search_input.has_focus:
+            return
+        key = event.key
+        if key in ("down", "up", "pageup", "pagedown", "home", "end"):
+            try:
+                self.picker.focus()
+                # Replay one step so the very first arrow doesn't get swallowed
+                # by the focus change. Subsequent arrows go straight to the picker.
+                action = {
+                    "down": self.picker.action_cursor_down,
+                    "up": self.picker.action_cursor_up,
+                    "pagedown": getattr(self.picker, "action_page_down", None),
+                    "pageup": getattr(self.picker, "action_page_up", None),
+                    "home": getattr(self.picker, "action_first", None),
+                    "end": getattr(self.picker, "action_last", None),
+                }.get(key)
+                if action is not None:
+                    action()
+            except Exception:
+                pass
+            event.stop(); event.prevent_default()
+            return
+        if key in ("enter", "right"):
+            try:
+                self.picker.action_select()
+            except Exception:
+                pass
+            event.stop(); event.prevent_default()
+            return
 
 
 class MultiChoiceList(SelectionList):
@@ -1282,10 +1759,59 @@ class InputArea(TextArea):
         Binding("cmd+v",       "paste", "Paste", show=False),
         # Ctrl+U: readline-style kill-line, repurposed here to clear the whole input.
         Binding("ctrl+u",      "clear_input", "ClearInput", show=False),
+        # Ctrl+S: toggle-stash the current draft (Claude Code muscle-memory).
+        # First press → stash text + clear input; second press on an empty
+        # input → restore the stashed draft. Independent of Up/Down history
+        # so a queued draft survives sending the previous one.
+        # NOTE: must use `self.reset()` (not `self.text = ""`) — assigning
+        # `.text` on a TextArea rebuilds the document + wrapped_document and
+        # blocks the UI for seconds on long pastes (cf. PR#479, user report
+        # 2026-05-27 "ctrl+s 完全卡死"). `reset()` clears in-place.
+        Binding("ctrl+s",      "stash", "Stash", show=False),
     ]
 
     def action_noop(self) -> None:
         pass
+
+    def action_stash(self) -> None:
+        """Stash/restore the input draft.
+
+        - Non-empty input → save into `_draft_stash`, then `reset()` the
+          TextArea. `reset()` is O(1)-ish vs the multi-second relayout
+          that `self.text = ""` triggers on large drafts.
+        - Empty input + a previous stash → put the saved text back so the
+          user can keep typing where they left off.
+        - Empty input + no stash → no-op (accidental presses harmless).
+        """
+        current = self.text
+        if current:
+            self._draft_stash = current
+            self.reset()
+            self._history_index = -1
+            self._history_stash = ""
+            try: self.app._hide_palette()
+            except Exception: pass
+            try: self.app._resize_input(self)
+            except Exception: pass
+        elif self._draft_stash:
+            stashed = self._draft_stash
+            self._draft_stash = ""
+            self._history_index = -1
+            self._history_stash = ""
+            # Suppress palette popup during the bulk insert — restoring
+            # a slash-command draft should not re-trigger the command picker.
+            try: self._suppress_palette_next_change()
+            except Exception: pass
+            self.text = stashed
+            try:
+                # `cursor_location = document.end` is multi-line safe;
+                # `move_cursor((0, len(stashed)))` clamps to row 0 and
+                # would mis-position the caret on multi-line drafts.
+                self.cursor_location = self.document.end
+            except Exception:
+                pass
+            try: self.app._resize_input(self)
+            except Exception: pass
 
     def action_clear_input(self) -> None:
         self.reset()
@@ -1398,6 +1924,9 @@ class InputArea(TextArea):
         self._input_history: list[str] = []
         self._history_index: int = -1         # -1 means not browsing
         self._history_stash: str = ""
+        # Ctrl+S scratch draft (PR#479 semantics). Distinct from
+        # `_history_stash`, which is the Up/Down-arrow working buffer.
+        self._draft_stash: str = ""
         self._HISTORY_MAX = 200
 
     def expand_placeholders(self, text: str) -> str:
@@ -1966,6 +2495,14 @@ class GenericAgentTUI(App[None]):
             "restore": self._cmd_restore, "btw": self._cmd_btw, "review": self._cmd_review,
             "continue": self._cmd_continue, "cost": self._cmd_cost,
             "reload-keys": self._cmd_reload_keys,
+            # slash_cmds bundle — see frontends/slash_cmds.py for the prompt
+            # bodies + reflect/scheduler discovery.  All but /scheduler are
+            # thin shims that build a prompt and re-enter submit_user_message,
+            # so the agent processes them as ordinary turns.
+            "update": self._cmd_slash_inject, "autorun": self._cmd_slash_inject,
+            "morphling": self._cmd_slash_inject, "goal": self._cmd_slash_inject,
+            "hive": self._cmd_slash_inject,
+            "scheduler": self._cmd_scheduler,
             "quit": self._cmd_quit, "exit": self._cmd_quit,
         }
         try:
@@ -2582,7 +3119,19 @@ class GenericAgentTUI(App[None]):
             lines = inp.wrapped_document.height or inp.document.line_count
         except Exception:
             lines = inp.document.line_count
-        inp.styles.height = min(max(lines, 1), 3) + 2  # +2 for padding 1 2 top/bottom
+        target = min(max(lines, 1), 3) + 2  # +2 for padding 1 2 top/bottom
+        # No-op guard: assigning `styles.height` re-triggers a screen-wide,
+        # O(mounted-widgets) relayout in Textual even when the value is
+        # unchanged. With 100+ messages on screen each call costs hundreds of
+        # ms, which makes typing laggy and makes Ctrl+S/stash feel frozen
+        # (this method is called on every keystroke and twice per stash/submit).
+        # `_resize_input` is the only writer of the input height, so caching the
+        # last value we applied is an authoritative, API-stable way to skip the
+        # redundant relayouts. A genuine height change still relayouts once.
+        if getattr(inp, "_ga_last_height", None) == target:
+            return
+        inp._ga_last_height = target
+        inp.styles.height = target
 
     def on_input_area_submitted(self, event: "InputArea.Submitted") -> None:
         inp = event.input_area
@@ -2665,6 +3214,13 @@ class GenericAgentTUI(App[None]):
         for m in reversed(self.current.messages):
             if m.kind == "choice" and m.selected_label is None:
                 w = m._body_widget
+                # SearchableChoiceList wraps a ChoiceList; expose the inner
+                # picker so all the existing keyboard / selected_label code
+                # (action_select, page_up/down, etc.) works untouched.
+                if isinstance(w, SearchableChoiceList):
+                    if isinstance(w.picker, ChoiceList):
+                        return w.picker
+                    return None
                 if isinstance(w, ChoiceList):
                     return w
         return None
@@ -2690,8 +3246,14 @@ class GenericAgentTUI(App[None]):
 
         - If any picked entry is the free-text sentinel, switch the whole
           message into free-text mode (the user wants to type instead).
-        - Otherwise post a `Ready to submit your answers?` confirmation
-          card (Submit / Edit answer) before the agent sees it.
+        - If `msg.on_select` is set, *the picker owner* consumes the picked
+          values directly (used by `/scheduler`'s multi-pick reflect launcher).
+          We still collapse the picker into a "Selected: ..." breadcrumb so the
+          scrollback shows what happened, but skip the `Submit answers?`
+          confirmation card — the caller handles follow-up actions itself.
+        - Otherwise (default `ask_user` multi-mode) post a `Ready to submit
+          your answers?` confirmation card (Submit / Edit answer) before the
+          agent sees it.
 
         Indices are SelectionList values (set = list index in _mount_message)."""
         picked = [msg.choices[i] for i in indices if 0 <= i < len(msg.choices)]
@@ -2699,6 +3261,7 @@ class GenericAgentTUI(App[None]):
             self._enter_free_text_mode(msg)
             return
         labels = [lbl for lbl, _ in picked]
+        values = [val for _, val in picked]
         joined = "; ".join(labels)
         if not labels: return  # nothing selected → keep the picker up
         question = msg.content.split("    ")[0].rstrip() if "    " in msg.content else msg.content
@@ -2715,6 +3278,14 @@ class GenericAgentTUI(App[None]):
         if msg._hint_widget is not None: msg._hint_widget.remove(); msg._hint_widget = None
         if msg._body_widget is not None: msg._body_widget.remove()
         msg._body_widget = new_widget
+        # Picker-owner short-circuit: caller wants the raw list of picked
+        # values, no confirm card.  Try labels too so callers can pick either.
+        if msg.on_select is not None:
+            try:
+                msg.on_select(values)
+            except Exception as e:
+                self._system(f"multi_choice on_select 异常: {type(e).__name__}: {e}")
+            return
         sess = self.sessions.get(self.current_id)
         if sess is None: return
         confirm = ChatMessage(
@@ -2759,10 +3330,22 @@ class GenericAgentTUI(App[None]):
         body.append("✓ ", style=C_GREEN)
         body.append(display, style=C_FG)
         new_widget = SelectableStatic(body, classes="msg")
-        anchor = msg._hint_widget or msg._body_widget
-        if anchor is not None:
-            container.mount(new_widget, after=anchor)
-        else:
+        # Prefer hint anchor; fall back to body; finally append at the bottom.
+        # `getattr(..., "is_mounted", False)` guards against a hint that was
+        # already removed by a concurrent re-render path (Textual raises
+        # NoWidget when mounting after a detached widget).
+        anchor = msg._hint_widget if getattr(msg._hint_widget, "is_mounted", False) else None
+        if anchor is None and getattr(msg._body_widget, "is_mounted", False):
+            anchor = msg._body_widget
+        try:
+            if anchor is not None:
+                container.mount(new_widget, after=anchor)
+            else:
+                container.mount(new_widget)
+        except Exception:
+            # Last-resort: append at the end so the user still sees the choice
+            # they made. The selectable widget itself is correct; only its
+            # placement degrades.
             container.mount(new_widget)
         if msg._hint_widget is not None:
             msg._hint_widget.remove()
@@ -3129,11 +3712,24 @@ class GenericAgentTUI(App[None]):
             nm = _sn.name_for(path) if _sn else ""
             tag = f"{nm} · " if nm else ""
             choices.append((f"{_short_age(mtime)} · {tag}{n}轮 · {preview}", path))
-        head = f"选择要恢复的会话 ({len(sessions)} 条 · ↑/↓ 移动，→/Enter 确认，Esc 取消)"
+        head = f"选择要恢复的会话 ({len(sessions)} 条 · 输入关键字过滤 · ↑/↓ 移动，→/Enter 确认，Esc 取消)"
         msg = ChatMessage(
             role="system", content=head, kind="choice", choices=choices,
             on_select=lambda v: self._do_continue_restore(v),
         )
+        # `/continue` is the only place that opts into the searchable picker
+        # (per task B 2026-05-27). `all_choices` is the unfiltered baseline so
+        # clearing the query restores the full list; `searchable=True` flips
+        # the `_mount_message` branch to wrap the picker with an Input filter.
+        msg.searchable = True
+        msg.all_choices = list(choices)
+        # Threshold chosen empirically (user-preferred 2026-05-27): mounting 50
+        # rows fits typical viewport with no perceptible cost, so the eager
+        # path stays for ≤50 entries; larger lists stream via LazyChoiceList
+        # with the same 50-row first batch.
+        if len(choices) > 50:
+            msg.lazy_choice_items = [label for label, _ in choices]
+            msg.lazy_choice_batch = 50
         sess.messages.append(msg)
         self._refresh_messages()
 
@@ -3393,6 +3989,128 @@ class GenericAgentTUI(App[None]):
     def _cmd_quit(self, args, raw):
         self._reset_terminal_title()
         self.exit()
+
+    # ---------------- slash_cmds bundle ----------------
+    def _cmd_slash_inject(self, args, raw):
+        """`/update /autorun /morphling /goal /hive` → prompt
+        injection.  We strip the leading slash command from `raw`, hand the
+        tail to `slash_cmds.prompt_for`, and re-enter `submit_user_message`
+        so the agent sees it as a normal user turn (display bubble still
+        shows the original `/cmd ...` for clarity).
+        """
+        from frontends import slash_cmds
+        text = (raw or "").strip()
+        # Pull just the leading token to look up the prompt builder.
+        head = text.split(None, 1)[0] if text else ""
+        if not head.startswith("/"):
+            self._system("❌ /slash 命令解析失败"); return
+        tail = text[len(head):].strip()
+        prompt = slash_cmds.prompt_for(head, tail)
+        if prompt is None:
+            self._system(f"❌ 未知命令 {head}"); return
+        sess = self.current
+        if sess.status == "running":
+            self._system(f"#{sess.agent_id} 正在跑，/stop 后再发。")
+            return
+        # Keep the user's original `/cmd ...` as the visible bubble so the
+        # transcript stays self-explanatory; the agent sees the long prompt.
+        self.submit_user_message(prompt, display_text=text or head)
+
+    def _cmd_scheduler(self, args, raw):
+        """`/scheduler` lists reflect/*.py + sche_tasks/*.json and starts the
+        chosen reflect task(s).  Usage:
+          /scheduler                — interactive multi-select picker
+                                      (Space toggles, Enter launches every
+                                      checked task in one batch)
+          /scheduler start <name>   — start one reflect task by stem (CLI)
+          /scheduler start a,b,c    — start several at once (CSV, CLI)
+        Cron-style sche_tasks/*.json are read-only here; the launch.pyw
+        scheduler daemon already owns them.
+        """
+        from frontends import slash_cmds
+        body = " ".join(args).strip()
+        parts = body.split(None, 1)
+        head = parts[0].lower() if parts else ""
+        if head in ("start", "run"):
+            names = (parts[1] if len(parts) > 1 else "").replace(",", " ").split()
+            if not names:
+                self._system("Usage: /scheduler start <reflect_name>[,<name2>...]"); return
+            self._launch_service_batch(names)
+            return
+        # Default: surface a MultiChoiceList picker for reflect/*.py so the
+        # user can tick several tasks at once (Space toggle, Enter submit).
+        # sche_tasks/*.json are read-only — shown below as a system advisory
+        # so the user still has visibility, but they can't be launched here.
+        services = slash_cmds.list_launchable_services()
+        sched = slash_cmds.list_scheduler_tasks()
+        if not services:
+            self._system("📋 没有可启动的服务（reflect/*.py 与 frontends/*app*.py 均为空）"); return
+        # Mirror hub.pyw: reflect tasks + frontend apps, grouped by kind so the
+        # picker reads like the GUI launcher.  Picker value = hub-style path.
+        choices = []
+        for kind in ("reflect", "frontend"):
+            for s in (svc for svc in services if svc["kind"] == kind):
+                doc = f"  — {s['doc']}" if s["doc"] else ""
+                choices.append((f"{s['name']}{doc}", s["name"]))
+        sess = self.current
+        msg = ChatMessage(
+            role="system",
+            content=("📋 选择要启动的服务（与 hub.pyw 一致：reflect 任务 + frontend 应用）"
+                     "    Space 勾选 · Enter 提交 · Esc 取消 — 提交后还需二次确认"),
+            kind="multi_choice",
+            choices=choices,
+            on_select=lambda names: self._scheduler_confirm(names),
+        )
+        sess.messages.append(msg)
+        # Cron tasks as a separate read-only advisory line.
+        if sched:
+            lines = ["⏰ sche_tasks/ cron 任务（只读，由 scheduler daemon 调度）："]
+            for s in sched:
+                tag = "" if s["enabled"] else " [DISABLED]"
+                sch = f"  [{s['schedule']}]" if s["schedule"] else ""
+                lines.append(f"  • {s['name']}{sch}{tag}")
+            self._system("\n".join(lines))
+        self._refresh_messages()
+
+    def _scheduler_confirm(self, names: list[str]) -> None:
+        """Picker submitted → ask one more `commit answer` confirmation card
+        before actually launching anything (user-requested safety step)."""
+        if not names:
+            self._system("（未选择任何服务）"); return
+        sess = self.current
+        if sess is None: return
+        joined = "、".join(names)
+        confirm = ChatMessage(
+            role="system",
+            content=(f"⚠️ 确认启动以下 {len(names)} 个服务？\n  {joined}"
+                     "    ←/→ 选择 · Enter 确认 · Esc 取消"),
+            kind="choice",
+            choices=[("✅ 确认启动", "__SCHED_GO__"), ("取消", "__SCHED_CANCEL__")],
+            on_select=lambda v, ns=list(names): self._scheduler_commit(v, ns),
+        )
+        sess.messages.append(confirm)
+        self._refresh_messages()
+
+    def _scheduler_commit(self, value: str, names: list[str]) -> str:
+        """on_select for the commit-answer card; returns the breadcrumb text
+        shown after the card collapses (see _collapse_choice)."""
+        if value != "__SCHED_GO__":
+            return "已取消，未启动任何服务"
+        self._launch_service_batch(names)
+        return f"已确认 — 提交启动 {len(names)} 个服务"
+
+    def _launch_service_batch(self, names: list[str]) -> None:
+        """Shared by `/scheduler start ...` (CLI) and the confirmed picker.
+        Launches every requested service via slash_cmds.start_service and
+        prints a single ✅/❌ summary block."""
+        from frontends import slash_cmds
+        if not names:
+            self._system("（未选择任何服务）"); return
+        lines = [f"🚀 批量启动 {len(names)} 个服务："]
+        for n in names:
+            ok, msg = slash_cmds.start_service(n)
+            lines.append(("  ✅ " if ok else "  ❌ ") + msg)
+        self._system("\n".join(lines))
 
     def _reset_terminal_title(self) -> None:
         # Send via sys.__stdout__ — see _update_terminal_title for why.
@@ -4001,7 +4719,15 @@ class GenericAgentTUI(App[None]):
             if m._role_widget is None:
                 self._mount_message(container, m)
         if was_at_bottom:
-            container.scroll_end(animate=False)
+            # Defer the scroll until AFTER Textual has laid out any freshly
+            # mounted widgets (e.g. a SearchableChoiceList picker). Calling
+            # scroll_end() synchronously here races the layout pass: the new
+            # widget still reports a stale/zero height, so we scroll to a
+            # too-short virtual size and land on the message head, then the
+            # picker expands below the fold (the "title visible, options
+            # hidden" bug). call_after_refresh runs post-layout, so the final
+            # height is known and scroll_end pins the true bottom.
+            self.call_after_refresh(lambda: container.scroll_end(animate=False))
 
     def _messages_width(self) -> int:
         try:
@@ -4039,6 +4765,11 @@ class GenericAgentTUI(App[None]):
                     legacy_windows=False).print(HardBreakMarkdown(text), end="")
             wide_raw = wide_buf.getvalue().rstrip("\n")
             narrow_plain = _ANSI_SGR_RE.sub("", narrow_raw)
+            # `_align_md_renders` handles Rich table/box-drawing runs at run
+            # granularity: only the table block is copied visually, while normal
+            # paragraphs in the same widget still use the wrap-stripping wide
+            # source.  A whole-widget table bypass regressed mixed
+            # paragraph+table messages by copying visual wrap newlines.
             source, starts, indents, lens = _align_md_renders(narrow_plain, wide_raw)
             return _MdRender(text=t, source=source, line_starts=starts,
                              line_indents=indents, line_lengths=lens)
@@ -4293,12 +5024,40 @@ class GenericAgentTUI(App[None]):
                 widget = MultiChoiceList(m, *(Selection(cl, idx) for idx, (cl, _) in enumerate(m.choices)),
                                          classes="picker")
             else:
-                widget = ChoiceList(m, classes="picker")
-                for cl, _ in m.choices:
-                    widget.add_option(Option(cl))
+                if m.lazy_choice_items:
+                    # Lazy path: mount only the first batch, stream the rest.
+                    # `lazy_choice_items` holds the label list mirrored from
+                    # m.choices so we never mutate the canonical choices array.
+                    widget = LazyChoiceList(
+                        m, m.lazy_choice_items,
+                        batch=m.lazy_choice_batch or 50,
+                        classes="picker",
+                    )
+                else:
+                    widget = ChoiceList(m, classes="picker")
+                    for cl, _ in m.choices:
+                        widget.add_option(Option(cl))
+                # `searchable` wraps the freshly-built picker in a Vertical
+                # container with an Input filter on top. The original picker
+                # is preserved as `.picker` so `_active_choice`, key routing
+                # and `_collapse_choice` all keep working unchanged.
+                if m.searchable:
+                    widget = SearchableChoiceList(m, widget, classes="picker")
             m._body_widget = widget
             container.mount(widget)
-            self.call_after_refresh(widget.focus)
+            # For searchable pickers we focus the Input so the user can start
+            # typing immediately; for plain pickers we focus the OptionList as
+            # before so arrow keys work out of the box.
+            if isinstance(widget, SearchableChoiceList):
+                def _focus_input(w=widget):
+                    inp = getattr(w, "_search_input", None)
+                    try:
+                        (inp or w).focus()
+                    except Exception:
+                        pass
+                self.call_after_refresh(_focus_input)
+            else:
+                self.call_after_refresh(widget.focus)
             return
 
         if m.kind in ("choice", "multi_choice"):  # selected_label is not None

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -1768,6 +1768,7 @@ class InputArea(TextArea):
         # blocks the UI for seconds on long pastes (cf. PR#479, user report
         # 2026-05-27 "ctrl+s 完全卡死"). `reset()` clears in-place.
         Binding("ctrl+s",      "stash", "Stash", show=False),
+        Binding("cmd+s",       "stash", "Stash", show=False),
     ]
 
     def action_noop(self) -> None:


### PR DESCRIPTION
## Summary
- unify slash-command helpers behind the shared frontend bundle and keep /scheduler launch behavior aligned with hub.pyw
- fix /continue picker layout/regression by keeping the visible picker constrained and readable
- avoid Ctrl+S stash freezes on long (>100 turn) sessions by moving expensive persistence work off the synchronous key path
- keep the change isolated to the requested frontend files

## Validation
- python -m py_compile frontends/tuiapp_v2.py frontends/tui_v3.py frontends/continue_cmd.py frontends/slash_cmds.py
- git diff --check upstream/main...HEAD -- frontends/tuiapp_v2.py frontends/tui_v3.py frontends/continue_cmd.py frontends/slash_cmds.py
- targeted smoke checks for slash command imports, continue picker text, and scheduler helper behavior
- Ctrl+S stash performance harness with 240 displayed messages: max 0.241s, mean 0.218s

## Scope
Only the requested 4 frontend files are included:
- frontends/slash_cmds.py
- frontends/continue_cmd.py
- frontends/tui_v3.py
- frontends/tuiapp_v2.py