### PR TITLE
fix: remove extraneous f-prefix from plain string literals

### DIFF
--- a/agentmain.py
+++ b/agentmain.py
@@ -137,7 +137,7 @@ class GenericAgent:
             self.history.append(f"[USER]: {rquery}")
             
             sys_prompt = get_system_prompt() + getattr(self.llmclient.backend, 'extra_sys_prompt', '')
-            if self.peer_hint: sys_prompt += f"\n[Peer] 用户提及其他会话/后台任务状态时: temp/model_responses/ (只找近期修改的文件尾部)\n"
+            if self.peer_hint: sys_prompt += "\n[Peer] 用户提及其他会话/后台任务状态时: temp/model_responses/ (只找近期修改的文件尾部)\n"
             handler = GenericAgentHandler(self, self.history, os.path.join(script_dir, 'temp'))
             if self.handler and 'key_info' in self.handler.working: 
                 ki = re.sub(r'\n\[SYSTEM\] 此为.*?工作记忆[。\n]*', '', self.handler.working['key_info'])  # 去旧

--- a/assets/code_run_header.py
+++ b/assets/code_run_header.py
@@ -24,4 +24,4 @@ def _pinit(self, *a, **k):
     if os.name == 'nt': k['creationflags'] = (k.get('creationflags') or 0) | 0x08000000
     _Pi(self, *a, **k)
 subprocess.Popen.__init__ = _pinit
-sys.excepthook = lambda t, v, tb: (sys.__excepthook__(t, v, tb), print(f"\n[Agent Hint]: NO GUESSING! You MUST probe first. If missing common package, pip.")) if issubclass(t, (ImportError, AttributeError)) else sys.__excepthook__(t, v, tb)
+sys.excepthook = lambda t, v, tb: (sys.__excepthook__(t, v, tb), print("\n[Agent Hint]: NO GUESSING! You MUST probe first. If missing common package, pip.")) if issubclass(t, (ImportError, AttributeError)) else sys.__excepthook__(t, v, tb)


### PR DESCRIPTION
## Summary

Remove extraneous `f` prefix from two plain string literals that contain no placeholders, following Ruff F541 rule.

## Changes

| File | Line | Fix |
|------|------|-----|
| agentmain.py | 140 | `f"\n[Peer] ..."` → `"\n[Peer] ..."` |
| assets/code_run_header.py | 27 | `print(f"\n[Agent Hint]...")` → `print("\n[Agent Hint]...")` |

## Testing

- `python3 -m py_compile agentmain.py assets/code_run_header.py` — passes
- `ruff check --select F541 agentmain.py assets/code_run_header.py` — All checks passed
