### PR TITLE
fix: replace bare except with except Exception in ui_detect.py

### DIFF
--- a/memory/ui_detect.py
+++ b/memory/ui_detect.py
@@ -105,7 +105,7 @@ def visualize(image_path, elements, output_path=None):
     draw = ImageDraw.Draw(img)
     try:
         font = ImageFont.truetype("msyh.ttc", 14)
-    except:
+    except Exception:
         font = ImageFont.load_default()
     for el in elements:
         x1, y1, x2, y2 = el['bbox']


### PR DESCRIPTION
## Summary

Replace bare `except:` with `except Exception:` in `memory/ui_detect.py` (line 108).

## Changes

`memory/ui_detect.py` line 108: `except:` → `except Exception:`

This bare except was catching `ImageFont.truetype()` failures when loading the Microsoft YaHei font, which would silently fall back to the default bitmap font. Using `except Exception:` prevents masking serious errors like `KeyboardInterrupt` and `SystemExit`.

## Testing

- `python3 -m py_compile memory/ui_detect.py` — passes
- `ruff check --select E722 memory/ui_detect.py` — All checks passed
