### PR TITLE
feat(tui): add /conductor command + tips/i18n polish

### DIFF
--- a/frontends/slash_cmds.py
+++ b/frontends/slash_cmds.py
@@ -169,6 +169,23 @@ def build_hive_prompt(args_text: str = "") -> str:
     )
 
 
+def build_conductor_prompt(args_text: str = "") -> str:
+    """`/conductor <task>` → run `frontends/conductor.py` on the task.
+
+    Upstream `memory/` ships no conductor SOP, so we deliberately keep the
+    prompt short: name the entrypoint and forward the task verbatim.  The
+    agent is expected to know how to drive `conductor.py` (or consult a
+    local SOP if one happens to be installed).
+    """
+    args_text = (args_text or "").strip()
+    if args_text:
+        return f"请调用 frontends/conductor.py 执行：{args_text}"
+    return (
+        "请调用 frontends/conductor.py，根据后续指令完成多 subagent 编排。"
+        "若任务描述缺失，先 ask_user 一次性补齐。"
+    )
+
+
 # ----- /scheduler reflect-task discovery + launch -------------------------
 
 def list_reflect_tasks() -> list[dict]:
@@ -485,6 +502,7 @@ PALETTE_ENTRIES: list[tuple[str, str, str]] = [
     ("/morphling", "[target]",  "启用 Morphling 蒸馏 / 吞噬外部技能"),
     ("/goal",      "[goal]",    "进入 Goal 模式（需 condition 约束）"),
     ("/hive",      "[target]",  "进入 Hive 多 worker 协作模式"),
+    ("/conductor", "[task]",    "调用 frontends/conductor.py 多 subagent 编排"),
     ("/scheduler", "",          "多选启动 reflect 任务 / 查看 cron"),
 ]
 
@@ -503,6 +521,7 @@ def prompt_for(cmd: str, args_text: str) -> Optional[str]:
         "/morphling": build_morphling_prompt,
         "/goal":      build_goal_prompt,
         "/hive":      build_hive_prompt,
+        "/conductor": build_conductor_prompt,
     }
     fn = table.get(cmd)
     return fn(args_text) if fn else None

--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -97,6 +97,10 @@ _TIPS = {
         "Tip: /update auto-runs git pull and audits the impact; /autorun seeds an autonomous run.",
         "Tip: /morphling <target> absorbs an external skill.",
         "Tip: /goal <goal> enters Goal mode (will ask for budget / worker cap); /hive <target> for multi-worker.",
+        "Tip: /conductor <task> hands the task to frontends/conductor.py for multi-subagent orchestration.",
+        "Tip: /update runs a dual-branch upstream sync — previews the diff before fast-forwarding either side.",
+        "Tip: /scheduler is live — untick a running row to stop it; tick again to relaunch.",
+        "Tip: Ctrl+S stashes your draft input — it's waiting for you next time you open a picker.",
         "Tip: /scheduler lists reflect tasks and starts them via `/scheduler start a,b,c`.",
     ],
     'zh': [
@@ -111,6 +115,10 @@ _TIPS = {
         "Tip: /new [name] 新建会话；/language 切换界面语言。",
         "Tip: /export clip 把最后回复复制到系统剪贴板；/export all 打印日志路径。",
         "Tip: Ctrl+O 折叠 / 展开所有已完成的工具 chip —— 每个 chip 折叠成一行。",
+        "Tip: /conductor <任务> 直接交给 frontends/conductor.py 做多 subagent 编排。",
+        "Tip: /update 是双分支 upstream 同步 —— 先 diff 预演，再分别快进。",
+        "Tip: /scheduler 里再点一下已勾选的任务可以 stop —— 取消勾选 = 停止。",
+        "Tip: Ctrl+S 把当前输入 stash 起来，下次 / 打开 picker 时还在。",
     ],
 }
 
@@ -183,6 +191,8 @@ _I18N: dict[str, dict[str, str]] = {
         'cmd.goal.desc':        'enter Goal mode (needs condition)',
         'cmd.hive.arg':         '[target]',
         'cmd.hive.desc':        'enter Hive multi-worker mode',
+        'cmd.conductor.arg':    '[task]',
+        'cmd.conductor.desc':   'hand task to frontends/conductor.py for multi-subagent orchestration',
         'cmd.scheduler.desc':   'multi-pick reflect tasks / show cron',
 
         # status line (one-liner above input box)
@@ -389,6 +399,8 @@ _I18N: dict[str, dict[str, str]] = {
         'cmd.goal.desc':        '进入 Goal 模式（需 condition 约束）',
         'cmd.hive.arg':         '[target]',
         'cmd.hive.desc':        '进入 Hive 多 worker 协作模式',
+        'cmd.conductor.arg':    '[任务]',
+        'cmd.conductor.desc':   '调用 frontends/conductor.py 做多 subagent 编排',
         'cmd.scheduler.desc':   '多选启动 reflect 任务 / 查看 cron',
 
         # status line
@@ -1613,6 +1625,7 @@ def _cmds() -> list[tuple[str, str, str]]:
         ('/morphling', _t('cmd.morphling.arg'),  _t('cmd.morphling.desc')),
         ('/goal',      _t('cmd.goal.arg'),       _t('cmd.goal.desc')),
         ('/hive',      _t('cmd.hive.arg'),       _t('cmd.hive.desc')),
+        ('/conductor', _t('cmd.conductor.arg'),  _t('cmd.conductor.desc')),
         ('/scheduler', '',                       _t('cmd.scheduler.desc')),
         ('/rewind',   _t('cmd.rewind.arg'),     _t('cmd.rewind.desc')),
         ('/continue', _t('cmd.continue.arg'),   _t('cmd.continue.desc')),
@@ -3739,7 +3752,7 @@ class SB:
                     self.commit(Block('assistant', text))   # markdown re-renders on resize
                 except queue.Empty:
                     self.commit([_t('msg.review_empty')])
-        elif name in ('update', 'autorun', 'morphling', 'goal', 'hive'):
+        elif name in ('update', 'autorun', 'morphling', 'goal', 'hive', 'conductor'):
             # slash_cmds bundle — build a long prompt and feed it back through
             # _submit so the agent sees an ordinary user turn.  Keeps the
             # frontend ignorant of SOP details; see frontends/slash_cmds.py.

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -147,6 +147,10 @@ _TIPS = (
     "Tip: /morphling <目标> 启用蒸馏吞噬外部技能。",
     "Tip: /goal <目标> 进入 Goal 模式（缺 condition 时会回头问你预算 / worker 上限）。",
     "Tip: /hive <目标> 进入 Hive 多 worker 协作；/scheduler 调出 reflect 任务多选启动器。",
+    "Tip: /conductor <任务> 直接交给 frontends/conductor.py 做多 subagent 编排。",
+    "Tip: /update 是双分支 upstream 同步 —— 先 diff 预演，再分别快进。",
+    "Tip: /scheduler 里再点一下已勾选的任务可以 stop —— 取消勾选 = 停止。",
+    "Tip: Ctrl+S 把当前输入 stash 起来，下次 / 打开 picker 时还在。",
 )
 
 
@@ -1210,6 +1214,7 @@ COMMANDS = [
     ("/morphling", "[target]",         "启用 Morphling 蒸馏 / 吞噬外部技能"),
     ("/goal",      "[goal]",           "进入 Goal 模式（需 condition 约束）"),
     ("/hive",      "[target]",         "进入 Hive 多 worker 协作模式"),
+    ("/conductor", "[task]",           "调用 frontends/conductor.py 多 subagent 编排"),
     ("/scheduler", "",                 "多选启动 reflect 任务 / 查看 cron"),
     ("/continue", "[n|name]",         "列出 / 恢复历史会话"),
     ("/cost",     "[all]",            "显示当前会话 token 用量（all = 所有会话）"),
@@ -2515,7 +2520,7 @@ class GenericAgentTUI(App[None]):
             # so the agent processes them as ordinary turns.
             "update": self._cmd_slash_inject, "autorun": self._cmd_slash_inject,
             "morphling": self._cmd_slash_inject, "goal": self._cmd_slash_inject,
-            "hive": self._cmd_slash_inject,
+            "hive": self._cmd_slash_inject, "conductor": self._cmd_slash_inject,
             "scheduler": self._cmd_scheduler,
             "quit": self._cmd_quit, "exit": self._cmd_quit,
         }
@@ -4020,7 +4025,7 @@ class GenericAgentTUI(App[None]):
 
     # ---------------- slash_cmds bundle ----------------
     def _cmd_slash_inject(self, args, raw):
-        """`/update /autorun /morphling /goal /hive` → prompt
+        """`/update /autorun /morphling /goal /hive /conductor` → prompt
         injection.  We strip the leading slash command from `raw`, hand the
         tail to `slash_cmds.prompt_for`, and re-enter `submit_user_message`
         so the agent sees it as a normal user turn (display bubble still


### PR DESCRIPTION
- slash_cmds: register /conductor bundle + prompt_for builder (frontends/conductor.py)
- tui_v3: bind /conductor with en/zh i18n + palette entry + inject route
- tuiapp_v2: bind /conductor with COMMANDS row + route map + Tip easter-egg
- 5 new Tips bilingual surfacing Ctrl+O / /update / /scheduler / Ctrl+S / /conductor