### PR TITLE
fix(tui): pending-queue inject lands mid-turn (3 s hard cap)

### DIFF
--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -4784,11 +4784,6 @@ class SB:
                 elif isinstance(ev, (SystemEvent, ErrorEvent)):
                     self._finalize(getattr(ev, 'text', None) or getattr(ev, 'message', '')); break
         self._running = False
-        # Note: pending-drain timer is armed on each user submit (resets
-        # every time they add another), not on turn end — that matches
-        # the "5 s cooldown since LAST keystroke" intent.  Maintenance
-        # loop fires _drain_pending when the deadline lapses regardless
-        # of running state.
         # _ticker stops as soon as _running goes False so the title would
         # freeze on the last spinner frame.  Repaint it now to drop the
         # glyph and reveal a clean idle title.

--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -2256,16 +2256,13 @@ class SB:
         self._quit = False
         self._cc_t = 0.0                # last bare-Ctrl+C time (arm-to-quit window)
         self._last_esc_t = 0.0          # last bare-Esc time (Esc Esc → /clear)
-        # Pending user inputs queued while the agent was busy (codex-style).
-        # Drained as ONE combined prompt 5 s after the LAST pending arrived
-        # (cooldown resets on each new queue entry).  During the cooldown
-        # the user can Esc-cancel or Up-amend.  When the timer lapses we
-        # try mid-turn injection via `_intervene` first (agent picks it up
-        # at the next turn boundary); fall back to put_task if the agent
-        # is idle.
+        # Hard 3 s deadline from the FIRST queued entry — additional submits
+        # within the window don't extend it, so the inject lands while the
+        # agent is still mid-turn (avoids the "user kept typing → drain fired
+        # too late → fell back to a new task" failure).
         self._pending: list[str] = []
         self._pending_drain_t: float = 0.0
-        self._pending_cooldown: float = 5.0
+        self._pending_cooldown: float = 3.0
         self._epend = b''               # held trailing ESC (split-read disambiguation)
         self._undo: list[tuple[str, int]] = []   # buffer-edit history for Ctrl+Z
         self._redo: list[tuple[str, int]] = []   # cleared on any new edit
@@ -3960,13 +3957,9 @@ class SB:
                 (int(m.group(1)) for m in _IMG_PH_RE.finditer(raw)) if i in self._imgs]
         expanded = self._expand(raw)
         if self._running:
-            # Queue rather than reject — frees the user from /stop just to
-            # tack on a follow-up.  The pending preview block above the
-            # input shows what's waiting; Up amends the last entry, Esc
-            # clears.  Each new entry resets the 5 s cooldown so a burst
-            # of quick edits coalesces into one inject.
             self._pending.append(expanded)
-            self._pending_drain_t = time.time() + self._pending_cooldown
+            if self._pending_drain_t == 0.0:
+                self._pending_drain_t = time.time() + self._pending_cooldown
             self._commit_user(_t('pending.queued_marker', text=expanded))
             self._pstore.clear(); self._fstore.clear(); self._imgs.clear()
             self._render_live()

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -4497,13 +4497,13 @@ class GenericAgentTUI(App[None]):
             pass
 
     # ---------------- agent task + stream ----------------
-    # 5 s cooldown after the LAST user submit (cooldown resets per entry).
-    # Drain path:
-    #   running → write to <task_dir>/_intervene; ga.turn_end_callback
-    #             (ga.py:576) prepends it to next_prompt at the next
-    #             turn boundary — message lands mid-run.
-    #   idle    → fall back to put_task for a fresh turn.
-    _PENDING_COOLDOWN_SEC = 5.0
+    # Hard 3 s deadline from the FIRST queued entry — additional submits
+    # within the window don't extend it, so the inject lands while the
+    # agent is still mid-turn (avoids "user kept typing → drain fired too
+    # late → fell back to a new task" failure).  Drain path: running →
+    # <task_dir>/_intervene (ga.turn_end_callback prepends to next_prompt);
+    # idle → put_task for a fresh turn.
+    _PENDING_COOLDOWN_SEC = 3.0
 
     def _session_intervene_path(self, sess: AgentSession) -> Optional[str]:
         td = getattr(sess.agent, 'task_dir', None)
@@ -4544,12 +4544,10 @@ class GenericAgentTUI(App[None]):
         if self._maybe_intercept_free_text(sess, text):
             return -1
         if sess.status == "running":
-            # Codex-style: don't reject, queue.  Cooldown resets per entry
-            # so a burst of edits coalesces into one inject.  Drain fires
-            # `_inject_intervene` (mid-turn) or `put_task` (idle).
             visible = text if display_text is None else display_text
             sess.pending.append(text)
-            sess.pending_drain_at = time.time() + self._PENDING_COOLDOWN_SEC
+            if sess.pending_drain_at == 0.0:
+                sess.pending_drain_at = time.time() + self._PENDING_COOLDOWN_SEC
             sess.messages.append(ChatMessage(
                 "system",
                 f"[queued #{len(sess.pending)}] {visible}",

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -4607,11 +4607,6 @@ class GenericAgentTUI(App[None]):
         if done:
             s.status = "idle"
             s.current_display_queue = None
-            # NOTE: cooldown timer is armed on each user submit (see
-            # submit_user_message), NOT here on turn end.  This matches
-            # "5 s since LAST keystroke" semantics: if turn ends within
-            # the cooldown the timer keeps counting, drain fires whenever
-            # the deadline lapses (mid-turn → intervene; idle → put_task).
         self._update_assistant(agent_id, text, task_id=task_id, done=done, refresh_chrome=True)
         # End-of-turn re-parse only; mid-stream `[...]` fragments would flash.
         if done:


### PR DESCRIPTION
## Summary

User types follow-up lines while the agent is running; queued lines never reach the model — the agent finishes its current run and the queued text spawns a fresh task instead of being spliced in. Two compounding causes:

1. **Cooldown was 5 s.** Longer than many turns. By drain time the agent was already idle, so `_inject_intervene` returned False; the fallback called `put_task`, which starts a new turn rather than injecting into the current one.
2. **Deadline reset on every keystroke.** A steady typer could push the drain off indefinitely. Once they paused, the agent had usually finished.

## Fix

Hard 3 s deadline anchored to the **first** queued entry. Subsequent submits within the window append to the queue without moving the timer. Drain now fires reliably while the current run is still in flight, GA's `turn_end_callback` (ga.py:576) consumes `_intervene` at the next turn boundary, and `[MASTER] ...` is prepended to the upcoming prompt — exactly what mainstream TUIs (Codex CLI Enter-queue, Claude Code) do.

Symmetric change in `tuiapp_v2.py` and `tui_v3.py`.

## Reference
- Codex CLI: Enter queues + drains at next tool call; ESC interrupts and submits immediately (openai/codex#15842, #17095)
- Claude Code: Enter queues; Ctrl+C drains (anthropics/claude-code#44851, #36326)

## Test plan
- [x] `python -c "import ast; ast.parse(open('frontends/tui_v3.py').read())"` syntax OK
- [x] `python -c "import ast; ast.parse(open('frontends/tuiapp_v2.py').read())"` syntax OK
- [x] Type 3 lines in quick succession while a task is running → deadline locks at line-1 + 3 s, all three drain together via `_intervene` before the turn ends.
- [x] Esc on empty input still clears the queue and resets `_pending_drain_t` to 0.
- [x] Up still pops the most-recent queued line back into the composer; deadline clears only when queue becomes empty.