### PR TITLE
fix(tui-v3): detect Shift+Enter on Windows via GetAsyncKeyState

### DIFF
--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -807,7 +807,12 @@ def _ptk_keypress_to_bytes(kp) -> bytes:
         return any(n in a for a in aliases for n in needles)
 
     # Enter submits; Ctrl+J / Shift+Enter insert newline when PTK can distinguish.
+    # Windows terminals send \r for both Enter/Shift+Enter — detect Shift physically.
     if has('controlm', 'c-m') or key_s in ('\r', '\n'):
+        if _IS_WINDOWS:
+            import ctypes
+            if ctypes.windll.user32.GetAsyncKeyState(0x10) & 0x8000:
+                return b'\n'
         return b'\r'
     if has('controlj', 'c-j', 's-enter', 'shift-enter'):
         return b'\n'


### PR DESCRIPTION
 Windows 终端下，Prompt Toolkit 无法区分 Shift+Enter 和 Enter（两者均发送 \r），导致 Shift+Enter
 无法换行，直接提交消息。

 修改内容

 在 frontends/tui_v3.py 的 Enter 处理逻辑中增加 Windows 专用检测：

  1 导入 ctypes 模块（仅在 Windows 时）
  2 使用 GetAsyncKeyState(0x10) 实时读取 Shift 键物理状态
  3 按下 Shift 时返回 \n（换行），否则返回 \r（提交）
```python


   if has('controlm', 'c-m') or key_s in ('\r', '\n'):
  +    if _IS_WINDOWS:
  +        import ctypes
  +        if ctypes.windll.user32.GetAsyncKeyState(0x10) & 0x8000:
  +            return b'\n'
       return b'\r'
```

 影响范围

  • 仅 tui_v3.py 一个文件，+5 行
  • 仅 Windows 平台生效，Linux/macOS 不受影响
  • 无新增依赖（ctypes 为 Python 内置）

 测试步骤

  1 在 Windows 终端运行 TUI V3
  2 按 Enter → 提交消息 ✅
  3 按 Shift+Enter → 换行 ✅