### PR TITLE
feat(tui-v3): v2-style arrow navigation with logical line boundaries

### DIFF
--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -2553,6 +2553,16 @@ class SB:
         total = self.buf.count('\n') + 1
         return line_no, total, ls, le
 
+    def _logical_visual_range(self, segs, line_no):
+        """返回第 line_no 个逻辑行在 segs 中的 (first_vi, last_vi)"""
+        lines = self.buf.split('\n')
+        iw = max(1, _term()[0] - 6)
+        first = 0
+        for i in range(line_no):
+            first += max(1, len(_wrap_cells(lines[i], iw)))
+        cnt = max(1, len(_wrap_cells(lines[line_no], iw)))
+        return first, first + cnt - 1
+
     def _cur_v(self, d: int) -> None:
         """↑/↓ roam by VISUAL row (a long single-line paste wraps to many rows
         yet stays one logical line — must still roam). At the top/bottom visual
@@ -5170,11 +5180,19 @@ class SB:
                 else:
                     self._sel = None
                     line_no, total, ls, le = self._line_region()
-                    if line_no == 0:
-                        if self.pos == ls:
-                            self._nav_hist(-1)
+                    segs = self._segs(max(1, _term()[0] - 6))
+                    vi, _ = self._seg_at(segs)
+                    first_vi, _ = self._logical_visual_range(segs, line_no)
+                    if vi == first_vi:          # 在视觉首行
+                        if line_no == 0:
+                            if self.pos == ls:
+                                self._nav_hist(-1)
+                            else:
+                                self.pos = ls
+                        elif self.pos == ls:
+                            self._cur_v(-1)     # 已在行首 → 正常上移
                         else:
-                            self.pos = ls
+                            self.pos = ls       # 跳到该行行首
                     else:
                         self._cur_v(-1)
             elif o == 0x13:                       # Ctrl+S stash/restore draft
@@ -5186,11 +5204,19 @@ class SB:
                 else:
                     self._sel = None
                     line_no, total, ls, le = self._line_region()
-                    if line_no == total - 1:
-                        if self.pos == le:
-                            self._nav_hist(1)
+                    segs = self._segs(max(1, _term()[0] - 6))
+                    vi, _ = self._seg_at(segs)
+                    first_vi, last_vi = self._logical_visual_range(segs, line_no)
+                    if vi == last_vi:           # 在视觉末行
+                        if line_no == total - 1:
+                            if self.pos == le:
+                                self._nav_hist(1)
+                            else:
+                                self.pos = le
+                        elif self.pos == le:
+                            self._cur_v(1)      # 已在行末 → 正常下移
                         else:
-                            self.pos = le
+                            self.pos = le       # 跳到该行行末
                     else:
                         self._cur_v(1)
             elif o == 0x02:                       # ← caret left

--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -2542,6 +2542,17 @@ class SB:
                 return i, p - st
         return len(segs) - 1, len(segs[-1][1])
 
+    def _line_region(self, pos: int | None = None) -> tuple[int, int, int, int]:
+        """(行号, 总行数, 行起始偏移, 行结束偏移) 基于逻辑行（\\n分割）"""
+        p = self.pos if pos is None else pos
+        ls = self.buf.rfind('\n', 0, p) + 1
+        le = self.buf.find('\n', p)
+        if le == -1:
+            le = len(self.buf)
+        line_no = self.buf[:p].count('\n')
+        total = self.buf.count('\n') + 1
+        return line_no, total, ls, le
+
     def _cur_v(self, d: int) -> None:
         """↑/↓ roam by VISUAL row (a long single-line paste wraps to many rows
         yet stays one logical line — must still roam). At the top/bottom visual
@@ -5157,7 +5168,15 @@ class SB:
                         self._pending_drain_t = 0.0
                     self._render_live()
                 else:
-                    self._sel = None; self._cur_v(-1)
+                    self._sel = None
+                    line_no, total, ls, le = self._line_region()
+                    if line_no == 0:
+                        if self.pos == ls:
+                            self._nav_hist(-1)
+                        else:
+                            self.pos = ls
+                    else:
+                        self._cur_v(-1)
             elif o == 0x13:                       # Ctrl+S stash/restore draft
                 self._stash_draft()
             elif o == 0x0e:                       # ↓ visual-row down (history at bottom)
@@ -5165,7 +5184,15 @@ class SB:
                     n = len(self._cmd_matches(self.buf))
                     self._palette_sel = min(n - 1, self._palette_sel + 1) if n else 0
                 else:
-                    self._sel = None; self._cur_v(1)
+                    self._sel = None
+                    line_no, total, ls, le = self._line_region()
+                    if line_no == total - 1:
+                        if self.pos == le:
+                            self._nav_hist(1)
+                        else:
+                            self.pos = le
+                    else:
+                        self._cur_v(1)
             elif o == 0x02:                       # ← caret left
                 self._sel = None; self.pos = max(0, self.pos - 1)
             elif o == 0x06:                       # → caret right


### PR DESCRIPTION
 新增 _logical_visual_range() (L2556-2564)

 计算指定逻辑行在视觉行列表 segs 中的起止索引范围，用于判断光标是否在视觉首行/末行。

 上键 ↑ 新逻辑


  多行(buf中有\n) 且 在视觉首行？
    ├─ 第0行且已在行首 → _nav_hist(-1)    翻历史
    ├─ 第0行但不在行首 → pos=行首          跳行首
    ├─ 非第0行且已在行首 → _cur_v(-1)      正常上移（到上一行）
    └─ 非第0行但不在行首 → pos=行首        跳该行行首
 - 多行 且 不在视觉首行 → _cur_v(-1)         视觉行上移
 - 单行(无\n) → _cur_v(-1)                  保持原行为


 下键 ↓ 新逻辑


  多行(buf中有\n) 且 在视觉末行？
    ├─ 末行且已在行末 → _nav_hist(1)      翻历史
    ├─ 末行但不在行末 → pos=行末          跳行末
    ├─ 非末行且已在行末 → _cur_v(1)       正常下移（到下一行）
    └─ 非末行但不在行末 → pos=行末        跳该行行末
- 多行 且 不在视觉末行 → _cur_v(1)         视觉行下移
- 单行(无\n) → _cur_v(1)                  保持原行为



| 场景               | `↑` 效果    | `↓` 效果    |
| ---------------- | --------- | --------- |
| 单行（长文本 wrap）     | 视觉行上移     | 视觉行下移     |
| 多行 · 视觉首行        | 跳行首 / 翻历史 | 视觉行下移     |
| 多行 · 视觉末行        | 视觉行上移     | 跳行末 / 翻历史 |
| 多行 · 视觉中间行       | 视觉行上移     | 视觉行下移     |
| 调色板可见时           | 上移选中项     | 下移选中项     |
| pending 消息 + 空输入 | 弹回消息      | —         |



 兼容性

  • ✅ 不影响其他快捷键（←→/Ctrl+U/Ctrl+A/Home/End 等）
  • ✅ 不影响命令补全调色板
  • ✅ 不影响 pending 消息弹回
  • ✅ 不新增外部依赖