### PR TITLE
feat(wizard): add CommonStack as a unified API gateway provider

### DIFF
--- a/assets/configure_mykey.py
+++ b/assets/configure_mykey.py
@@ -300,6 +300,21 @@ LLM_PROVIDERS = [
         'model_choices': ['anthropic/claude-opus-4-7', 'openai/gpt-5.5'],
     },
     {
+        'id': 'commonstack',
+        'name': 'CommonStack (统一网关)',
+        'desc': '一个 Key 通吃 Claude/GPT/Gemini/DeepSeek/MiniMax/Zhipu/xAI 等',
+        'type': 'native_oai',
+        'template': {
+            'name': 'commonstack', 'apikey': 'sk-<your-commonstack-key>',
+            'apibase': 'https://api.commonstack.ai/v1',
+            'model': 'anthropic/claude-opus-4-7',
+            'api_mode': 'chat_completions',
+            'max_retries': 3, 'connect_timeout': 10, 'read_timeout': 120,
+        },
+        'key_hint': '在 https://commonstack.ai 注册后从 Dashboard 获取 API Key',
+        'model_choices': ['anthropic/claude-opus-4-7', 'openai/gpt-5.5'],
+    },
+    {
         'id': 'crs',
         'name': 'CRS 反代 (Claude Max 多通道)',
         'desc': 'CRS 协议的反代服务，支持 Claude Max / Gemini Ultra 通道',


### PR DESCRIPTION
  ## Summary

  Adds [CommonStack](https://commonstack.ai) as a selectable LLM provider in
  `assets/configure_mykey.py`. CommonStack is an OAI/Anthropic-compatible
  unified gateway that aggregates flagship models from OpenAI, Anthropic,
  Google, DeepSeek, MiniMax, Zhipu, xAI, Moonshot, Qwen and Xiaomi behind
  a single key — same shape as the existing `openrouter` entry.

  ## Details

  - Single-entry addition to `LLM_PROVIDERS`, between `openrouter` and `crs`.
  - `type: native_oai`, `apibase: https://api.commonstack.ai/v1`,
    `api_mode: chat_completions`. Standard Bearer auth — no quirks.
  - `model_choices` kept to 2 flagship ids mirroring `openrouter`'s shape,
    since `probe_models()` fetches the live `/v1/models` list at config time
    (returns ~55 ids currently). `model_choices` is only consulted by
    `_fallback_model()` on probe failure.
  - Default `model` is `anthropic/claude-opus-4-7`, matching the project's
    pattern of defaulting to the flagship Claude.

  ## Test plan

  - [x] `from configure_mykey import LLM_PROVIDERS` imports cleanly.
  - [x] Provider menu order: `cc_relay → openrouter → commonstack → crs → gmi`.
  - [x] `probe_models()` against live `/v1/models` returns 55 ids.
  - [x] End-to-end `configure_llm(commonstack)` with mocked stdin confirms
        the live list (alphabetical, starts with `anthropic/claude-haiku-4-5`)
        populates the picker, not the 2-item fallback.