### PR TITLE
fix(tui-v3): skip ask card when ask_user has no candidates

### DIFF
--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -1312,9 +1312,18 @@ def _extract_ask_user(ctx: dict | None) -> AskUserEvent | None:
     if payload.get('status') != 'INTERRUPT' or payload.get('intent') != 'HUMAN_INTERVENTION':
         return None
     data = payload.get('data') or {}
+    candidates = data.get('candidates') or []
+    # v2 parity: skip the ask card when the agent didn't supply candidates —
+    # the 'Waiting for your answer ...' marker already lands in scrollback as
+    # part of the assistant stream, and the user replies via the normal input
+    # box.  Pushing an empty-candidate event onto the queue would route us
+    # through _enter_ask → free-text ask card, which freezes the live region
+    # in some terminals.
+    if not candidates:
+        return None
     return AskUserEvent(
         question=data.get('question', ''),
-        candidates=data.get('candidates', []),
+        candidates=candidates,
     )
 
 


### PR DESCRIPTION
## Summary

`_extract_ask_user` previously pushed empty-candidate `ask_user` events onto the ask queue, routing v3 through `_enter_ask` → free-text ask card. In some terminals this freezes the live region (card draws but page stops updating).

`tuiapp_v2.py:2909-2910` already handles this case by dropping the event:

```python
cands = _sanitize_candidates(data.get("candidates"))
if not cands: return
```

This PR brings v3's hook in line. With no candidates, the agent's "Waiting for your answer ..." marker simply lands in the assistant stream (the agent has already exited via `should_exit=True`), and the user replies via the normal input box — same UX as v2.

## Test plan

- [x] v3: agent invokes `ask_user` with no candidates → question appears as plain assistant output (no ask card); user replies in the normal input box and agent continues
- [x] v3: agent invokes `ask_user` *with* candidates → ask card still appears as before (single / multi modes unaffected)