### PR TITLE
fix(tui_v3): remove unused imports and fix duplicate dataclass import

### DIFF
--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -6,11 +6,10 @@ Run: `python -m frontends.tui_v3` or `python frontends/tui_v3.py`.
 """
 from __future__ import annotations
 
-import asyncio, atexit, json, locale, logging, os, queue, random, re, select, shutil, signal, subprocess
+import asyncio, atexit, json, locale, logging, os, queue, random, re, shutil, subprocess
 import sys, tempfile, threading, time
 
 _IS_WINDOWS = os.name == 'nt'
-
 
 # Make `frontends/` parent (project root) importable so `from agentmain import …`
 # works whether this file is run as `python -m frontends.tui_v3` or directly
@@ -22,16 +21,14 @@ for _p in (_proj_root, _front_dir):
         sys.path.insert(0, _p)
 
 from agentmain import GeneraticAgent
-from dataclasses import dataclass
 from dataclasses import dataclass, field
-from functools import lru_cache
+
 from io import StringIO
 from rich.cells import cell_len
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.text import Text
 from rich.theme import Theme
-from typing import Callable
 
 # ════════════════════════════════════════════════════════════════════════════
 # i18n — minimal dict-based zh/en translation layer (inlined; was tui_v3_i18n.py)


### PR DESCRIPTION
## 清理 tui_v3.py 中未使用的导入

### 修改范围

- 移除 `select` 和 `signal`（未在 tui_v3.py 中使用）
- 移除重复的 `from dataclasses import dataclass`（已包含在 `dataclass, field` 导入中）
- 移除未使用的 `functools.lru_cache` 和 `typing.Callable` 导入
- 修复双重空行格式问题

### 验证

- Python 语法检查通过 (`python3 -m py_compile`)
- ruff F401 检查通过
- 修改范围精准，无功能性变更

### 影响

降低模块加载时的内存开销，提升代码可维护性。
