### PR TITLE
修复：simphtml.py 中 4 处裸 except 子句

### DIFF
--- a/simphtml.py
+++ b/simphtml.py
@@ -635,7 +635,7 @@ temp_monitor_js = """function startStrMonitor(interval) {
 """  
 def start_temp_monitor(driver):  
     try: driver.execute_js(temp_monitor_js)
-    except: pass
+    except Exception: pass
 
 def get_temp_texts(driver):  
     js = """function stopStrMonitor() {  
@@ -821,7 +821,7 @@ def execute_js_rich(script, driver, no_monitor=False):
     last_html = None
     if not no_monitor:
         try: last_html = get_html(driver, cutlist=False, extra_js=temp_monitor_js, maxchars=9999999)
-        except: pass
+        except Exception: pass
     result = None;  error_msg = None;  reloaded = False; newTabs = []
     before_sids = set(driver.get_session_dict().keys()); response = {}
     try:
@@ -853,7 +853,7 @@ def execute_js_rich(script, driver, no_monitor=False):
     if no_monitor: return rr
     if not reloaded:
         try: rr['transients'] = get_temp_texts(driver)
-        except: rr['transients'] = []
+        except Exception: rr['transients'] = []
     if not reloaded and len(newTabs) == 0:
         try:
             current_html = get_html(driver, cutlist=False, maxchars=9999999)
@@ -867,7 +867,7 @@ def execute_js_rich(script, driver, no_monitor=False):
             if change_count == 0 and not transients and len(newTabs) == 0:
                 diff_summary += " (页面无变化)"
                 rr['suggestion'] = "页面无明显变化"
-        except:
+        except Exception:
             diff_summary = "页面变化监控不可用"
         rr['diff'] = diff_summary
     return rr


### PR DESCRIPTION
## Summary

Replace 4 bare `except:` clauses with `except Exception:` in `simphtml.py`.

Bare `except:` catches all exceptions including `SystemExit` and `KeyboardInterrupt`, which should normally propagate. This is a standard Python best practice (PEP 8 / E722) fix.

## Changes

- `simphtml.py:638` — `start_temp_monitor`: suppress js execution failure silently
- `simphtml.py:824` — `execute_js`: suppress get_html failure in no_monitor mode
- `simphtml.py:856` — `get_temp_texts` call: fallback to empty list on failure
- `simphtml.py:870` — DOM diff block: report unavailable on any error

## Verification

- Syntax check: `python3 -m py_compile simphtml.py` ✓
- Lint: `ruff check simphtml.py --select E722` — All checks passed ✓