### PR TITLE
修复：替换 frontends 中 stapp.py 和 stapp2.py 的裸 except 子句

### DIFF
--- a/frontends/stapp.py
+++ b/frontends/stapp.py
@@ -4,9 +4,9 @@ from urllib.parse import quote
 if sys.stdout is None: sys.stdout = open(os.devnull, "w")
 if sys.stderr is None: sys.stderr = open(os.devnull, "w")
 try: sys.stdout.reconfigure(errors='replace')
-except: pass
+except Exception: pass
 try: sys.stderr.reconfigure(errors='replace')
-except: pass
+except Exception: pass
 script_dir = os.path.dirname(__file__)
 sys.path.append(os.path.abspath(os.path.join(script_dir, '..')))
 sys.path.append(os.path.abspath(script_dir))

--- a/frontends/stapp2.py
+++ b/frontends/stapp2.py
@@ -3,9 +3,9 @@ import html
 if sys.stdout is None: sys.stdout = open(os.devnull, "w")
 if sys.stderr is None: sys.stderr = open(os.devnull, "w")
 try: sys.stdout.reconfigure(errors='replace')
-except: pass
+except Exception: pass
 try: sys.stderr.reconfigure(errors='replace')
-except: pass
+except Exception: pass
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import streamlit as st


### PR DESCRIPTION
## Summary

替换 `frontends/stapp.py` 和 `frontends/stapp2.py` 中的裸 `except:` 子句为 `except Exception: pass`。

## Changes

- `frontends/stapp.py` L7-9：两处 `except: pass` → `except Exception: pass`
- `frontends/stapp2.py` L6-8：两处 `except: pass` → `except Exception: pass`

## Verification

- `ruff check --select E722` 通过，无 E722 错误
- `python3 -m py_compile` 语法检查通过

## Rationale

裸 `except:` 会捕获所有异常，包括 `SystemExit` 和 `KeyboardInterrupt`，导致程序在配置 stdout/stderr 失败时无法正常退出。`except Exception:` 仅捕获程序可处理的异常，符合 Python PEP 8 规范。