### PR TITLE
fix(wechat): check abort flag in streaming loop to honor /stop command

### DIFF
--- a/frontends/wechatapp.py
+++ b/frontends/wechatapp.py
@@ -393,7 +393,9 @@ def on_message(bot, msg):
         try:
             done = []; turn = 1
             while True:
-                item = dq.get(timeout=300)
+                if _task_aborted.get(uid): break
+                try: item = dq.get(timeout=300)
+                except queue.Empty: continue
                 if 'done' in item: break
                 if item.get('turn', turn) > turn:
                     outputs = item.get('outputs', [])


### PR DESCRIPTION
## Problem

Closes #396

In WeChat clawbot mode, when a user sends `/stop` during task execution, the `_task_aborted` flag is set but `_handle()` never checks it inside its streaming loop. The loop blocks on `dq.get(timeout=300)` and continues processing accumulated intermediate results, sending them to the user before finally showing `[任务已完成]`.

## Root Cause

The `while True` loop in `_handle()` (line 373) only breaks on `'done' in item` or `queue.Empty` timeout. It never checks `_task_aborted[uid]`, so the abort flag is only evaluated *after* the loop exits — by which time all accumulated results have already been sent.

## Fix

Added an abort check at the top of each loop iteration:
```python
if _task_aborted.get(uid): break
```

Also changed `dq.get(timeout=300)` to use a try/except for `queue.Empty` so the abort check runs every 300s instead of blocking indefinitely. This ensures the `/stop` command takes effect within one queue poll cycle.

## Verification

- `python3 -m py_compile frontends/wechatapp.py` — no syntax errors
- `ruff check frontends/wechatapp.py` — no new issues introduced