### PR TITLE
fix: clean up unused variables and duplicate import across 6 modules

### DIFF
--- a/frontends/fsapp.py
+++ b/frontends/fsapp.py
@@ -809,7 +809,7 @@ def _run_async(coro):
 
 
 def handle_message(data):
-    event, message, sender = data.event, data.event.message, data.event.sender
+    _event, message, sender = data.event, data.event.message, data.event.sender
     message_id = getattr(message, "message_id", "") or ""
     if not _claim_message_once(message_id):
         print(f"忽略重复飞书消息: {message_id}")

--- a/frontends/genericagent_acp_bridge.py
+++ b/frontends/genericagent_acp_bridge.py
@@ -146,7 +146,6 @@ class GenericAgentAcpBridge:
     def write_message(self, msg: Dict[str, Any]) -> None:
         payload = compact_json(msg)
         raw = (payload + "\n").encode("utf-8")
-        method = msg.get("method", msg.get("id", "?"))
         eprint(f"[ACP-BRIDGE] >>> {payload[:500]}")
         try:
             with self._write_lock:

--- a/frontends/qtapp.py
+++ b/frontends/qtapp.py
@@ -833,7 +833,7 @@ class _MsgRow(QWidget):
             try:
                 with open(file_path, "w", encoding="utf-8") as f:
                     f.write(self._text)
-            except Exception as e:
+            except Exception:
                 import traceback
                 traceback.print_exc()
 

--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -22,7 +22,6 @@ for _p in (_proj_root, _front_dir):
         sys.path.insert(0, _p)
 
 from agentmain import GeneraticAgent
-from dataclasses import dataclass
 from dataclasses import dataclass, field
 from functools import lru_cache
 from io import StringIO
@@ -789,7 +788,7 @@ def _ptk_keypress_to_bytes(kp) -> bytes:
     try:
         from prompt_toolkit.keys import Keys
     except Exception:
-        Keys = None  # type: ignore[assignment]
+        Keys = None  # type: ignore[assignment]  # noqa: F841
 
     key = getattr(kp, 'key', None)
     data = getattr(kp, 'data', '') or ''

--- a/frontends/tuiapp.py
+++ b/frontends/tuiapp.py
@@ -721,7 +721,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Optional[list[str]] = None) -> int:
-    args = build_arg_parser().parse_args(argv)
+    _args = build_arg_parser().parse_args(argv)
     app = GenericAgentTUI()
     app.run()
     return 0

--- a/memory/autonomous_operation_sop/helper.py
+++ b/memory/autonomous_operation_sop/helper.py
@@ -70,8 +70,6 @@ def complete_task(taskname: str, historyline: str, report_path: str) -> str:
     Returns:
         成功消息 + 改TODO指令，或错误消息
     """
-    errors = []
-
     # ── 校验 ──
     if "\n" in historyline.strip():
         return "[ERROR] historyline 必须是单行，不能包含换行符"


### PR DESCRIPTION
## Changes

Clean up ruff F841 (unused variable) and F811 (redefined import) issues across 6 modules:

| File | Issue | Fix |
|------|-------|-----|
| `frontends/fsapp.py` | F841: `event` assigned but unused | Prefix with `_event` |
| `frontends/genericagent_acp_bridge.py` | F841: `method` assigned but unused | Remove assignment |
| `frontends/qtapp.py` | F841: `e` in except clause unused | Use bare `except Exception:` |
| `frontends/tui_v3.py` | F841 + F811: `Keys` fallback + duplicate `dataclass` import | Add `noqa` comment + remove duplicate import |
| `frontends/tuiapp.py` | F841: `args` in `main()` unused | Prefix with `_args` |
| `memory/autonomous_operation_sop/helper.py` | F841: `errors` list unused | Remove initialization |

## Verification

- `ruff check --select F841,F811` on all 6 files → All checks passed
- `python3 -m py_compile` on all 6 files → No syntax errors