### PR TITLE
fix: remove unused time import from checklist_master.py

### DIFF
--- a/reflect/checklist_master.py
+++ b/reflect/checklist_master.py
@@ -1,4 +1,4 @@
-import json, time, random
+import json, random
 from pathlib import Path
 from urllib import request
 


### PR DESCRIPTION
## Change

Remove unused `time` import from the newly added `reflect/checklist_master.py`.

The module imports `json, time, random` but `time` is never referenced in the module body.

## Verification

- `ruff check reflect/checklist_master.py --select F401` → All checks passed
- `python3 -m py_compile reflect/checklist_master.py` → No syntax errors