### PR TITLE
fix: remove unused imports across 21 source files

### DIFF
--- a/agentmain.py
+++ b/agentmain.py
@@ -275,7 +275,7 @@ if __name__ == '__main__':
                 except Exception as e: print(f'[Reflect] on_done error: {e}')
             if getattr(mod, 'ONCE', False): print('[Reflect] ONCE=True, exiting.'); break
     else:
-        try: import readline
+        try: import readline  # noqa: F401 — side-effect: enables REPL history
         except Exception: pass
         agent.inc_out = True
         if sys.stdout.isatty():

--- a/assets/agent_bbs.py
+++ b/assets/agent_bbs.py
@@ -5,7 +5,7 @@
 import sqlite3, uuid, time, json, os
 from threading import Lock, Thread
 from fastapi import FastAPI, HTTPException, Query, Body, UploadFile, File
-from fastapi.responses import JSONResponse, HTMLResponse, PlainTextResponse, FileResponse
+from fastapi.responses import HTMLResponse, PlainTextResponse, FileResponse
 from contextlib import contextmanager
 from starlette.requests import Request
 from starlette.responses import Response

--- a/assets/code_run_header.py
+++ b/assets/code_run_header.py
@@ -1,4 +1,4 @@
-import sys, os, json, re, time, subprocess
+import sys, os, subprocess
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'memory'))
 _r = subprocess.run
 def _d(b):

--- a/frontends/conductor.py
+++ b/frontends/conductor.py
@@ -1,6 +1,6 @@
-import os, sys, re, time, json, uuid, queue, asyncio, threading, builtins
+import os, sys, re, time, uuid, queue, asyncio, threading, builtins
 from dataclasses import dataclass, field
-from typing import Dict, Any, Optional, List
+from typing import Dict, Optional, List
 
 # Silence print() from subagent threads (they share stdout with conductor)
 _original_print = builtins.print

--- a/frontends/dcapp.py
+++ b/frontends/dcapp.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from agentmain import GeneraticAgent
 from chatapp_common import (
-    AgentChatMixin, build_done_text, ensure_single_instance, extract_files,
+    AgentChatMixin, ensure_single_instance, extract_files,
     public_access, redirect_log, require_runtime, split_text, strip_files, clean_reply,
     HELP_TEXT, FILE_HINT, format_restore,
     _handle_continue_frontend, _reset_conversation,

--- a/frontends/qtapp.py
+++ b/frontends/qtapp.py
@@ -20,7 +20,7 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import (
     Qt, QTimer, QPoint, QPointF, QByteArray, QSize,
-    Signal, QMetaObject, Q_ARG, QObject, QDateTime, QEvent,
+    QDateTime, QEvent,
 )
 from PySide6.QtGui import (
     QPainter, QColor, QLinearGradient, QRadialGradient,
@@ -29,7 +29,7 @@ from PySide6.QtGui import (
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from agentmain import GeneraticAgent
-from chatapp_common import FILE_HINT, HELP_TEXT, clean_reply, build_done_text, format_restore
+from chatapp_common import FILE_HINT, HELP_TEXT, format_restore
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -823,7 +823,6 @@ class _MsgRow(QWidget):
 
     def _export_as_md(self):
         from PySide6.QtWidgets import QFileDialog
-        import os
         from datetime import datetime
         default_name = f"msg_{datetime.now().strftime('%Y%m%d_%H%M%S')}.md"
         file_path, _ = QFileDialog.getSaveFileName(

--- a/frontends/stapp.py
+++ b/frontends/stapp.py
@@ -14,7 +14,7 @@ sys.path.append(os.path.abspath(script_dir))
 import streamlit as st
 import time, json, re, threading, queue
 from agentmain import GeneraticAgent
-import chatapp_common  # activate /continue command (monkey patches GeneraticAgent)
+import chatapp_common  # noqa: F401 — side-effect: activates /continue command
 from continue_cmd import handle_frontend_command, reset_conversation, list_sessions, extract_ui_messages
 from btw_cmd import handle_frontend_command as btw_handle_frontend
 from export_cmd import last_assistant_text, export_to_temp, wrap_for_clipboard

--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -6,7 +6,7 @@ Run: `python -m frontends.tui_v3` or `python frontends/tui_v3.py`.
 """
 from __future__ import annotations
 
-import asyncio, atexit, json, locale, logging, os, queue, random, re, select, shutil, signal, subprocess
+import asyncio, atexit, json, locale, logging, os, queue, random, re, shutil, subprocess
 import sys, tempfile, threading, time
 
 _IS_WINDOWS = os.name == 'nt'
@@ -24,14 +24,12 @@ for _p in (_proj_root, _front_dir):
 from agentmain import GeneraticAgent
 from dataclasses import dataclass
 from dataclasses import dataclass, field
-from functools import lru_cache
 from io import StringIO
 from rich.cells import cell_len
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.text import Text
 from rich.theme import Theme
-from typing import Callable
 
 # ════════════════════════════════════════════════════════════════════════════
 # i18n — minimal dict-based zh/en translation layer (inlined; was tui_v3_i18n.py)

--- a/frontends/tuiapp.py
+++ b/frontends/tuiapp.py
@@ -22,7 +22,6 @@ import queue
 import re
 import sys
 import threading
-import time
 from dataclasses import dataclass, field
 from itertools import count
 from typing import Any, Callable, Optional

--- a/frontends/wechatapp.py
+++ b/frontends/wechatapp.py
@@ -1,4 +1,4 @@
-import os, sys, re, threading, queue, time, socket, json, struct, base64, uuid, hashlib, math
+import os, sys, re, threading, queue, time, socket, json, struct, base64, uuid, hashlib
 from pathlib import Path
 from urllib.parse import quote
 import requests, qrcode

--- a/frontends/wecomapp.py
+++ b/frontends/wecomapp.py
@@ -1,7 +1,7 @@
 import asyncio, os, select, sys, threading, time, traceback
 from collections import deque
 from datetime import datetime
-from typing import Any, Callable, Dict, Optional, TypedDict
+from typing import Any, Callable, Optional, TypedDict
 
 
 class TurnContext(TypedDict, total=False):

--- a/llmcore.py
+++ b/llmcore.py
@@ -1,4 +1,4 @@
-import os, json, re, time, requests, sys, threading, urllib3, base64, importlib, uuid
+import os, json, re, time, requests, sys, threading, urllib3, importlib, uuid
 from datetime import datetime
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 _RESP_CACHE_KEY = str(uuid.uuid4())

--- a/memory/L4_raw_sessions/compress_session.py
+++ b/memory/L4_raw_sessions/compress_session.py
@@ -1,7 +1,7 @@
 """L4 Session Log Processor — compress & extract history.
 Format A (JSON): kept as-is.  Format B (Raw): strip sys prompt & assistant echo.
 """
-import re, os, json, ast
+import re, os
 from datetime import datetime
 
 L4_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/memory/autonomous_operation_sop/helper.py
+++ b/memory/autonomous_operation_sop/helper.py
@@ -10,7 +10,6 @@ autonomous_task.py - 自主行动任务管理API
   set_todo()        → 返回TODO真实路径
 """
 
-import os
 import re
 import shutil
 from pathlib import Path

--- a/memory/ljqCtrl.py
+++ b/memory/ljqCtrl.py
@@ -10,14 +10,14 @@ ljqCtrl Quick Reference:
 - GrabWindow(hwnd) -> PIL Image: DPI-safe window screenshot (needs foreground)
 - GrabWindowBg(hwnd_or_name) -> PIL Image: WGC background capture (Win10+, pip install windows-capture)
 """
-import os, sys, time, random, math, win32api, win32con, win32gui, ctypes
+import os, time, win32api, win32con, win32gui, ctypes
 import numpy as np
 
 print('[TIPS] always use physical coordinates!')
 
 dpi_scale = 1
 try:
-	from PIL import ImageGrab, Image, ImageEnhance, ImageFilter, ImageDraw
+	from PIL import ImageGrab, Image
 	import cv2
 except: pass
 

--- a/memory/procmem_scanner.py
+++ b/memory/procmem_scanner.py
@@ -2,8 +2,6 @@ import ctypes
 import ctypes.wintypes
 import argparse
 import yara
-import sys
-import os
 import json
 
 # Define WinAPI Types for 64-bit compatibility

--- a/memory/ui_detect.py
+++ b/memory/ui_detect.py
@@ -96,7 +96,7 @@ def detect(image_path, mode='match', model_path=None, conf=0.25, iou_thresh=0.5)
     """
     # 归一化：PIL Image → 临时文件
     if isinstance(image_path, Image.Image):
-        import tempfile, os
+        import tempfile
         tmp = tempfile.NamedTemporaryFile(suffix='.png', delete=False)
         image_path.save(tmp.name)
         image_path = tmp.name

--- a/plugins/langfuse_tracing.py
+++ b/plugins/langfuse_tracing.py
@@ -7,7 +7,7 @@ Replaces old monkey-patch approach with hooks on:
 
 Usage tracking (SSE parser wrapping) stays as internal llmcore patch.
 """
-import threading, sys
+import threading
 
 try:
     from llmcore import _load_mykeys

--- a/reflect/agent_team_worker.py
+++ b/reflect/agent_team_worker.py
@@ -1,6 +1,6 @@
 # reflect module: BBS接单
 # check()内预检BBS，无新帖返回None不唤醒agent
-import json, time, os
+import json, os
 from urllib import request
 
 INTERVAL = 60

--- a/reflect/checklist_master.py
+++ b/reflect/checklist_master.py
@@ -1,4 +1,4 @@
-import json, time, random
+import json, random
 from pathlib import Path
 from urllib import request
 

--- a/simphtml.py
+++ b/simphtml.py
@@ -659,7 +659,7 @@ def get_temp_texts(driver):
         print(e)
         return []
     
-import time, re, os
+import time, re
 def get_main_block(driver, extra_js="", text_only=False): 
     page = driver.execute_js(f"{extra_js}\n{js_optHTML}\nreturn optHTML({str(text_only).lower()});").get('data', '')
     if text_only:


### PR DESCRIPTION
## Changes

Remove 40 `F401` (unused import) violations across 21 source files, as detected by `ruff check --select F401`.

Side-effect imports are preserved with `# noqa: F401` comments:
- `agentmain.py`: `readline` enables REPL history
- `stapp.py`: `chatapp_common` activates `/continue` command via monkey-patching

All other removed imports were verified unused (no runtime references found).

## Verification

- `ruff check . --select F401` → All checks passed (0 remaining)
- `python3 -m py_compile` on all `.py` files → No syntax errors