### PR TITLE
fix: add plugins/__init__.py for proper package recognition

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,0 +1,1 @@
+# plugins package marker


### PR DESCRIPTION
## Problem
`plugins/` directory is missing `__init__.py`, which prevents Python's import system
from recognizing it as a package. This causes plugin loading to fail during
`discover_and_load()` at agent startup.

## Fix
Add empty `plugins/__init__.py` (package marker file with a comment).

## Changes
- `plugins/__init__.py` — new file, single-line comment (`# plugins package marker`)

## Impact
- Restores plugin discovery and loading for all modules under `plugins/`
- No functional logic changes, purely structural fix

Fixes #549 

