### PR TITLE
feat(wizard): bump MiniMax default to M3

### DIFF
--- a/assets/configure_mykey.py
+++ b/assets/configure_mykey.py
@@ -145,16 +145,16 @@ LLM_PROVIDERS = [
     },
     {
         'id': 'minimax',
-        'name': 'MiniMax M2.7 (双协议)',
-        'desc': 'MiniMax M2.7，支持 Anthropic 和 OpenAI 双协议',
+        'name': 'MiniMax M3 (双协议)',
+        'desc': 'MiniMax M3，支持 Anthropic 和 OpenAI 双协议',
         'type': 'native_claude',
         'template': {
             'name': 'minimax', 'apikey': 'eyJh...<your-minimax-key>',
             'apibase': 'https://api.minimaxi.com/anthropic',
-            'model': 'MiniMax-M2.7', 'max_retries': 3,
+            'model': 'MiniMax-M3', 'max_retries': 3,
         },
         'key_hint': '在 https://platform.minimaxi.com/user-center/basic-information 获取',
-        'model_choices': ['MiniMax-M2.7', 'MiniMax-M2.5'],
+        'model_choices': ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
         'extra_fields': [
             {
                 'key': '_protocol', 'label': '选择 API 协议',

--- a/mykey_template.py
+++ b/mykey_template.py
@@ -252,13 +252,13 @@ mixin_config = {
 #  MiniMax 同时提供 OAI 和 Anthropic 兼容接口，同一个 key 两个端点都能用：
 #    - /v1             → chat/completions (LLMSession)
 #    - /anthropic      → Anthropic Messages (NativeClaudeSession)
-#  Anthropic 路径更简洁，OAI 路径会返回 <think> 标签（M2.7 自带思考）。
-#  温度自动修正为 (0, 1]，支持 M2.7 / M2.5 全系列，204K 上下文。
+#  Anthropic 路径更简洁，OAI 路径会返回 <think> 标签（M3/M2.7 自带思考）。
+#  温度自动修正为 (0, 1]，支持 M3 / M2.7 全系列，M3 512K 上下文。
 # native_claude_config_minimax = {
 #     'name': 'minimax-anthropic',                   # /llms 显示名
 #     'apikey': 'sk-<your-minimax-key>',             # 与 OAI 路径同一个 key
 #     'apibase': 'https://api.minimaxi.com/anthropic',  # Anthropic Messages 兼容端点
-#     'model': 'MiniMax-M2.7',
+#     'model': 'MiniMax-M3',
 #     'max_retries': 3,                              # int
 #     # 'fake_cc_system_prompt': False,              # MiniMax 不做 CC 指纹校验
 # }
@@ -355,14 +355,14 @@ native_oai_config = {
 # ══════════════════════════════════════════════════════════════════════════════
 
 # ── 4a. MiniMax OAI 路径 (/v1 chat/completions) ────────────────────────────
-#  OAI 路径会返回 <think> 标签（M2.7 自带思考）；Anthropic 路径更简洁（见 1f）。
-#  温度自动修正为 (0, 1]，支持 M2.7/M2.5 全系列，204K 上下文。
+#  OAI 路径会返回 <think> 标签（M3/M2.7 自带思考）；Anthropic 路径更简洁（见 1f）。
+#  温度自动修正为 (0, 1]，支持 M3/M2.7 全系列，M3 512K 上下文。
 # oai_config_minimax = {
 #     'name': 'minimax-oai',                           # /llms 显示名
 #     'apikey': 'sk-<your-minimax-key>',               # 形如 sk-cp-xxxxxxxxx；Bearer 鉴权
 #     'apibase': 'https://api.minimaxi.com/v1',        # OAI 兼容端点
-#     'model': 'MiniMax-M2.7',                         # 名含 'minimax' → temp 夹到 (0.01,1.0]
-#     'context_win': 50000,                            # int；MiniMax 204K 上下文，此处是裁剪阈值
+#     'model': 'MiniMax-M3',                           # 名含 'minimax' → temp 夹到 (0.01,1.0]
+#     'context_win': 50000,                            # int；MiniMax M3 512K 上下文，此处是裁剪阈值
 # }
 
 


### PR DESCRIPTION
## Summary

Update the wizard's MiniMax provider entry to use **M3** as the new default model. M3 is the latest MiniMax flagship (512K context, 128K max output, image input supported across both OAI and Anthropic protocols). Keep `M2.7` (and `M2.7-highspeed`) as alternates; drop the older `M2.5`.

## Changes

- `assets/configure_mykey.py`: switch the `minimax` provider name/description/default model from `MiniMax-M2.7` to `MiniMax-M3`; refresh `model_choices` to `[M3, M2.7, M2.7-highspeed]` (M3 first/default, drop M2.5).
- `mykey_template.py`: align the two commented MiniMax snippets (Anthropic + OAI paths) — switch the example `model` to `MiniMax-M3` and update the supported-models / context-window notes to mention M3 (512K).

Net diff: 11+/11- across two files; no behavioural changes outside the wizard's default value and the model_choices list.

## Why

`MiniMax-M3` is the latest MiniMax flagship — 512K context, up to 128K output, image input on both OAI-compatible and Anthropic-compatible endpoints — so it should be the wizard's recommended default for new installs. Keeping `M2.7` and `M2.7-highspeed` in `model_choices` preserves the option to fall back for users who want the previous generation.

## Testing

- `assets/configure_mykey.py`: imports + the wizard's provider list lookup still works; `LLM_PROVIDERS[minimax].template.model == 'MiniMax-M3'` and `model_choices == ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed']`.
- `mykey_template.py`: file is comment-only configuration examples — manual review.