### PR TITLE
fix: replace bare except clauses with except Exception in agentmain.py

### DIFF
--- a/agentmain.py
+++ b/agentmain.py
@@ -60,14 +60,14 @@ class GenericAgent:
         mykeys, changed = reload_mykeys()
         if not changed and hasattr(self, 'llmclients'): return
         try: oldhistory = self.llmclient.backend.history
-        except: oldhistory = None
+        except Exception: oldhistory = None
         llm_sessions = []
         for k, cfg in mykeys.items():
             if not any(x in k for x in ['api', 'config', 'cookie']): continue
             try:
                 if 'mixin' in k: llm_sessions += [{'mixin_cfg': cfg}]
                 elif c := resolve_client(k): llm_sessions += [c]
-            except: pass
+            except Exception: pass
         for i, s in enumerate(llm_sessions):
             if isinstance(s, dict) and 'mixin_cfg' in s:
                 try:
@@ -85,7 +85,7 @@ class GenericAgent:
         lastc = self.llmclient
         self.llmclient = self.llmclients[self.llm_no]
         try: self.llmclient.backend.history = lastc.backend.history
-        except: raise Exception('[ERROR] BAD Mixin config: Check your mykey.py')
+        except Exception: raise Exception('[ERROR] BAD Mixin config: Check your mykey.py')
         self.llmclient.last_tools = ''
         name = self.get_llm_name(model=True)
         if 'glm' in name or 'minimax' in name or 'kimi' in name: load_tool_schema('_cn')


### PR DESCRIPTION
## Summary

Replace 3 bare `except:` clauses in `agentmain.py` with `except Exception:` to pass ruff E722 lint checks.

## Changes

- Line 63: `load_llm_sessions()` — catch AttributeError when llmclient has no backend/history
- Line 70: client resolution loop — ignore client resolution failures silently
- Line 88: `next_llm()` — raise descriptive error on mixin history copy failure

## Verification

- `python3 -m py_compile agentmain.py` passes
- `ruff check agentmain.py --select E722` reports all checks passed