### PR TITLE
fix: replace bare except clauses with except Exception in ga.py

### DIFF
--- a/ga.py
+++ b/ga.py
@@ -47,9 +47,9 @@ def code_run(code, code_type="python", timeout=60, cwd=None, code_cwd=None, stop
                 try: line = line_bytes.decode('utf-8')
                 except UnicodeDecodeError: line = line_bytes.decode('gbk', errors='ignore')
                 logs.append(line)
-                try: print(line, end="") 
-                except: pass
-        except: pass
+                try: print(line, end="")
+                except Exception: pass
+        except Exception: pass
 
     try:
         process = subprocess.Popen(
@@ -159,7 +159,7 @@ def log_memory_access(path):
     stats_file = os.path.join(script_dir, 'memory/file_access_stats.json')
     try:
         with open(stats_file, 'r', encoding='utf-8') as f: stats = json.load(f)
-    except: stats = {}
+    except Exception: stats = {}
     fname = os.path.basename(path)
     stats[fname] = {'count': stats.get(fname, {}).get('count', 0) + 1, 'last': datetime.now().strftime('%Y-%m-%d')}
     with open(stats_file, 'w', encoding='utf-8') as f: json.dump(stats, f, indent=2, ensure_ascii=False)
@@ -289,7 +289,7 @@ class GenericAgentHandler(BaseHandler):
             code = self._extract_code_block(response, code_type)
             if not code: return StepOutcome("[Error] Code missing. Must use reply code block or 'script' arg.", next_prompt="\n")
         try: timeout = int(args.get("timeout", 60))
-        except: timeout = 60
+        except Exception: timeout = 60
         raw_path = os.path.join(self.cwd, args.get("cwd", './'))
         cwd = os.path.normpath(os.path.abspath(raw_path))
         code_cwd = os.path.normpath(self.cwd)
@@ -348,10 +348,10 @@ class GenericAgentHandler(BaseHandler):
             try:
                 with open(abs_path, 'w', encoding='utf-8') as f: f.write(str(content))
                 result["js_return"] += f"\n\n[已保存完整内容到 {abs_path}]"
-            except: result['js_return'] += f"\n\n[保存失败，无法写入文件 {abs_path}]"
+            except Exception: result['js_return'] += f"\n\n[保存失败，无法写入文件 {abs_path}]"
         show = smart_format(json.dumps(result, ensure_ascii=False, indent=2, default=json_default), max_str_len=300)
         try: print("Web Execute JS Result:", show)
-        except: pass
+        except Exception: pass
         yield f"JS 执行结果:\n{show}\n"
         next_prompt = self._get_anchor_prompt(skip=args.get('_index', 0) > 0)
         result = json.dumps(result, ensure_ascii=False, default=json_default)
@@ -433,7 +433,7 @@ class GenericAgentHandler(BaseHandler):
     def _check_plan_completion(self):
         if not os.path.isfile(p:=self._in_plan_mode() or ''): return None
         try: return len(re.findall(r'\[ \]', open(p, encoding='utf-8', errors='replace').read()))
-        except: return None
+        except Exception: return None
     
     def do_update_working_checkpoint(self, args, response):
         '''为整个任务设定后续需要临时记忆的重点。'''
@@ -544,7 +544,7 @@ class GenericAgentHandler(BaseHandler):
         if self.working.get('related_sop'): prompt += f"\n有不清晰的地方请再次读取{self.working.get('related_sop')}"
         if getattr(self.parent, 'verbose', False):
             try: print(prompt)
-            except: pass
+            except Exception: pass
         return prompt
     
     def turn_end_callback(self, response, tool_calls, tool_results, turn, next_prompt, exit_reason):


### PR DESCRIPTION
## Summary

Replace 8 bare `except:` clauses in `ga.py` with `except Exception:` to pass ruff E722 lint checks.

## Changes

- Line 51/52: `code_run()` stream reader — ignore print failures and process stdout close errors
- Line 162: `log_memory_access()` — fall back to empty stats dict on JSON decode failure
- Line 292: `do_code_run()` — fall back to 60s timeout when timeout arg is non-integer
- Line 351: `web_execute_js()` — gracefully report file write failure
- Line 354: same method — ignore print failures for result display
- Line 436: `_check_plan_completion()` — return None when plan file read/regex fails
- Line 547: `build_system_prompt()` — ignore verbose print failures

## Verification

- `python3 -m py_compile ga.py` passes
- `ruff check ga.py --select E722` reports all checks passed