### PR TITLE
fix(continue): robust session preview for malformed logs

### DIFF
--- a/frontends/continue_cmd.py
+++ b/frontends/continue_cmd.py
@@ -46,6 +46,20 @@ def _first_user(pairs):
     return ''
 
 
+def _last_user(text):
+    """Last real user prompt. Scans `=== Prompt ===` blocks directly (no
+    Prompt/Response pairing, so response-less/aborted sessions still preview),
+    newest-first, returning the first one `_user_text` accepts (it drops
+    tool_result continuations + all _INJECT_MARKERS). Better preview anchor than
+    the first prompt — reflects what the session was most recently about."""
+    for label, body in reversed(_BLOCK_RE.findall(text or '')):
+        if label == 'Prompt':
+            t = _user_text(body)
+            if t:
+                return t
+    return ''
+
+
 def _last_summary(pairs):
     for _, response_body in reversed(pairs):
         try:
@@ -173,12 +187,20 @@ def _preview_from_file(path):
                 fh.seek(-_PREVIEW_WIN, 2); tail = fh.read()
     except OSError: return ''
     tail_s = tail.decode('utf-8', errors='replace')
-    m = _SUMMARY_RE.findall(tail_s)
-    if m: return m[-1].strip()
-    for line in head.decode('utf-8', errors='replace').splitlines():
-        s = line.strip()
-        if s and not s.startswith('===') and not s.startswith('###') and '<history>' not in s:
+    # Use only the latest <summary>, and reject it if dirty. Models sometimes emit
+    # an unclosed <summary>, so the non-greedy DOTALL match pairs it with a far-away
+    # </summary> and swallows === block headers / JSON across rounds. Treat such a
+    # match as invalid and fall through to the last user prompt (don't dig older ones).
+    cands = _SUMMARY_RE.findall(tail_s)
+    if cands:
+        s = ' '.join(cands[-1].split())
+        if s and '=== ' not in s and '"role"' not in s and len(s) <= 200:
             return s
+    # Summary invalid/absent -> last real user prompt (JSON-aware, skips anchors;
+    # scans Prompt blocks directly so response-less sessions still preview).
+    lu = _last_user(tail_s) or _last_user(head.decode('utf-8', errors='replace'))
+    if lu:
+        return ' '.join(lu.split())[:120]
     return ''
 
 


### PR DESCRIPTION
## 问题
`/continue` 列表里部分会话的预览显示成 JSON 碎片,例如 `{` 或 `！\n\n" } ]} === Response === 2026-...`(本地 261 个日志里有 26 个中招)。

## 根因(`continue_cmd._preview_from_file`)
1. 模型有时输出 `<summary>` 忘了闭合,`_SUMMARY_RE`(非贪婪 + DOTALL)便把它和很远处的 `</summary>` 配对,把中间跨轮的 `=== Response ===` 块头、JSON 全captured进来。
2. 找不到 summary 时的兜底是「取第一条非 `===`/`###` 行」,会回 `{` / `" } ]}` 这种结构行。

## 修复
- 只看**最近一条** `<summary>`;若它像跨段误捕获(含 `=== ` / `"role"` 或 >200 字)则判为失效,**不再回退翻更旧的 summary**。
- 兜底改用新的 `_last_user()`:**直接扫 `=== Prompt ===` 块**(不依赖 Prompt/Response 配对,所以没等到回复就中断的会话也能预览),从尾取**末条真实用户提问**,并复用既有 `_user_text()` 跳过 tool_result 续轮和全部 `_INJECT_MARKERS`(WORKING MEMORY / SYSTEM TIPS / DANGER 等)。

## 验证
本地扫 261 个 `model_responses` 日志:脏预览 **26 → 0**,且原先无 summary 的会话现在也能显示首/末条提问。改动仅 `frontends/continue_cmd.py` 一处。