### PR TITLE
docs: add description for galley in friendly links

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Thanks to the **LinuxDo** community for the support!
 **Community GUIs** *(independent open-source projects)*:
 
 - [chilishark27/ga-manager](https://github.com/chilishark27/ga-manager)
-- [wangjc683/galley](https://github.com/wangjc683/galley)
+- [wangjc683/galley](https://github.com/wangjc683/galley) — Out-of-the-box local agent workbench with a bundled GA runtime (CPython 3.11 + deps), native GUI/CLI, multi-session + Project orchestration, local-first.
 - [FroStorM/A3Agent](https://github.com/FroStorM/A3Agent/tree/workbench)
 
 ---
@@ -765,7 +765,7 @@ GenericAgent 通过 **分层记忆 × 最小工具集 × 自主执行循环** �
 **社区 GUI 客户端** *（独立开源项目）*：
 
 - [chilishark27/ga-manager](https://github.com/chilishark27/ga-manager)
-- [wangjc683/galley](https://github.com/wangjc683/galley)
+- [wangjc683/galley](https://github.com/wangjc683/galley) —— 开箱即用的本地 Agent 工作台，自带 GA 内核（内置 CPython 3.11 + 运行依赖），GUI/CLI 双原生、多 session + Project 编排、本地优先。
 - [FroStorM/A3Agent](https://github.com/FroStorM/A3Agent/tree/workbench)
 
 ---


### PR DESCRIPTION
## What
给友情链接（Friendly Links / 友情链接）里的 galley 补一行简短说明（中英文各一处）。

## Why
galley (wangjc683/galley) 是基于 GenericAgent 的开箱即用下游项目，加描述方便读者了解其内置 runtime、免部署的特点。描述内容对齐 galley 自身 README 的自述，未夸大。

## Changes
- README.md: galley 条目从裸链接补充为带说明的条目（英文 + 中文各一行）
- ga-manager / A3Agent 保持原样

## Testing
纯文档改动，无需测试。