### PR TITLE
fix: reject unknown CLI args unless running in --reflect mode

### DIFF
--- a/agentmain.py
+++ b/agentmain.py
@@ -206,7 +206,13 @@ if __name__ == '__main__':
     parser.add_argument('--nobg', action='store_true')
     parser.add_argument('--nolog', action='store_true')
     args, _unknown = parser.parse_known_args()
-    _extra_args = dict(zip([k.lstrip('-') for k in _unknown[::2]], _unknown[1::2])) if _unknown else {}
+    if _unknown and not args.reflect:
+        # Reject unknown CLI flags unless we are in --reflect mode, where
+        # extra key/value pairs are forwarded to the reflect script.
+        # Without this guard, typos like `--goal` silently fall through to
+        # interactive mode and the process looks alive without doing any work.
+        parser.error(f"unrecognized arguments: {' '.join(_unknown)}")
+    _reflect_args = dict(zip([k.lstrip('-') for k in _unknown[::2]], _unknown[1::2])) if _unknown else {}
 
     if (args.func or args.task) and not args.nobg:
         import subprocess, platform


### PR DESCRIPTION
## Problem

`agentmain.py` used `parse_known_args()`, which silently accepted unknown
CLI flags. A typo like `--goal` (intended for a separate Hive launcher)
was swallowed without warning, causing the process to fall through into
the interactive agent loop in the background — the TUI looked frozen
because no master dispatch was ever published.

Reported in #566.

## Fix

Add a guard after `parse_known_args()`:
- If unknown args are present **and** `--reflect` is not set, call
  `parser.error(...)` so argparse prints usage and exits non-zero.
- The `--reflect` path is unchanged: extra `--key value` pairs are still
  forwarded to the reflect script as `_reflect_args`.

## Verification

Local tests with a synthetic argv (no API keys required):

```text
Test 1 — unknown --goal without --reflect:
  exit code: 2
  stderr:    usage: agentmain.py ...
             agentmain.py: error: unrecognized arguments: --goal /tmp/foo.json

Test 2 — --reflect with extra args (--base_url / --board_key):
  exit code: 0
  OK args= Namespace(... reflect='reflect/agent_team_master.py' ...) unknown= ['--base_url', '...']

Test 3 — no unknown args (--nobg only):
  argparse stage passes; later GeneraticAgent() raises unrelated to this change
```

`ruff check agentmain.py --select F,E9` reports only pre-existing
findings (F541 f-string in another function, F401 side-effect `readline`
import) — none introduced by this patch.

Closes #566
