### PR TITLE
fix: clear ruff F811/F841 findings across frontends and helpers

### DIFF
--- a/frontends/fsapp.py
+++ b/frontends/fsapp.py
@@ -809,7 +809,7 @@ def _run_async(coro):
 
 
 def handle_message(data):
-    event, message, sender = data.event, data.event.message, data.event.sender
+    _event, message, sender = data.event, data.event.message, data.event.sender
     message_id = getattr(message, "message_id", "") or ""
     if not _claim_message_once(message_id):
         print(f"忽略重复飞书消息: {message_id}")

--- a/frontends/genericagent_acp_bridge.py
+++ b/frontends/genericagent_acp_bridge.py
@@ -147,7 +147,7 @@ class GenericAgentAcpBridge:
         payload = compact_json(msg)
         raw = (payload + "\n").encode("utf-8")
         method = msg.get("method", msg.get("id", "?"))
-        eprint(f"[ACP-BRIDGE] >>> {payload[:500]}")
+        eprint(f"[ACP-BRIDGE] >>> [{method}] {payload[:500]}")
         try:
             with self._write_lock:
                 self._json_out.write(raw)

--- a/frontends/qtapp.py
+++ b/frontends/qtapp.py
@@ -833,7 +833,7 @@ class _MsgRow(QWidget):
             try:
                 with open(file_path, "w", encoding="utf-8") as f:
                     f.write(self._text)
-            except Exception as e:
+            except Exception:
                 import traceback
                 traceback.print_exc()
 

--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -22,7 +22,6 @@ for _p in (_proj_root, _front_dir):
         sys.path.insert(0, _p)
 
 from agentmain import GeneraticAgent
-from dataclasses import dataclass
 from dataclasses import dataclass, field
 from functools import lru_cache
 from io import StringIO
@@ -821,11 +820,6 @@ def _ptk_keypress_to_bytes(kp) -> bytes:
     ConPTY, mintty/msys pty) into symbolic Keys.  Keep the editor core small by
     translating those symbols back to the bytes already handled by _feed/_keys.
     """
-    try:
-        from prompt_toolkit.keys import Keys
-    except Exception:
-        Keys = None  # type: ignore[assignment]
-
     key = getattr(kp, 'key', None)
     data = getattr(kp, 'data', '') or ''
     mods = {str(m).lower().replace('_', '-') for m in (getattr(kp, 'modifiers', None) or ())}

--- a/frontends/tuiapp.py
+++ b/frontends/tuiapp.py
@@ -721,7 +721,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Optional[list[str]] = None) -> int:
-    args = build_arg_parser().parse_args(argv)
+    build_arg_parser().parse_args(argv)
     app = GenericAgentTUI()
     app.run()
     return 0

--- a/memory/autonomous_operation_sop/helper.py
+++ b/memory/autonomous_operation_sop/helper.py
@@ -70,8 +70,6 @@ def complete_task(taskname: str, historyline: str, report_path: str) -> str:
     Returns:
         成功消息 + 改TODO指令，或错误消息
     """
-    errors = []
-
     # ── 校验 ──
     if "\n" in historyline.strip():
         return "[ERROR] historyline 必须是单行，不能包含换行符"


### PR DESCRIPTION
fix: clear ruff F811/F841 findings across frontends and helpers

Resolve all F811 (redefined-while-unused) and F841 (unused-local) issues
reported by ruff so the lint baseline is cleaner:

- frontends/tui_v3.py: drop a duplicate `from dataclasses import
  dataclass` line that was shadowed by the very next import; remove the
  dead `from prompt_toolkit.keys import Keys` block in
  _ptk_keypress_to_bytes — the symbol was never referenced in the
  function body, only `getattr(kp, 'key', None)` is used.
- frontends/fsapp.py: handle_message unpacks data.event but never reads
  the event object — rename to `_event` to flag intent.
- frontends/genericagent_acp_bridge.py: write_message computed `method`
  but only logged the payload — embed method in the ACP-BRIDGE log line
  so the local is used and debugging is easier.
- frontends/qtapp.py: drop unused `as e` from an exception handler that
  already prints via traceback.print_exc().
- frontends/tuiapp.py: drop the unused `args` assignment in main();
  parse_args still validates argv and surfaces errors.
- memory/autonomous_operation_sop/helper.py: remove an unused `errors`
  list in complete_task.

Verification:
- `python3 -m py_compile` on all six files passes.
- `ruff check <files> --select F811,F841` reports `All checks passed!`.
- No behavioural change; the only logic tweak is the ACP-BRIDGE log
  gaining a `[method]` prefix.
