### PR TITLE
fix(stapp): fall back to st.rerun() when fragment scope rerun is unavailable

### DIFF
--- a/frontends/stapp.py
+++ b/frontends/stapp.py
@@ -105,7 +105,11 @@ def render_sidebar():
     st.caption(f"LLM Core: {llm_labels.get(current_idx, str(current_idx))}")
     selected_idx = st.selectbox("LLM", [idx for idx, _, _ in llm_options], index=next((i for i, (idx, _, _) in enumerate(llm_options) if idx == current_idx), 0), format_func=llm_labels.get, label_visibility="collapsed", key="sidebar_llm_select")
     if selected_idx != current_idx:
-        agent.next_llm(selected_idx); st.rerun(scope="fragment")
+        agent.next_llm(selected_idx)
+        try:
+            st.rerun(scope="fragment")
+        except st.StreamlitAPIException:
+            st.rerun()
     if st.button(T('force_stop')):
         agent.abort(); st.toast("Stop signal sended"); st.rerun()
     if st.button(T('desktop_pet')):


### PR DESCRIPTION
## Summary

Fixes #564

The Streamlit sidebar in `frontends/stapp.py` crashes on startup when the persisted LLM selectbox value (`st.session_state['sidebar_llm_select']`) disagrees with the agent's current `llm_no`:

```
StreamlitAPIException: scope="fragment" can only be specified from
@st.fragment-decorated functions during fragment reruns.
```

## Root cause

`render_sidebar()` is decorated with `@st.fragment`. On the initial app run, the function executes as part of the main script — not as a fragment rerun. If `selected_idx != current_idx` triggers in that first execution, calling `st.rerun(scope="fragment")` is illegal and Streamlit aborts.

The other `st.rerun(scope="app")` calls in the same fragment are unaffected — `scope="app"` is legal from both fragment and non-fragment contexts; the restriction applies only to `scope="fragment"`.

## Fix

Wrap the call so that when fragment-scoped rerun is unavailable (initial run / outside a fragment rerun), we fall back to a full `st.rerun()`. The user-visible behavior is unchanged: the LLM is switched and the UI refreshes either way.

```python
if selected_idx != current_idx:
    agent.next_llm(selected_idx)
    try:
        st.rerun(scope="fragment")
    except st.StreamlitAPIException:
        st.rerun()
```

`frontends/stapp2.py` does not use `scope="fragment"` and is unaffected. No other frontend touches this pattern.

## Verification

- `python3 -m py_compile frontends/stapp.py` — passes
- `ruff check frontends/stapp.py` — no new findings introduced by this change (60 pre-existing project-style warnings remain, untouched)
- Manual review: try/except is the documented Streamlit pattern for this scenario; behavior on subsequent fragment reruns (where `scope="fragment"` is legal and faster) is preserved
