### PR TITLE
fix: use context managers for file writes to prevent resource leaks

### DIFF
--- a/agentmain.py
+++ b/agentmain.py
@@ -24,16 +24,20 @@ lang_suffix = '_en' if os.environ.get('GA_LANG', '') == 'en' else ''
 mem_dir = os.path.join(script_dir, 'memory')
 if not os.path.exists(mem_dir): os.makedirs(mem_dir)
 mem_txt = os.path.join(mem_dir, 'global_mem.txt')
-if not os.path.exists(mem_txt): open(mem_txt, 'w', encoding='utf-8').write('# [Global Memory - L2]\n')
+if not os.path.exists(mem_txt):
+    with open(mem_txt, 'w', encoding='utf-8') as f: f.write('# [Global Memory - L2]\n')
 mem_insight = os.path.join(mem_dir, 'global_mem_insight.txt')
 if not os.path.exists(mem_insight):
     t = os.path.join(script_dir, f'assets/global_mem_insight_template{lang_suffix}.txt')
-    open(mem_insight, 'w', encoding='utf-8').write(open(t, encoding='utf-8').read() if os.path.exists(t) else '')
+    tpl = ''
+    if os.path.exists(t):
+        with open(t, encoding='utf-8') as src: tpl = src.read()
+    with open(mem_insight, 'w', encoding='utf-8') as f: f.write(tpl)
 cdp_cfg = os.path.join(script_dir, 'assets/tmwd_cdp_bridge/config.js')
 if not os.path.exists(cdp_cfg):
     try:
         os.makedirs(os.path.dirname(cdp_cfg), exist_ok=True)
-        open(cdp_cfg, 'w', encoding='utf-8').write(f"const TID = '__ljq_{hex(random.randint(0, 99999999))[2:8]}';")
+        with open(cdp_cfg, 'w', encoding='utf-8') as f: f.write(f"const TID = '__ljq_{hex(random.randint(0, 99999999))[2:8]}';")
     except Exception as e: print(f'[WARN] CDP config init failed: {e} — advanced web features (tmwebdriver) will be unavailable.')
 
 def get_system_prompt():
@@ -289,7 +293,8 @@ if __name__ == '__main__':
                     print(f'[Reflect] drain error: {e}'); result = f'[ERROR] {e}'
                 log_dir = os.path.join(script_dir, 'temp/reflect_logs'); os.makedirs(log_dir, exist_ok=True)
                 script_name = os.path.splitext(os.path.basename(args.reflect))[0]
-                open(os.path.join(log_dir, f'{script_name}_{datetime.now():%Y-%m-%d}.log'), 'a', encoding='utf-8').write(f'[{datetime.now():%m-%d %H:%M}]\n{result}\n\n')
+                with open(os.path.join(log_dir, f'{script_name}_{datetime.now():%Y-%m-%d}.log'), 'a', encoding='utf-8') as f:
+                    f.write(f'[{datetime.now():%m-%d %H:%M}]\n{result}\n\n')
                 if (on_done := getattr(mod, 'on_done', None)):
                     try: on_done(result)
                     except Exception as e: print(f'[Reflect] on_done error: {e}')

--- a/frontends/wechatapp.py
+++ b/frontends/wechatapp.py
@@ -285,7 +285,8 @@ def _dl_media(items):
                 ct = requests.get(f'{CDN_BASE}/download?encrypted_query_param={quote(eq)}', headers={'User-Agent': UA}, timeout=60).content
                 pt = AES.new(aes_key, AES.MODE_ECB).decrypt(ct); pt = pt[:-pt[-1]]
                 fname = sub.get('file_name') or f'{uuid.uuid4().hex[:8]}{ext or ".bin"}'
-                p = os.path.join(_TEMP_DIR, fname); open(p, 'wb').write(pt)
+                p = os.path.join(_TEMP_DIR, fname)
+                with open(p, 'wb') as f: f.write(pt)
                 paths.append(p); print(f'[WX] media saved: {fname}', file=sys.__stdout__)
             except Exception as e:
                 print(f'[WX] media dl err ({key}): {e}', file=sys.__stdout__)

--- a/ga.py
+++ b/ga.py
@@ -394,8 +394,10 @@ class GenericAgentHandler(BaseHandler):
         try:
             new_content = expand_file_refs(content, base_dir=self.cwd)
             if mode == "prepend":
-                old = open(path, 'r', encoding="utf-8").read() if os.path.exists(path) else ""
-                open(path, 'w', encoding="utf-8").write(new_content + old)
+                old = ''
+                if os.path.exists(path):
+                    with open(path, 'r', encoding="utf-8") as f: old = f.read()
+                with open(path, 'w', encoding="utf-8") as f: f.write(new_content + old)
             else:
                 with open(path, 'a' if mode == "append" else 'w', encoding="utf-8") as f: f.write(new_content)
             yield f"[Status] ✅ {mode.capitalize()} 成功 ({len(new_content)} bytes)\n"


### PR DESCRIPTION
## Summary

Replace six `open(path, mode, ...).write(...)` call sites with proper `with open(...) as f:` context managers so file handles are deterministically closed and writes are guaranteed to flush.

The bare form relies on garbage collection to release file descriptors, which can leave buffered writes un-flushed if the interpreter is interrupted (Ctrl+C, OOM, crash). The most exposed call site is `ga.py`'s `file_write` tool in prepend mode, which reads the existing file then rewrites it in one shot — without `with`, an abort between read and re-flush would silently truncate the user's file.

## Call sites changed

| File | Line | Context |
|---|---|---|
| `agentmain.py` | 27 | `global_mem.txt` seed write (first-run init) |
| `agentmain.py` | 31 | `global_mem_insight.txt` template copy (first-run init) |
| `agentmain.py` | 36 | `tmwd_cdp_bridge/config.js` (first-run init) |
| `agentmain.py` | 276 | reflect log append (per-task) |
| `ga.py` | 401 | `file_write` tool, prepend mode (per-call, rewrites entire file) |
| `frontends/wechatapp.py` | 266 | WeChat media download write (per-message) |

## Behavior

Unchanged. Each call site preserves the same read/write ordering, the same encoding, and the same conditional semantics (e.g. the template copy still only reads the source file if `os.path.exists(t)` returns True).

## Verification

- `python3 -m py_compile agentmain.py ga.py frontends/wechatapp.py` — passes
- `python3 -c "import ast; ast.parse(open('agentmain.py').read())"` (and same for ga.py, wechatapp.py) — passes
- `ruff check` — no new findings introduced by this change; pre-existing project-style warnings (E701, F541 etc.) are untouched
- Project has no test suite (`tests/` is empty), so runtime behavior was checked by AST + manual review only
- `git diff` reviewed for read-then-write ordering preservation
