### PR TITLE
fix(tui-v2): copy via native clipboard, OSC 52 only over SSH

### DIFF
--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -3025,17 +3025,10 @@ class GenericAgentTUI(App[None]):
         self._refresh_all()
 
     def copy_to_clipboard(self, text: str) -> None:
-        """Override Textual's OSC 52 clipboard (broken on macOS Terminal.app).
-        Use pbcopy on macOS, fall back to OSC 52 on other platforms."""
-        import sys, subprocess as _sp
-        if sys.platform == "darwin":
-            try:
-                _sp.Popen(["pbcopy"], stdin=_sp.PIPE, stdout=_sp.DEVNULL, stderr=_sp.DEVNULL).communicate(text.encode("utf-8"))
-                self._clipboard = text
-                return
-            except Exception:
-                pass
-        # Non-macOS or pbcopy failed: fall back to Textual default (OSC 52)
+        self._clipboard = text
+        _ssh = os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_TTY")
+        if not _ssh and _copy_to_clipboard(text):
+            return
         super().copy_to_clipboard(text)
 
     def action_handle_ctrl_c(self) -> None:


### PR DESCRIPTION
## 问题
tui_v2 在 Windows/Linux 上的 Ctrl+C / 选区复制会走 Textual 的 OSC 52 转义序列，把内容“喊”给终端去写系统剪贴板。这带来两个**终端相关**的故障：

1. **VSCode 集成终端：中文复制后变乱码。** VSCode 把 OSC 52 的 base64 载荷按 latin-1（而非 UTF-8）解码再写剪贴板，非 ASCII 文本全部 mojibake。例：复制「需要」→ 粘出来是「éè¦」。Windows Terminal 按 UTF-8 解码，所以一直正常。
2. **Windows Server / 经典 conhost：复制完全不生效。** conhost 根本没实现 OSC 52 剪贴板写入，序列被静默丢弃，复制等于没执行。

## 原因
`copy_to_clipboard` 此前只对 macOS 用原生 pbcopy，其余平台一律 fallback 到 OSC 52，把“写剪贴板”的正确性押在了终端对 OSC 52 的字符集处理与支持程度上。

## 修复
改为**原生剪贴板优先**：复用仓库已有的 `_copy_to_clipboard()`（win32 `CF_UNICODETEXT` / pbcopy / wl-copy / xclip），直接写系统剪贴板、绕开终端，从根上消除 OSC 52 的字符集与支持问题。OSC 52 仅作兜底，并**在 SSH 会话下强制使用**（`SSH_CONNECTION` / `SSH_TTY`）——因为 SSH 下原生调用写的是远端主机的剪贴板，只有 OSC 52 能顺着终端流回到用户的本地剪贴板。

```python
def copy_to_clipboard(self, text: str) -> None:
    self._clipboard = text
    _ssh = os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_TTY")
    if not _ssh and _copy_to_clipboard(text):
        return
    super().copy_to_clipboard(text)
```

## 行为矩阵
| 场景 | 通道 | 结果 |
|---|---|---|
| 本地控制台 / RDP | 原生 win32 | 写真·系统剪贴板 ✅ |
| VSCode 本地终端 | 原生 | 不再 latin-1 mojibake ✅ |
| SSH 远程 | OSC 52 | 序列回本地终端写本地剪贴板 ✅（需本地终端支持 OSC 52） |

非 SSH 分支保持“原生优先 + OSC 52 兜底”，对既有 RDP/本地/Windows Terminal 场景无回归。

## 测试建议
- VSCode 本地终端：复制中文 → 粘贴不再乱码。
- Windows Terminal / RDP / 本地控制台：复制粘贴正常。
- SSH 远程：复制能回到本地剪贴板（前提是本地终端支持 OSC 52）。
