### PR TITLE
fix(tui-v3): expand pasted placeholders before slash-command dispatch

### DIFF
--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -3997,12 +3997,20 @@ class SB:
             self._run_shell(raw[1:].strip())
             return
         if raw.startswith('/'):
+            # Expand pasted/file/image placeholders BEFORE dispatch so a command
+            # carries the real pasted text, not a `[Pasted text #N]` marker — e.g.
+            # `/morphling <pasted multi-line target>`. Without this the command
+            # path returned here before the expansion below ever ran, so the agent
+            # got the literal placeholder. `self.hist` already kept the raw input.
+            expanded = self._expand(raw)
             # /btw owns its own live-region panel — keep the command itself
             # out of the main scrollback.
-            cmd0 = (raw[1:].split(None, 1)[0] or '').lower()
+            cmd0 = (expanded[1:].split(None, 1)[0] or '').lower()
             if cmd0 != 'btw':
-                self._commit_user(raw)
-            self._cmd(raw); return
+                self._commit_user(expanded)
+            self._cmd(expanded)
+            self._pstore.clear(); self._fstore.clear(); self._imgs.clear()
+            return
         # Expand placeholders FIRST so the agent receives the resolved text,
         # not the [Image #N] / [Pasted #N] markers.  This matches the idle
         # submit path below — keeping the form identical means a queued


### PR DESCRIPTION
## Problem

In tui-v3, `_on_enter`'s slash-command branch `return`ed before the `_expand()` call further down ever ran. So a command argument kept the literal `[Pasted text #N]` / `[File #N]` / `[Image #N]` placeholder instead of the real content.

Concretely, pasting a multi-line block after a command — e.g. `/morphling <pasted target>` — reached the agent as the marker string `[Pasted text #1 +N lines]`, not the pasted text. Plain (non-command) input was unaffected because it fell through to `_expand()`.

## Fix

Expand placeholders at the top of the command branch (mirroring the normal submit path), then clear the placeholder stores. No-op for commands without placeholders; `self.hist` still keeps the unexpanded raw input so ↑ history recall is unchanged.

## Test

Verified `_expand('/morphling [Pasted text #1 +4 lines]')` resolves to the real multi-line content, and `_cmd`'s `split(None, 1)` passes the full multi-line argument through intact.