### PR TITLE
fix(vision): respect versioned api bases in openai-compat url join

### DIFF
--- a/memory/vision_api.template.py
+++ b/memory/vision_api.template.py
@@ -1,4 +1,4 @@
-import base64, requests, sys, os
+import base64, re, requests, sys, os
 from io import BytesIO
 from pathlib import Path
 
@@ -96,7 +96,7 @@ def _call_claude(b64, prompt, timeout, max_tokens=1024):
 def _call_openai_compat(b64, prompt, timeout, *, apibase, apikey, model, proxy=None):
     proxies = {'https': proxy, 'http': proxy} if proxy else None
     resp = requests.post(
-        apibase.rstrip('/') + '/v1/chat/completions',
+        apibase.rstrip('/') + ('/chat/completions' if re.search(r'/v\d+$', apibase.rstrip('/')) else '/v1/chat/completions'),
         json={'model': model, 'messages': [{
             'role': 'user',
             'content': [


### PR DESCRIPTION
**现象**:vision_api 模板的 openai 兼容路径写死 `apibase + '/v1/chat/completions'`,火山 Ark Coding(`.../api/coding/v3`)这类自带版本号的端点全部 404。

**修法**:base 以 `/v<N>` 结尾时只拼 `/chat/completions`,其余行为不变(+2/−2,单文件)。

**实测**:腾讯云真机,火山 coding 端点此前 404,修后视觉调用正常。