### PR TITLE
fix(wechat): check the real terminal for QR login, not the log file

### DIFF
--- a/frontends/wechatapp.py
+++ b/frontends/wechatapp.py
@@ -415,7 +415,7 @@ if __name__ == '__main__':
     print(f'[NEW] Process starting {time.strftime("%m-%d %H:%M")}')
     bot = WxBotClient()
     if _do_relogin or not bot.token:
-        if not sys.stdout.isatty():
+        if not (sys.__stdout__ and sys.__stdout__.isatty()):
             print('[Bot] no token and not interactive, exit.'); sys.exit(1)
         sys.stdout = sys.stderr = sys.__stdout__  # restore for QR display
         bot.login_qr()


### PR DESCRIPTION
**现象**:终端里跑 `python frontends/wechatapp.py` 永远打出 `no token and not interactive` 退出,首次扫码绑定走不通。

**根因**:`__main__` 先把 `sys.stdout` 重定向到日志文件,之后才 `isatty()` —— 检查对象是日志文件,永远非 tty。

**修法**:改查 `sys.__stdout__`(真实终端),加 None 防护(pythonw 场景)。+1/−1。

**实测**:无头 Ubuntu 服务器,此前必须单写脚本调 `WxBotClient().login_qr()` 才能绑定,修后主入口直接可扫码。