### PR TITLE
fix: os.startfile is Windows-only, use webbrowser.open to wake the browser

### DIFF
--- a/ga.py
+++ b/ga.py
@@ -1,4 +1,4 @@
-import sys, os, re, json, time, threading, importlib
+import sys, os, re, json, time, threading, importlib, webbrowser
 from datetime import datetime
 from pathlib import Path
 import tempfile, traceback, subprocess, itertools, collections, difflib, shutil
@@ -112,7 +112,7 @@ def first_init_driver():
         time.sleep(2)
         sess = driver.get_all_sessions()
         if len(sess) > 0: break
-        if i == 4: os.startfile("https://example.com")
+        if i == 4: webbrowser.open("https://example.com")
 
 def web_scan(tabs_only=False, switch_tab_id=None, text_only=False, maxlen=35000):
     """获取当前页面的简化HTML内容和标签页列表。注意：简化过程会过滤边栏、浮动元素等非主体内容。


### PR DESCRIPTION
**现象**:Linux/macOS 上 web driver 初始化重试期间抛 `AttributeError: module 'os' has no attribute 'startfile'`。

**根因**:唤醒浏览器用了 `os.startfile`,该 API 仅 Windows 存在。

**修法**:换 stdlib `webbrowser.open`,三平台同效。+2/−2。

**实测**:腾讯云 Ubuntu 真机复现并验证。