### PR TITLE
fix(tui-v2): 修复 CJK Markdown 表格复制错位

### DIFF
--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -1137,8 +1137,13 @@ def _md_line_has_box_drawing(line: str) -> bool:
     left after rstrip trims the trailing space of an empty command/output line).
     Exempt all of them so the cards keep their exact narrow\u2194wide line mapping
     instead of the visible-text passthrough (which would copy the card's
-    visual-only margin). A pure horizontal run (only `\u2500` + spaces) is a
-    separator / markdown hr, not a table \u2014 also exempt.
+    visual-only margin).
+
+    A pure horizontal run (only `─` + spaces) is NOT exempt: a SIMPLE-box
+    Markdown table's only box glyph is its header rule, so exempting bare
+    `─` rows drops the whole table out of passthrough and misaligns CJK
+    copy. The cosmetic cost is that a real markdown hr copies as a dash run
+    — the pre-card behavior, never reported as a problem.
     """
     s = line.lstrip()
     for pfx in ("\u2514\u2500 ", "\u2502 ", "\u2514 "):
@@ -1148,8 +1153,6 @@ def _md_line_has_box_drawing(line: str) -> bool:
     else:
         if s in ("\u2502", "\u2514"):  # gutter-only row (empty command/output line)
             s = ""
-    if not s.replace("\u2500", "").replace(" ", ""):
-        return False
     return any("\u2500" <= ch <= "\u257f" for ch in s)
 
 


### PR DESCRIPTION
## 问题
TUI v2 里复制含中文（宽字符）的 Markdown 表格时，剪贴板内容列错位。

## 根因
工具卡片那次改动（#593）收紧了 `_md_line_has_box_drawing`，新增一条「纯横线 `─` 视为 markdown hr，豁免」的规则。但 SIMPLE-box 渲染的 Markdown 表格**唯一的 box 字符就是表头那条 `─────` 横线**——被豁免后，整张表不再走 passthrough 复制路径，而掉进 wide-render 对齐逻辑。该逻辑用「选区屏幕列号」当「字符下标」映射，中文宽字符占 2 列 1 字符，于是复制错位。

## 修复
删掉这条纯横线豁免，表头横线重新被识别为 box-drawing → 表格恢复 passthrough。卡片的 `└─ `/`│ `/`└ ` gutter 仍由各自的前缀豁免处理，**工具卡片不受影响**。唯一代价：真正的 markdown hr 复制时会带上那行 `────`——即 #593 之前的行为，从未有人反馈过问题。

## 验证
- `_md_line_has_box_drawing`：表头横线/表格边框 → True；卡片 gutter（`└─`/`│`/`└`/gutter-only）→ False，全部符合预期。
- CJK 表格 run `_md_run_has_box_drawing == True`，恢复 passthrough。
- 语法 `ast.parse` 通过。