### PR TITLE
fix(wechat): sanitize media file_name to block path traversal in _dl_media

### DIFF
--- a/frontends/wechatapp.py
+++ b/frontends/wechatapp.py
@@ -284,7 +284,7 @@ def _dl_media(items):
                            if sub.get('media', {}).get('aes_key') else bytes.fromhex(ak))
                 ct = requests.get(f'{CDN_BASE}/download?encrypted_query_param={quote(eq)}', headers={'User-Agent': UA}, timeout=60).content
                 pt = AES.new(aes_key, AES.MODE_ECB).decrypt(ct); pt = pt[:-pt[-1]]
-                fname = sub.get('file_name') or f'{uuid.uuid4().hex[:8]}{ext or ".bin"}'
+                fname = os.path.basename(sub.get('file_name') or '') or f'{uuid.uuid4().hex[:8]}{ext or ".bin"}'
                 p = os.path.join(_TEMP_DIR, fname); open(p, 'wb').write(pt)
                 paths.append(p); print(f'[WX] media saved: {fname}', file=sys.__stdout__)
             except Exception as e:


### PR DESCRIPTION
## 现象

`frontends/wechatapp.py` 的 `_dl_media` 把入站消息里的 `file_name` 直接用来落盘解密后的媒体内容。`file_name` 来自对方消息，攻击者可控。

## 根因

```python
fname = sub.get('file_name') or f'{uuid...}{ext}'
p = os.path.join(_TEMP_DIR, fname); open(p, 'wb').write(pt)
```

`os.path.join(base, '../../x')`（或绝对路径）会逃出 `_TEMP_DIR`。任何能给 bot 发消息的人，就能把自己控制的内容写到宿主机任意路径——比如丢进自启动目录。这是一个**远程可达的任意写**原语。

## 修法

落盘前把入站名收敛成 basename。正常文件名没有目录部分，basename 是恒等，合法行为完全不变；只有 `../` / 绝对路径被中和。空名仍走原来的 uuid 兜底。

```diff
-                fname = sub.get('file_name') or f'{uuid.uuid4().hex[:8]}{ext or ".bin"}'
+                fname = os.path.basename(sub.get('file_name') or '') or f'{uuid.uuid4().hex[:8]}{ext or ".bin"}'
```

## 实测

- `python3 -m py_compile frontends/wechatapp.py` 通过
- 行为快测：`../../../../etc/cron.d/evil` → `evil`、`/root/.bashrc` → `.bashrc`、`photo.jpg` → `photo.jpg`（恒等）、空名 → uuid 兜底

单文件单行改动，行为对合法文件名不变。
