### PR TITLE
fix(tui-v3): /continue 恢复后镜像源日志，避免续聊丢失旧历史

### DIFF
--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -4483,7 +4483,16 @@ class SB:
                 self.commit([_DIM + _t('msg.no_history') + _RST]); return
 
             def _do_restore(path: str) -> None:
+                continue_cmd.reset_conversation(ag, message=None)  # 快照+清空当前进程日志
                 msg, _ = continue_cmd.restore(ag, path)
+                # 镜像源日志进当前进程日志，否则续聊只 append 增量，下次 /continue 丢旧历史。
+                # 对齐 v2 _do_continue_restore（tuiapp_v2.py:5285）。
+                current_log = getattr(ag, 'log_path', '') or ''
+                if current_log and path != current_log:
+                    try:
+                        shutil.copyfile(path, current_log)
+                    except Exception:
+                        pass
                 self.commit([_DIM + '┄┄ ' + _t('msg.continue_loading', name=os.path.basename(path)) + ' ┄┄' + _RST])
                 for mm in continue_cmd.extract_ui_messages(path):
                     c = (mm.get('content') or '').strip()


### PR DESCRIPTION
## 问题
v3 从 `/continue` 恢复会话续聊后，**退出再恢复时只剩续聊部分，被恢复的旧历史丢失**。

## 根因
- 每个进程的会话日志 `temp/model_responses/model_responses_{pid}.txt` 由 native 后端**逐轮增量 append**（`llmcore.py` 每轮只写当轮新增的单条消息）。
- `continue_cmd.restore()` 只把选中会话解析后**替换内存 `backend.history`**，不碰当前进程日志。
- 于是恢复出的旧历史从未写入当前进程日志；续聊只把增量 append 进去。下次 `/continue` 扫到本进程文件时只有续聊部分 → 旧历史“丢失”。

## 修复
对齐 v2 的 `_do_continue_restore`（`tuiapp_v2.py`），在 v3 的 `_do_restore` 补两步：
1. 恢复前 `reset_conversation`：快照+清空当前进程日志（保护本进程 `/continue` 之前的对话，可日后再恢复）；
2. 恢复后 `shutil.copyfile(源日志 → 当前进程日志)`：让续聊接在完整历史之后，`…_{pid}.txt = 旧历史 + 续聊`。

## 影响 / 验证
- 仅改 v3 的 `_do_restore`（+9 行）；不影响 scrollback 显示（只动后端状态），`/continue` 本就是 idle-only、`abort` 无副作用。
- `py_compile` 通过；逻辑与 v2 同构。端到端（恢复→续聊→重启→再恢复）建议在 v3 实测确认。
- 注：此前已被写坏的旧日志（只剩续聊部分）无法找回，修复仅对之后的恢复生效。