### PR TITLE
feat(continue): 将 /continue 默认改为原地恢复,并引入会话锁与占用确认

### DIFF
--- a/frontends/continue_cmd.py
+++ b/frontends/continue_cmd.py
@@ -1,7 +1,7 @@
 """`/continue` command: list & restore past model_responses sessions.
 Pure functions + one `install(cls)` monkey-patch entry. No side effects at import.
 """
-import ast, glob, json, os, re, time
+import ast, atexit, glob, json, os, random, re, shutil, threading, time
 _LOG_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
                         'temp', 'model_responses')
 _LOG_GLOB = os.path.join(_LOG_DIR, 'model_responses_*.txt')
@@ -294,12 +294,19 @@ def _rounds_for_file(path, st):
     return n, key
 
 
-def list_sessions(exclude_pid=None):
-    """Newest-first list of (path, mtime, preview_text, n_rounds). Preview uses head/tail window only."""
+def list_sessions(exclude_pid=None, exclude_log=None):
+    """Newest-first list of (path, mtime, preview_text, n_rounds). Preview uses head/tail window only.
+
+    `exclude_log` (basename, e.g. 'model_responses_123456.txt') drops the caller's
+    OWN current session — preferred over `exclude_pid`, which assumed the log file
+    was named by PID (it isn't: agentmain mints a random 6-digit logid), so the
+    pid tag never matched and the current session leaked into its own list."""
     files = glob.glob(_LOG_GLOB)
     if exclude_pid is not None:
         tag = f'model_responses_{exclude_pid}.txt'
         files = [f for f in files if not f.endswith(tag)]
+    if exclude_log:
+        files = [f for f in files if os.path.basename(f) != exclude_log]
     out = []
     valid_keys = []
     for f in files:
@@ -773,6 +780,269 @@ def handle_frontend_command(agent, query, exclude_pid=None):
     reset_conversation(agent, message=None)
     msg, _ = restore(agent, sessions[idx][0])
     return msg
+
+
+# ===========================================================================
+# 原地复原(in-place continue)共享层 —— 仅供 TUI(tui_v2/tui_v3 及其 rewind 副本)
+# 调用;其它前端(IM/qt/streamlit…)不调用这些函数,行为完全不受影响。
+#
+# 模型:每个会话 = 一个 `model_responses_<logid>.txt`,身份就是文件本身。
+#   · 原地续 X = 把 agent 的 log_path 指回 X,之后的轮次追加到 X 本身(同一会话延续)。
+#   · 拷贝续 X = 铸一个新 logid、把 X 拷进去,在副本上续;X 原件不动(并发安全)。
+#   · 切走/新对话 = 释放当前锁、旧日志原样留作"空闲会话"(不存快照、不清空),新对话铸新 logid。
+#
+# 独占:每个 TUI 会话出生即持有自己日志的一把锁(`.locks/<logid>.lock`);
+#   整进程共用一个心跳线程,每 ~5s touch 锁文件 mtime(无 fsync)。
+#   判活 = 锁 mtime 在 30s 内新鲜;超 30s 视为持锁者已死,可被接管。
+#   抢锁用原子 O_EXCL;锁基础设施任何故障都降级为"假定空闲、放行续接",绝不阻断 /continue。
+# ===========================================================================
+
+_LOCK_DIR = os.path.join(_LOG_DIR, '.locks')
+_HB_INTERVAL = 5.0       # 心跳间隔(秒)
+_STALE_AFTER = 30.0      # 超过这么久无心跳 → 持锁者视为已死,可接管
+_held_locks = set()      # 本进程当前持有的 log_path 集合
+_hb_lock = threading.Lock()
+_hb_thread = None
+
+
+def _lock_path(log_path):
+    base = os.path.splitext(os.path.basename(log_path))[0]
+    return os.path.join(_LOCK_DIR, base + '.lock')
+
+
+def _read_lock(lock_file):
+    try:
+        with open(lock_file, encoding='utf-8') as fh:
+            return json.load(fh)
+    except Exception:
+        return None
+
+
+def _lock_fresh(lock_file):
+    """心跳新鲜度 = 锁文件 mtime 距今 < _STALE_AFTER。"""
+    try:
+        return (time.time() - os.path.getmtime(lock_file)) < _STALE_AFTER
+    except OSError:
+        return False
+
+
+def session_occupant(log_path):
+    """若 `log_path` 正被一个活着的(心跳新鲜)进程持有,返回其 owner 元数据 dict;
+    否则返回 None(空闲,或锁已过期可接管)。供 TUI 判断"原地 / 弹窗拷贝"。"""
+    lf = _lock_path(log_path)
+    meta = _read_lock(lf)
+    if meta is not None and _lock_fresh(lf):
+        return meta
+    return None
+
+
+def acquire_lock(log_path, agent_id=None):
+    """尝试独占 `log_path`。成功(或锁设施故障降级)返回 True;
+    仅当被另一活进程(心跳新鲜)持有时返回 False。"""
+    try:
+        os.makedirs(_LOCK_DIR, exist_ok=True)
+        lf = _lock_path(log_path)
+        meta = {'pid': os.getpid(), 'agent_id': agent_id,
+                'log': os.path.basename(log_path),
+                'started': time.time()}
+        blob = json.dumps(meta, ensure_ascii=False)
+        try:
+            fd = os.open(lf, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            with os.fdopen(fd, 'w', encoding='utf-8') as fh:
+                fh.write(blob)
+        except FileExistsError:
+            cur = _read_lock(lf)
+            if cur and cur.get('pid') != os.getpid() and _lock_fresh(lf):
+                return False                      # 被另一活进程持有
+            # 过期锁 / 本进程自己的 → 接管(覆盖)。小竞态窗口可接受。
+            try: os.remove(lf)
+            except OSError: pass
+            try:
+                fd = os.open(lf, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+                with os.fdopen(fd, 'w', encoding='utf-8') as fh:
+                    fh.write(blob)
+            except FileExistsError:
+                cur2 = _read_lock(lf)
+                if cur2 and cur2.get('pid') != os.getpid() and _lock_fresh(lf):
+                    return False                  # 抢锁竞态输了
+                with open(lf, 'w', encoding='utf-8') as fh:
+                    fh.write(blob)
+        with _hb_lock:
+            _held_locks.add(log_path)
+        _ensure_hb_thread()
+        return True
+    except Exception:
+        # 锁设施故障绝不阻断续接 —— 降级为"假定空闲、放行"。
+        return True
+
+
+def release_lock(log_path):
+    """释放本进程对 `log_path` 的锁(只删自己持有/无主的锁文件)。"""
+    with _hb_lock:
+        _held_locks.discard(log_path)
+    try:
+        lf = _lock_path(log_path)
+        cur = _read_lock(lf)
+        if cur is None or cur.get('pid') == os.getpid():
+            os.remove(lf)
+    except Exception:
+        pass
+
+
+def _hb_tick():
+    now = time.time()
+    with _hb_lock:
+        items = list(_held_locks)
+    for lp in items:
+        try:
+            os.utime(_lock_path(lp), (now, now))   # 仅更新 mtime,无 fsync
+        except OSError:
+            pass
+
+
+def _hb_loop():
+    while True:
+        time.sleep(_HB_INTERVAL)
+        try:
+            _hb_tick()
+        except Exception:
+            pass
+
+
+def _ensure_hb_thread():
+    global _hb_thread
+    with _hb_lock:
+        if _hb_thread is None:
+            _hb_thread = threading.Thread(target=_hb_loop,
+                                          name='ga-session-heartbeat', daemon=True)
+            _hb_thread.start()
+
+
+@atexit.register
+def _release_all_locks():
+    for lp in list(_held_locks):
+        release_lock(lp)
+
+
+def _new_log_path():
+    """铸一个新的 6 位 logid 日志路径(与 agentmain 同公式)。"""
+    logid = f'{(time.time_ns() + random.randrange(1_000_000)) % 1_000_000:06d}'
+    return os.path.join(_LOG_DIR, f'model_responses_{logid}.txt')
+
+
+def _retarget_log(agent, new_path):
+    """把 agent(及其所有 llmclient)的日志写入点切到 new_path —— 之后的轮次写这里。"""
+    try:
+        agent.log_path = new_path
+    except Exception:
+        pass
+    for client in _agent_clients(agent):
+        try: client.log_path = new_path
+        except Exception: pass
+
+
+def is_snapshot(path):
+    """遗留快照存档(model_responses_snapshot_*.txt)。这类只能拷贝续,不参与原地
+    (provisional,待 worktree 复审)。"""
+    return os.path.basename(path).startswith('model_responses_snapshot_')
+
+
+def _clear_conversation_state(agent):
+    """清空对话状态(对齐 reset_conversation,但不碰日志文件)。"""
+    if hasattr(agent, 'history'):
+        agent.history = []
+    for client in _agent_clients(agent):
+        backend = getattr(client, 'backend', None)
+        if backend is not None and hasattr(backend, 'history'):
+            backend.history = []
+        if hasattr(client, 'last_tools'):
+            client.last_tools = ''
+    if hasattr(agent, 'handler'):
+        agent.handler = None
+
+
+def acquire_birth_lock(agent, agent_id=None):
+    """会话出生时持有自己当前日志的锁(新 logid 必然抢到)。TUI 在建会话时调用,
+    使本会话对"占用检测"可见 —— 别的会话才能据此判定它是否还活着。"""
+    lp = getattr(agent, 'log_path', '') or ''
+    if lp:
+        acquire_lock(lp, agent_id)
+
+
+def release_current(agent):
+    """切走:释放 agent 当前日志的锁,旧日志原样留作"空闲会话"(不存快照、不清空)。"""
+    lp = getattr(agent, 'log_path', '') or ''
+    if lp:
+        release_lock(lp)
+
+
+def begin_fresh_session(agent, agent_id=None):
+    """新对话 / clear:释放当前锁(旧日志留作空闲会话)→ 铸新 logid 重指 → 持新锁 →
+    清空对话状态。**替代 TUI 里的 reset_conversation**(不再存快照/清空旧日志)。"""
+    try: agent.abort()
+    except Exception: pass
+    release_current(agent)
+    newp = _new_log_path()
+    _retarget_log(agent, newp)
+    acquire_lock(newp, agent_id)
+    _clear_conversation_state(agent)
+
+
+def _load_history_into(agent, path):
+    """把 `path` 解析进 backend.history(native;否则降级摘要)。镜像 restore() 的解析,
+    但不 abort/不快照(日志重指由调用方先做好)。返回 (msg, is_full)。"""
+    try:
+        with open(path, encoding='utf-8', errors='replace') as fh:
+            content = fh.read()
+    except Exception as e:
+        return f'❌ 读取失败: {e}', False
+    pairs = _pairs(content)
+    if not pairs:
+        return f'❌ {os.path.basename(path)} 为空或格式不符', False
+    history = _parse_native_history(pairs)
+    name = os.path.basename(path)
+    if history is not None:
+        _replace_backend_history(agent, history)
+        return f'✅ 已恢复 {len(pairs)} 轮完整对话（{name}）', True
+    from chatapp_common import _restore_native_history, _restore_text_pairs
+    summary = _restore_text_pairs(content) or _restore_native_history(content)
+    if not summary:
+        return f'❌ {name} 无法解析（非 native 且无摘要可提取）', False
+    if hasattr(agent, 'history'):
+        agent.history.extend(summary)
+    n = sum(1 for l in summary if l.startswith('[USER]: '))
+    return f'⚠️ 非 native 格式，降级恢复 {n} 轮摘要（{name}）', False
+
+
+def continue_inplace(agent, path, agent_id=None):
+    """原地续:把 agent 的日志指回 `path` 本身,之后轮次追加到 X,延续同一会话。
+    调用方应已确认空闲(session_occupant 为 None);抢锁失败(被占)返回错误。
+    返回 (msg, ok)。"""
+    try: agent.abort()
+    except Exception: pass
+    if not acquire_lock(path, agent_id):       # 先抢到目标锁;失败则保持现状,不丢自己的锁
+        return '❌ 会话已被占用，无法原地接管', False
+    cur = getattr(agent, 'log_path', '') or ''
+    if cur and os.path.basename(cur) != os.path.basename(path):
+        release_lock(cur)                       # 目标到手,旧会话释放为空闲(同一文件则不放)
+    _retarget_log(agent, path)
+    return _load_history_into(agent, path)
+
+
+def continue_copy(agent, path, agent_id=None):
+    """拷贝续:铸新 logid、把 `path` 内容拷进去,在副本上续;`path` 原件不动。
+    用于"被占用→用户选拷贝"以及快照源。返回 (msg, ok)。"""
+    try: agent.abort()
+    except Exception: pass
+    release_current(agent)
+    newp = _new_log_path()
+    try:
+        shutil.copyfile(path, newp)
+    except Exception:
+        pass
+    acquire_lock(newp, agent_id)
+    _retarget_log(agent, newp)
+    return _load_history_into(agent, newp)
 
 
 def install(cls):

--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -309,6 +309,9 @@ _I18N: dict[str, dict[str, str]] = {
 
         # continue picker
         'continue.title':       'Restore historical session',
+        'continue.occupied.title':  'Session in use (pid {p}) — copy it and continue?',
+        'continue.occupied.copy':   'Copy & continue',
+        'continue.occupied.cancel': 'Cancel',
         # /workspace (parity with v2; backed by workspace_cmd.py)
         'cmd.workspace.arg':    '[path|off]',
         'cmd.workspace.desc':   'set working dir (abs path) and enter project mode',
@@ -573,6 +576,9 @@ _I18N: dict[str, dict[str, str]] = {
 
         # continue picker
         'continue.title':       '恢复历史会话',
+        'continue.occupied.title':  '该会话正被占用（pid {p}）—— 从原会话拷贝一份继续？',
+        'continue.occupied.copy':   '拷贝一份继续',
+        'continue.occupied.cancel': '取消',
         # /workspace（与 v2 一致；后端 workspace_cmd.py）
         'cmd.workspace.arg':    '[path|off]',
         'cmd.workspace.desc':   '设定工作目录(绝对路径)并进入项目模式',
@@ -1396,6 +1402,12 @@ class AgentBridge:
         if not getattr(self.agent, 'llmclient', None):
             self._healthy = False
             self._init_error = _t('err.no_llm')
+        # 原地复原:本会话出生即持有自己日志的锁,使占用检测对它可见(别的会话据此判活)。
+        try:
+            from frontends import continue_cmd as _cc
+            _cc.acquire_birth_lock(self.agent)
+        except Exception:
+            pass
         self._runner = threading.Thread(target=self._run_safe, daemon=True, name=f'ga-tui-agent')
         self._runner.start()
 
@@ -4311,7 +4323,7 @@ class SB:
         """Wipe the conversation: drop LLM history, clear the screen and every
         rendered block.  Shared by /clear and /new."""
         from frontends import continue_cmd
-        continue_cmd.reset_conversation(ag)
+        continue_cmd.begin_fresh_session(ag)   # 切走:旧日志留作空闲会话 + 铸新 logid(不存快照)
         _w('\x1b[2J\x1b[H'); self._painted = []; self._live_rows = 0
         self._blocks = []; self._streaming_block = None; self._sent = 0
         self._tool_base = 0; self._tools = {}
@@ -4478,23 +4490,15 @@ class SB:
         #     self.commit([_t('err.multi_session', name=name)])
         elif name == 'continue':
             from frontends import continue_cmd
-            sess = continue_cmd.list_sessions(exclude_pid=os.getpid())
+            sess = continue_cmd.list_sessions(exclude_log=os.path.basename(getattr(ag, "log_path", "") or ""))
             if not sess:
                 self.commit([_DIM + _t('msg.no_history') + _RST]); return
 
-            def _do_restore(path: str) -> None:
-                continue_cmd.reset_conversation(ag, message=None)  # 快照+清空当前进程日志
-                msg, _ = continue_cmd.restore(ag, path)
-                # 镜像源日志进当前进程日志，否则续聊只 append 增量，下次 /continue 丢旧历史。
-                # 对齐 v2 _do_continue_restore（tuiapp_v2.py:5285）。
-                current_log = getattr(ag, 'log_path', '') or ''
-                if current_log and path != current_log:
-                    try:
-                        shutil.copyfile(path, current_log)
-                    except Exception:
-                        pass
+            def _rc_finish(path: str, msg: str) -> None:
+                # restore 后:重放对话到 scrollback + 恢复 workspace。读 ag.log_path
+                # (原地=源文件本身;拷贝=内容相同的新副本),内容一致。
                 self.commit([_DIM + '┄┄ ' + _t('msg.continue_loading', name=os.path.basename(path)) + ' ┄┄' + _RST])
-                for mm in continue_cmd.extract_ui_messages(path):
+                for mm in continue_cmd.extract_ui_messages(getattr(ag, 'log_path', '') or path):
                     c = (mm.get('content') or '').strip()
                     if not c:
                         continue
@@ -4521,6 +4525,26 @@ class SB:
                                          default='已恢复工作目录: {t}').format(t=r['target']) + _RST])
                 except Exception:
                     pass
+
+            def _do_restore(path: str) -> None:
+                # 默认原地续。快照只能拷贝续;若被活进程占用 → 弹窗问是否拷贝一份。
+                if continue_cmd.is_snapshot(path):
+                    msg, _ = continue_cmd.continue_copy(ag, path)
+                    _rc_finish(path, msg); return
+                occ = continue_cmd.session_occupant(path)
+                if occ is not None:
+                    def _pick(i):
+                        if i == 0:
+                            msg, _ = continue_cmd.continue_copy(ag, path)
+                            _rc_finish(path, msg)
+                    self._show_menu(
+                        _t('continue.occupied.title', p=occ.get('pid', '?')),
+                        [_t('continue.occupied.copy'),
+                         _t('continue.occupied.cancel')],
+                        _pick)
+                    return
+                msg, _ = continue_cmd.continue_inplace(ag, path)
+                _rc_finish(path, msg)
 
             if arg:
                 # Direct numeric argument still supported for power users / scripts.

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -3787,6 +3787,11 @@ class GenericAgentTUI(App[None]):
         except Exception:
             pass
         sess = AgentSession(agent_id=agent_id, name=name or f"agent-{agent_id}", agent=agent)
+        try:
+            from continue_cmd import acquire_birth_lock
+            acquire_birth_lock(agent, agent_id)   # 原地复原:出生持锁,使占用检测对本会话可见
+        except Exception:
+            pass
         thread = threading.Thread(target=agent.run, name=f"ga-tui-agent-{agent_id}", daemon=True)
         thread.start()
         sess.thread = thread
@@ -5218,7 +5223,7 @@ class GenericAgentTUI(App[None]):
         if m:
             token = m.group(1)
             if token.isdigit():
-                sessions = continue_list(exclude_pid=os.getpid())
+                sessions = continue_list(exclude_log=os.path.basename(getattr(sess.agent, "log_path", "") or ""))
                 idx = int(token) - 1
                 if not (0 <= idx < len(sessions)):
                     self._system(f"❌ 索引越界（有效范围 1-{len(sessions)}）"); return
@@ -5237,7 +5242,7 @@ class GenericAgentTUI(App[None]):
                 self._system(f"❌ 找不到名为 {token!r} 的会话"); return
             self._do_continue_restore(path)
             return
-        sessions = continue_list(exclude_pid=os.getpid())
+        sessions = continue_list(exclude_log=os.path.basename(getattr(sess.agent, "log_path", "") or ""))
         if not sessions:
             self._system("❌ 没有可恢复的历史会话"); return
         choices = []
@@ -5272,25 +5277,38 @@ class GenericAgentTUI(App[None]):
         self._refresh_messages()
 
     def _do_continue_restore(self, path: str) -> str:
+        # 默认原地续(接管原日志,延续同一会话)。快照只能拷贝续;被活进程占用 →
+        # 弹窗问是否从原会话拷贝一份继续(复用内联 choice)。
+        import continue_cmd as _cc
         sess = self.current
-        from continue_cmd import reset_conversation, restore
+        if not _cc.is_snapshot(path):
+            occ = _cc.session_occupant(path)
+            if occ is not None:
+                head = f"该会话正被占用（pid {occ.get('pid', '?')}）—— 是否从原会话拷贝一份继续？"
+                msg = ChatMessage(
+                    role="system", content=head, kind="choice",
+                    choices=[("拷贝一份继续", path), ("取消", None)],
+                    on_select=lambda v: (self._continue_restore_apply(v, copy=True) if v else None),
+                )
+                sess.messages.append(msg); self._refresh_messages()
+                return head
+        return self._continue_restore_apply(path, copy=_cc.is_snapshot(path))
+
+    def _continue_restore_apply(self, path: str, copy: bool) -> str:
+        sess = self.current
+        import continue_cmd as _cc
         try:
-            reset_conversation(sess.agent, message=None)
-            result, ok = restore(sess.agent, path)
+            if copy:
+                result, ok = _cc.continue_copy(sess.agent, path, sess.agent_id)
+            else:
+                result, ok = _cc.continue_inplace(sess.agent, path, sess.agent_id)
         except Exception as e:
             msg = f"❌ 恢复失败: {e}"
             self._system(msg); return msg
         if not ok:
             self._system(result); return result
-        # Mirror the source transcript into this agent's own log file so a
-        # future /continue resolves the merged history under the migrated name.
-        current_log = getattr(sess.agent, "log_path", "") or ""
-        if current_log and path != current_log:
-            try:
-                import shutil
-                shutil.copyfile(path, current_log)
-            except Exception:
-                pass
+        # 原地:new_log == path(接管原文件);拷贝:new_log 是内容相同的新副本。
+        new_log = getattr(sess.agent, "log_path", "") or ""
         def _finish():
             sess.messages.clear()
             # Plan state belongs to the *previous* conversation. Clearing it
@@ -5339,8 +5357,8 @@ class GenericAgentTUI(App[None]):
                 nm = session_names.name_for(path)
                 if nm:
                     sess.name = nm
-                    if current_log:
-                        session_names.migrate(path, current_log)
+                    if new_log and new_log != path:   # 仅拷贝续才迁移名字到新副本;原地无需迁移
+                        session_names.migrate(path, new_log)
             except Exception:
                 pass
             # Auto-restore workspace: if the continued session worked in a


### PR DESCRIPTION
## 背景与动机

现有 `/continue N` 采用镜像复制策略(见 #612):恢复历史会话时,将源会话日志复制进当前进程日志,后续轮次写入该副本。此策略保证多个会话可并发恢复同一来源而互不冲突,但每次恢复都会派生一份新的会话副本,导致 `temp/model_responses/` 下的日志文件持续增殖。

本 PR 将 `/continue N` 的默认行为改为原地恢复(in-place restore):直接接管所选会话的日志文件,后续轮次写回该文件本身。如此在最常见的场景(恢复一个已结束的会话)下不再产生副本。

## 方案

恢复时按目标会话的占用状态分流:

- 目标空闲:直接原地接管,写回原文件。
- 目标正被活动进程占用:弹出确认对话框「会话被占用,是否从原会话拷贝一份继续?」,用户确认后再复制一份继续。

并发安全由每会话一把文件锁保证「同一时刻至多一个写者」。原镜像策略「多会话并发恢复同一来源」的能力予以保留,仅在目标确实被占用时需要一次确认。

## 实现

### 会话锁与存活判定
- 每个会话在创建时持有 `temp/model_responses/.locks/<logid>.lock`。
- 进程内共用单个心跳线程,每约 5 秒更新锁文件 mtime(不调用 fsync)。
- 存活判定基于 mtime 新鲜度:30 秒内有心跳视为存活,超过则视为持有者已退出,锁可被接管。
- 抢锁使用原子的 `O_EXCL` 创建。`atexit` 在正常退出时即时释放;进程被强制终止或崩溃时,由 30 秒超时兜底回收。
- 锁相关操作的任何故障均降级为「假定空闲、放行恢复」,不阻断 `/continue`。

### 移除快照机制
- 切换会话、新建对话、清空时,不再执行「快照 + 清空当前日志」。原 `_snapshot_current_log` 依据 PID 拼接文件名,而会话日志实际以随机 logid 命名,二者永不匹配,该函数从未实际生成过快照(遗留死代码)。
- 现在切换会话时,旧日志原样保留为一个空闲会话,新对话分配新的 logid。

### 修正 `list_sessions`
- 新增 `exclude_log` 参数,按文件名排除调用方自身的当前会话。原 `exclude_pid` 因相同的 PID 与 logid 不匹配问题而失效,导致当前会话出现在自己的恢复列表中。

## 影响范围与兼容性

- 改动仅涉及 `frontends/continue_cmd.py`、`frontends/tui_v3.py`、`frontends/tuiapp_v2.py` 三个文件。
- `continue_cmd.py` 中 `reset_conversation`、`restore`、`handle`、`handle_frontend_command` 等既有接口未作改动,新增逻辑均以新函数形式提供。dcapp、tgapp、stapp、qtapp 等其他前端行为不变。
- 已知限制:会话锁仅在上述两个 TUI 前端中持有。若以 TUI 原地恢复一个由非-TUI 前端持有的活动会话,将无法检测到占用。本 PR 暂不处理该情形。

## 测试

- 三个改动文件及相关模块均通过 `py_compile` 与导入检查。
- `continue_cmd` 的锁获取、存活判定、原地恢复、复制恢复、新建会话、过期接管、心跳刷新、抢锁竞态等场景均通过离线单元测试。
- 真实终端下的交互测试(占用确认对话框、原地接管完整流程、双进程争用同一会话、清空后分配新 logid)尚在进行中。
