### PR TITLE
fix(continue): preserve session workspace on in-place restore

### DIFF
--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -4329,9 +4329,14 @@ class SB:
         self._tool_base = 0; self._tools = {}
 
     # ── workspace（与 v2 共用 workspace_cmd；单会话 → 进程级一个绑定）─────────
-    def _bind_workspace(self, info) -> None:
+    def _bind_workspace(self, info, persist: bool = True) -> None:
         """绑定 / 解绑 workspace。info=prepare() 的结果 dict → 绑定；None → 解绑。
-        同步 agent 的 project_mode 属性（插件据此注入项目上下文），刷新 @ 索引根。"""
+        同步 agent 的 project_mode 属性（插件据此注入项目上下文），刷新 @ 索引根。
+
+        persist=False: 仅刷新内存绑定状态，不写 session→ws 映射表。续接时的
+        reset(_bind_workspace(None)) 用它——原地续后 agent.log_path==被续文件，
+        若持久化会把本会话映射抹成 ""(= 已 off)，反而毁掉自动恢复。映射表只应由
+        显式 /workspace、/workspace off 与成功的续接恢复来写。"""
         ag = self._bridge.agent if self._bridge else None
         if info:
             self._ws_name = info.get('name') or ''
@@ -4349,7 +4354,8 @@ class SB:
             except Exception:
                 pass
             # 持久化绑定/off → /continue 即时恢复，不必先聊一轮留 PROJECT MODE 块。
-            workspace_cmd.session_ws_set(getattr(ag, "log_path", "") or "", pm_path or "")
+            if persist:
+                workspace_cmd.session_ws_set(getattr(ag, "log_path", "") or "", pm_path or "")
         at_complete.get_index(self._at_root()).warm()   # 预热新根（或 CWD）
 
     def _do_workspace_activate(self, path: str) -> str:
@@ -4509,7 +4515,10 @@ class SB:
                 self.commit([_DIM + '┄┄ ' + _t('msg.continue_ready', msg=msg) + ' ┄┄' + _RST])
                 # 自动恢复 workspace：续接的会话若在某个已登记 workspace 里工作过，
                 # 重新绑定（必要时重建 junction），不触碰 project_mode 的进程锚。
-                self._bind_workspace(None)
+                # persist=False：reset 绑定绝不写 session→ws 映射表——原地续把
+                # agent.log_path 指回 path，若持久化会把本会话映射抹成 ""，在读回
+                # 之前就毁掉自动恢复。
+                self._bind_workspace(None, persist=False)
                 try:
                     rec = workspace_cmd.session_ws_get(path)   # 路径 / "" (off) / None(无记录)
                     if rec is not None:

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -3803,7 +3803,12 @@ class GenericAgentTUI(App[None]):
         self._refresh_all()
         return sess
 
-    def _bind_workspace(self, sess: AgentSession, info: Optional[dict]) -> None:
+    def _bind_workspace(self, sess: AgentSession, info: Optional[dict],
+                        persist: bool = True) -> None:
+        # persist=False: 仅刷新内存绑定状态，不写 session→ws 映射表。续接时的
+        # reset(_bind_workspace(sess, None)) 用它——原地续后 agent.log_path==被续
+        # 文件，若持久化会把本会话映射抹成 ""(= 已 off)，反而毁掉自动恢复。映射表
+        # 只应由显式 /workspace、/workspace off 与成功的续接恢复来写。
         if info:
             sess.workspace_name = info.get("name") or ""
             sess.workspace_path = info.get("target") or info.get("path") or ""
@@ -3822,7 +3827,8 @@ class GenericAgentTUI(App[None]):
         except Exception:
             pass
         # 持久化绑定/off → /continue 即时恢复，不必先聊一轮留 PROJECT MODE 块。
-        workspace_cmd.session_ws_set(getattr(sess.agent, "log_path", "") or "", project_path or "")
+        if persist:
+            workspace_cmd.session_ws_set(getattr(sess.agent, "log_path", "") or "", project_path or "")
         if project_path:
             get_index(project_path).warm()  # @ 候选跟随 workspace
 
@@ -5364,7 +5370,10 @@ class GenericAgentTUI(App[None]):
             # Auto-restore workspace: if the continued session worked in a
             # registered workspace, bind it to this session (recreating the
             # junction if needed) without touching the legacy process anchor.
-            self._bind_workspace(self.current, None)
+            # persist=False: the reset bind must NOT write the session→ws map —
+            # in-place continue points log_path at `path`, so persisting "" here
+            # would erase this session's own mapping before we read it back.
+            self._bind_workspace(self.current, None, persist=False)
             try:
                 rec = workspace_cmd.session_ws_get(path)   # 路径 / "" (off) / None(无记录)
                 if rec is not None:


### PR DESCRIPTION
## 问题

设置了 workspace 的会话，用 `/continue` 原地续接后，workspace 没有被自动恢复。

## 根因

原地续（in-place restore，#617）会把 `agent.log_path` 指回被续接的日志文件本身。但续接流程里有一句无条件的 reset 绑定 `_bind_workspace(None)`，它有个持久化副作用——`session_ws_set(log_path, "")`，会往 `session_workspaces.json` 写一条"该会话已 off"。

于是顺序变成：

1. 原地续 → `agent.log_path` == 被续文件
2. reset 绑定 → 写 `session_workspaces.json[<被续文件>] = ""`（**把会话自己的映射抹成"已关"**）
3. 紧接着读 `session_ws_get(<被续文件>)` → 读回 `""` → 判定"用户主动关了 workspace" → 不恢复，连"扫日志回退"那条后路也被这个 `""` 短路

拷贝续之前没暴露，是因为它铸新 logid，写的是新文件、读的是旧文件，二者不撞；原地续让二者成了同一个文件。

## 修复

给 `_bind_workspace` 加 `persist` 开关：续接时的 reset 传 `persist=False`，只刷新内存绑定状态、**不写映射表**。映射表今后只由显式 `/workspace`、`/workspace off` 与成功的续接恢复来写——从根上消除"自我毒化"。

改动覆盖 `tuiapp_v2.py` 与 `tui_v3.py`（本地 `*_rewind.py` 副本同步处理，未追踪故不在此 PR）。