### PR TITLE
fix(agent_loop): apply agent_before hook return value to context

### DIFF
--- a/agent_loop.py
+++ b/agent_loop.py
@@ -46,7 +46,15 @@ def agent_runner_loop(client, system_prompt, user_input, handler, tools_schema,
         {"role": "user", "content": initial_user_content if initial_user_content is not None else user_input}
     ]
     turn = 0;  handler.max_turns = max_turns
-    _hook('agent_before', locals())
+    _ctx = _hook('agent_before', locals())  # plugins may return dict to override system_prompt/user_input
+    if isinstance(_ctx, dict):
+        if 'system_prompt' in _ctx:
+            system_prompt = _ctx['system_prompt']
+            messages[0]['content'] = system_prompt
+        if _ctx.get('initial_user_content') is not None:
+            messages[1]['content'] = _ctx['initial_user_content']
+        elif 'user_input' in _ctx and initial_user_content is None:
+            messages[1]['content'] = _ctx['user_input']
     while turn < handler.max_turns:
         turn += 1; turnstr = f'LLM Running (Turn {turn}) ...'
         if handler.parent.task_dir: turnstr = f'Turn {turn} ...'


### PR DESCRIPTION
## Problem

`plugins/hooks.py::trigger()` already supports returning a dict to mutate the
agent context, but `agent_runner_loop()` in `agent_loop.py` discarded the
return value of `_hook('agent_before', ...)`. Plugins that wanted to modify
`system_prompt`, `user_input`, or `initial_user_content` had their changes
silently dropped.

This is the same class of issue called out in #537 — only the
`agent_before` hook is affected here; other hooks (`tool_before`,
`tool_after`, `turn_*`, `llm_*`, `agent_after`) are intentionally left
unchanged because they are observed but not expected to mutate the
in-flight state.

## Fix

Capture the return value of `_hook('agent_before', locals())`:

- When a dict is returned, apply `system_prompt` / `user_input` /
  `initial_user_content` overrides to the `messages` list.
- When the hook returns `None` (the historical contract) or a
  non-dict value, the loop proceeds with the original arguments.
- The `initial_user_content` field takes precedence over `user_input`,
  preserving the existing argument-resolution order.

Backward compatibility: existing read-only hooks (logging, metrics,
telemetry) keep working without modification — they simply ignore the
return value internally, and `agent_runner_loop` ignores non-dict
return values.

## Verification

Eight standalone tests against `agent_runner_loop` using a stub client
and `BaseHandler` subclass:

| # | Scenario | Result |
|---|----------|--------|
| 1 | Hook returns dict with `system_prompt` override | messages[0] updated |
| 2 | Hook returns dict with `user_input` override | messages[1] updated |
| 3 | Hook returns `None` (legacy contract) | messages unchanged |
| 4 | Hook sets both `user_input` and `initial_user_content` | initial wins |
| 5 | Hook returns a non-dict (e.g. string) | messages unchanged |
| 6 | Hook mutates ctx in place without explicit return | in-place change applied |
| 7 | Issue #537 reproduction: system_prompt augmentation | messages[0] now contains augmented prompt |
| 8 | `ruff check --select F,E9` on modified file | only pre-existing findings; no new ones introduced |

`py_compile agent_loop.py` passes; `pytest tests/` (currently empty
in this repo) runs with no regressions.

Regression-test sanity: reverting this change and re-running Test 7
asserts messages[0] equals the original `'Old prompt'` rather than the
augmented version — confirming the test exercises the actual bug.

Closes #537
