### PR TITLE
feat: opt-in commit signature module (GA_COMMIT_SIGNATURE) + /signature toggle

### DIFF
--- a/agentmain.py
+++ b/agentmain.py
@@ -39,6 +39,8 @@ if not os.path.exists(cdp_cfg):
 def get_system_prompt():
     with open(os.path.join(script_dir, f'assets/sys_prompt{lang_suffix}.txt'), 'r', encoding='utf-8') as f: prompt = f.read()
     prompt += f"\nToday: {time.strftime('%Y-%m-%d %a')}\n"
+    sig = os.environ.get('GA_COMMIT_SIGNATURE', '').strip()
+    if sig: prompt += f"When you create a git commit, append `{sig}` as the final line of the commit message.\n"
     prompt += get_global_memory()
     return prompt
 

--- a/agentmain.py
+++ b/agentmain.py
@@ -12,6 +12,7 @@ try:
     from plugins.hooks import discover_and_load; discover_and_load()
 except Exception: pass
 from ga import GenericAgentHandler, smart_format, get_global_memory, format_error, consume_file
+import commit_signature
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
 def load_tool_schema(suffix=''):
@@ -39,8 +40,7 @@ if not os.path.exists(cdp_cfg):
 def get_system_prompt():
     with open(os.path.join(script_dir, f'assets/sys_prompt{lang_suffix}.txt'), 'r', encoding='utf-8') as f: prompt = f.read()
     prompt += f"\nToday: {time.strftime('%Y-%m-%d %a')}\n"
-    sig = os.environ.get('GA_COMMIT_SIGNATURE', '').strip()
-    if sig: prompt += f"When you create a git commit, append `{sig}` as the final line of the commit message.\n"
+    prompt += commit_signature.prompt_block()
     prompt += get_global_memory()
     return prompt
 
@@ -131,6 +131,9 @@ class GenericAgent:
             return None
         if raw_query.strip() == '/resume':
             return r'帮我看看最近有哪些会话可以恢复。读model_responses/目录，按修改时间取最近10个文件，从每个文件里找最后一个<history>...</history>块，用一句话总结每个会话在聊什么，列表给我选。注意读文件后要把字面的\n替换成真换行才能正确匹配。'
+        if m := re.match(r'/signature\b(.*)', raw_query.strip(), re.S):
+            display_queue.put({'done': '✅ ' + commit_signature.toggle(m.group(1)), 'source': 'system'})
+            return None
         return raw_query
 
     def run(self):

--- a/commit_signature.py
+++ b/commit_signature.py
@@ -1,0 +1,14 @@
+"""Opt-in commit signature: set GA_COMMIT_SIGNATURE (or use /signature) to append a trailer to commits."""
+import os
+
+_sig = os.environ.get('GA_COMMIT_SIGNATURE', '').strip()
+
+def prompt_block():
+    return f"When you create a git commit, append `{_sig}` as the final line of the commit message.\n" if _sig else ''
+
+def toggle(arg=''):
+    global _sig
+    a = (arg or '').strip()
+    if a.lower() in ('', 'status'): return f"commit signature: {_sig or 'off'}"
+    _sig = '' if a.lower() == 'off' else (os.environ.get('GA_COMMIT_SIGNATURE', '').strip() if a.lower() == 'on' else a)
+    return f"commit signature: {_sig or 'off'}"

--- a/commit_signature.py
+++ b/commit_signature.py
@@ -1,14 +1,15 @@
-"""Opt-in commit signature: set GA_COMMIT_SIGNATURE (or use /signature) to append a trailer to commits."""
+"""Commit signature: GA_COMMIT_SIGNATURE=true/false (or /signature on|off) toggles a fixed Co-Authored-By trailer."""
 import os
 
-_sig = os.environ.get('GA_COMMIT_SIGNATURE', '').strip()
+_SIGNATURE = "Co-Authored-By: GenericAgent <bot@gaagent.ai>"
+_on = os.environ.get('GA_COMMIT_SIGNATURE', 'false').strip().lower() in ('1', 'true', 'on', 'yes')
 
 def prompt_block():
-    return f"When you create a git commit, append `{_sig}` as the final line of the commit message.\n" if _sig else ''
+    return f"When you create a git commit, append `{_SIGNATURE}` as the final line of the commit message.\n" if _on else ''
 
 def toggle(arg=''):
-    global _sig
-    a = (arg or '').strip()
-    if a.lower() in ('', 'status'): return f"commit signature: {_sig or 'off'}"
-    _sig = '' if a.lower() == 'off' else (os.environ.get('GA_COMMIT_SIGNATURE', '').strip() if a.lower() == 'on' else a)
-    return f"commit signature: {_sig or 'off'}"
+    global _on
+    a = (arg or '').strip().lower()
+    if a == 'on': _on = True
+    elif a == 'off': _on = False
+    return f"commit signature: {'on' if _on else 'off'}"

--- a/frontends/desktop/static/app.js
+++ b/frontends/desktop/static/app.js
@@ -1537,6 +1537,9 @@ async function handleSlash(cmd) {
         }
       }
       break;
+    case 'signature':
+      await sendPrompt('/signature' + (arg ? ' ' + arg : ''));
+      break;
     default:
       showSystem(`Unknown command: /${name}. Try /help.`);
   }

--- a/frontends/tui_v3.py
+++ b/frontends/tui_v3.py
@@ -4689,6 +4689,9 @@ class SB:
                 self._submit(prompt, [])
             else:
                 self.commit([f'❌ unknown command /{name}'])
+        elif name == 'signature':
+            import commit_signature
+            self.commit(['✅ ' + commit_signature.toggle(arg or '')])
         elif name == 'scheduler':
             from frontends import slash_cmds
             parts = (arg or '').split(None, 1)

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -3864,6 +3864,7 @@ class GenericAgentTUI(App[None]):
             "update": self._cmd_slash_inject, "autorun": self._cmd_slash_inject,
             "morphling": self._cmd_slash_inject, "goal": self._cmd_slash_inject,
             "hive": self._cmd_slash_inject, "conductor": self._cmd_slash_inject,
+            "signature": self._cmd_signature,
             "scheduler": self._cmd_scheduler,
             "quit": self._cmd_quit, "exit": self._cmd_quit,
         }
@@ -6244,6 +6245,10 @@ class GenericAgentTUI(App[None]):
         # Keep the user's original `/cmd ...` as the visible bubble so the
         # transcript stays self-explanatory; the agent sees the long prompt.
         self.submit_user_message(prompt, display_text=text or head)
+
+    def _cmd_signature(self, args, raw):
+        import commit_signature
+        self._system('✅ ' + commit_signature.toggle(' '.join(args)))
 
     def _cmd_scheduler(self, args, raw):
         """`/scheduler` lists reflect/*.py + sche_tasks/*.json and starts the


### PR DESCRIPTION
## What

An **opt-in** commit signature: when enabled, the agent appends a fixed `Co-Authored-By: GenericAgent <bot@gaagent.ai>` trailer as the final line of the git commit messages it writes, so agent-authored commits stay attributable.

## How — isolated module, minimal core footprint

All logic lives in a small standalone module, **`commit_signature.py`** (14 lines). `agentmain.py` keeps only thin, logic-free delegating hooks:

- `get_system_prompt()` — one line: `prompt += commit_signature.prompt_block()`
- `_handle_slash_cmd()` — a small dispatch so `/signature` works from every frontend (including the web/desktop bridge and IM bots).

```python
# commit_signature.py
_SIGNATURE = "Co-Authored-By: GenericAgent <bot@gaagent.ai>"
_on = os.environ.get('GA_COMMIT_SIGNATURE', 'false').strip().lower() in ('1', 'true', 'on', 'yes')

def prompt_block():
    return f"When you create a git commit, append `{_SIGNATURE}` ..." if _on else ''

def toggle(arg=''):   # /signature on | off   (bare = show status)
    ...
```

## Off by default

When `GA_COMMIT_SIGNATURE` is unset or `false`, `prompt_block()` returns `''` and the system prompt is **byte-identical** to before — zero behavior change for existing users.

## Configuration — two switches, two values each

**Environment variable** (set before launch):

```bash
GA_COMMIT_SIGNATURE=true     # on
GA_COMMIT_SIGNATURE=false    # off  (default)
```

**Runtime slash command** (any frontend, no restart):

- `/signature on` — enable
- `/signature off` — disable
- `/signature` — show current state

## Why minimal

- All logic in one 14-line module; `agentmain.py` gains only thin delegating hooks — no signature logic in the core path.
- No new dependencies.
- Off by default: nothing changes unless `GA_COMMIT_SIGNATURE=true` or `/signature on`.

## Verification

```python
import os, importlib, commit_signature as c
os.environ['GA_COMMIT_SIGNATURE'] = 'false'; importlib.reload(c)
assert c.prompt_block() == ''                        # off by default
c.toggle('on');  assert 'GenericAgent' in c.prompt_block()
c.toggle('off'); assert c.prompt_block() == ''
```
