### PR TITLE
fix(llmcore): suppress intermediate error yield during retry and handle ChunkedEncodingError

### DIFF
--- a/llmcore.py
+++ b/llmcore.py
@@ -387,13 +387,13 @@ def _stream_with_retry(sess, url, headers, payload, parse_fn):
                 except StopIteration as e:
                     if not e.value and not streamed: raise requests.ConnectionError("empty response")
                     return e.value or []
-        except (requests.Timeout, requests.ConnectionError) as e:
+        except (requests.Timeout, requests.ConnectionError, requests.exceptions.ChunkedEncodingError) as e:
             #pathlib.Path(__file__).parent.joinpath('temp','bad_requests.json').write_text(json.dumps({"url":url,"headers":headers,"payload":payload,"err":str(e),"t":time.time()},ensure_ascii=False),encoding='utf-8')
             err = f"!!!Error: {type(e).__name__}: {e}" if str(e) else f"!!!Error: {type(e).__name__}"
             if attempt < sess.max_retries:
                 d = _delay(None, attempt)
                 print(f"[LLM Retry] {type(e).__name__}, retry in {d:.1f}s ({attempt+1}/{sess.max_retries+1})")
-                yield err; time.sleep(d); continue
+                time.sleep(d); continue
             yield err; return [{"type": "text", "text": err}]
         except Exception as e:
             err = f"\n\n[!!! 流异常中断 {type(e).__name__}: {e} !!!]" if streamed else f"!!!Error: {type(e).__name__}: {e}"


### PR DESCRIPTION
## What problem this solves

When the LLM stream hits a transient network error (e.g. wifi blip walking to a meeting room, VPN reconnect, or proxy hiccup), the retry path yielded the raw `!!!Error: ...` string back to the UI on every attempt. The user then saw a wall of stacked error messages like:

```
!!!Error: ProxyError!!!Error: ConnectionError!!!Error: SSLError!!!Error: SSLError
!!!Error: SSLError!!!Error: SSLError!!!Error: SSLError!!!Error: SSLError
LLM Running (Turn 19) ...
!!!Error: SSLError!!!Error: SSLError!!!Error: SSLError!!!Error: SSLError
```

even when the eventual retry succeeded and the assistant was still producing a response. The user reported this as issue #571 with the expected behavior: exponential-backoff retry rather than a visible fail.

There was also a secondary gap: `requests.exceptions.ChunkedEncodingError` was not in the retryable-exception tuple, so a truncated chunked response would fall through to the bare `except Exception` branch and abort the stream with no retry, even though it is a transient transport-level error.

## What changed

`llmcore.py:_stream_with_retry`:

- Added `requests.exceptions.ChunkedEncodingError` to the connection-error exception tuple. SSLError and ProxyError already inherit from `requests.ConnectionError` and were already caught - only ChunkedEncodingError was actually missing.
- Removed the `yield err` from the intermediate-retry branch, matching the existing HTTP-retry path (which `time.sleep`s without yielding). The retry is still visible via the existing `[LLM Retry] ...` stdout log; the user-facing stream now stays silent during retries and only surfaces a final error if all attempts are exhausted.

## Evidence

Behavior before vs after, mocked retry sequence (max_retries=3):

- **Before**: 2 ConnectionErrors -> 200 with content -> yielded 2 intermediate `!!!Error: ...` chunks + content.
- **After**: 2 ConnectionErrors -> 200 with content -> yielded 0 intermediate error chunks + content.
- **Before**: ChunkedEncodingError -> no retry, immediate abort.
- **After**: ChunkedEncodingError -> caught, retried with backoff, only final error yielded if exhausted.

Local validation:

```
$ python3 -m py_compile llmcore.py
[no output]   # exit 0

$ ruff check llmcore.py --select F821,E9
All checks passed!

$ python3 -c "import ast; ast.parse(open('llmcore.py').read())"
[no output]   # exit 0
```

Behavioral tests (unittest.mock) verified that on a 2-error-then-success sequence the user-visible stream contains zero intermediate error chunks, while on exhaustion exactly one final error chunk is produced.

## Risk

Minimal: 2 lines changed in one function. The removed `yield err` only affected the connection-error retry path; the HTTP-retry path was already yield-free, so this is just bringing the two paths into consistency. All three call sites of `_stream_with_retry` (`_openai_stream`, `_claude_stream`, `BaseSession.ask`) consume the generator without depending on intermediate yield count.

Closes #571
