### PR TITLE
fix(ga-cli): propagate exit code when update steps fail

### DIFF
--- a/ga_cli/cli.py
+++ b/ga_cli/cli.py
@@ -131,19 +131,22 @@ def cmd_status():
 
 
 def cmd_update():
-    """git pull + pip install"""
+    """git pull + pip install; abort if git pull fails so we never pip-install
+    on top of stale or conflicted source."""
     os.chdir(PROJECT_DIR)
     print("🔄 git pull...")
     r = subprocess.run(["git", "pull"], capture_output=True, text=True)
     print(r.stdout)
     if r.returncode != 0:
-        print(r.stderr)
+        print(r.stderr, file=sys.stderr)
+        sys.exit(r.returncode)
     print("📦 pip install...")
     r2 = subprocess.run([sys.executable, "-m", "pip", "install", "-e", "."],
                         capture_output=True, text=True)
     print(r2.stdout[-500:] if r2.stdout else "")
     if r2.returncode != 0:
-        print(r2.stderr[-500:])
+        print(r2.stderr[-500:], file=sys.stderr)
+        sys.exit(r2.returncode)
 
 
 def main():

--- a/tests/test_ga_cli_update_fail_fast.py
+++ b/tests/test_ga_cli_update_fail_fast.py
@@ -1,0 +1,121 @@
+"""Behavioural test for ga_cli.cli.cmd_update fail-fast behaviour.
+
+When `git pull` fails (network down, merge conflict, dirty tree,
+non-fast-forward, etc.), the old code printed the error to stdout and
+then ran `pip install -e .` on top of stale or conflicted source. That
+silently corrupted the editable install and made the next `ga` command
+behave unpredictably.
+
+The fix exits with the git return code when git pull fails, and routes
+the error to stderr (where it belongs). This test verifies both:
+  1. cmd_update exits non-zero when git pull fails (and does NOT call
+     pip install).
+  2. cmd_update still calls pip install and exits cleanly when both
+     steps succeed.
+  3. cmd_update propagates pip-install failure via SystemExit.
+"""
+
+from __future__ import annotations
+
+import builtins
+import os
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(REPO_ROOT, "ga_cli"))
+
+import importlib.util
+_spec = importlib.util.spec_from_file_location(
+    "_ga_cli_for_test", os.path.join(REPO_ROOT, "ga_cli", "cli.py"),
+)
+ga_cli = importlib.util.module_from_spec(_spec)
+sys.modules["_ga_cli_for_test"] = ga_cli
+_spec.loader.exec_module(ga_cli)  # type: ignore[union-attr]
+
+
+class _FakeResult:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_cmd_update_exits_when_git_pull_fails(monkeypatch):
+    """git pull fails -> cmd_update exits with that code, pip never runs."""
+    calls = []
+
+    def fake_run(argv, *a, **kw):
+        calls.append(list(argv))
+        if argv[:2] == ["git", "pull"]:
+            return _FakeResult(128, stdout="", stderr="fatal: not a git repository\n")
+        # pip install — should not be reached
+        raise AssertionError(f"pip install must not run after failed git pull (called: {argv!r})")
+
+    monkeypatch.setattr(ga_cli.subprocess, "run", fake_run)
+    # Don't actually chdir into the project root — avoid touching the real one.
+    monkeypatch.setattr(ga_cli.os, "chdir", lambda *_a, **_kw: None)
+    # Suppress print noise. Patching the `print` builtin in the
+    # importing module is a no-op because `print` resolves via the
+    # builtins namespace. Use `builtins.setattr` so the cli module
+    # sees the patched value.
+    monkeypatch.setattr(builtins, "print", lambda *_a, **_kw: None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        ga_cli.cmd_update()
+    assert exc_info.value.code == 128, f"expected exit 128 (git pull rc), got {exc_info.value.code!r}"
+    # Only git pull was invoked, then exit.
+    assert calls == [["git", "pull"]], f"unexpected calls: {calls!r}"
+
+
+def test_cmd_update_propagates_pip_install_failure(monkeypatch):
+    """git pull ok + pip install fails -> cmd_update exits with pip's code."""
+    calls = []
+
+    def fake_run(argv, *a, **kw):
+        calls.append(list(argv))
+        if argv[:2] == ["git", "pull"]:
+            return _FakeResult(0, stdout="Already up to date.\n", stderr="")
+        return _FakeResult(1, stdout="", stderr="ERROR: Could not find a version\n")
+
+    monkeypatch.setattr(ga_cli.subprocess, "run", fake_run)
+    monkeypatch.setattr(ga_cli.os, "chdir", lambda *_a, **_kw: None)
+    monkeypatch.setattr(builtins, "print", lambda *_a, **_kw: None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        ga_cli.cmd_update()
+    assert exc_info.value.code == 1, f"expected exit 1 (pip install rc), got {exc_info.value.code!r}"
+    # Both steps were called in order.
+    assert [c[:2] for c in calls] == [
+        ["git", "pull"],
+        [sys.executable, "-m"],
+    ], f"unexpected call order: {calls!r}"
+
+
+def test_cmd_update_succeeds_when_both_steps_ok(monkeypatch):
+    """git pull + pip install both ok -> cmd_update returns normally with rc=0."""
+    calls = []
+
+    def fake_run(argv, *a, **kw):
+        calls.append(list(argv))
+        if argv[:2] == ["git", "pull"]:
+            return _FakeResult(0, stdout="Already up to date.\n", stderr="")
+        return _FakeResult(0, stdout="Successfully installed ga\n", stderr="")
+
+    monkeypatch.setattr(ga_cli.subprocess, "run", fake_run)
+    monkeypatch.setattr(ga_cli.os, "chdir", lambda *_a, **_kw: None)
+    monkeypatch.setattr(builtins, "print", lambda *_a, **_kw: None)
+
+    # cmd_update returns implicitly (no return statement) on success.
+    rc = ga_cli.cmd_update()
+    assert rc is None, f"on success cmd_update should return None, got {rc!r}"
+    assert [c[:2] for c in calls] == [
+        ["git", "pull"],
+        [sys.executable, "-m"],
+    ], f"unexpected call order: {calls!r}"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

`ga update` previously swallowed errors from `git pull` and `pip install -e .`, printed them to stdout, and then proceeded to run the next step. When `git pull` failed (network down, merge conflict, dirty tree, non-fast-forward), the command still ran `pip install -e .` on top of stale or conflicted source, silently corrupting the editable install and leaving the user with a `ga` that behaved unpredictably.

This change makes `cmd_update` fail fast:
- Route git and pip stderr to `sys.stderr` (where it belongs).
- `sys.exit(rc)` on either failure so the shell sees the non-zero status and the caller can detect the failed update.

## Test plan

`tests/test_ga_cli_update_fail_fast.py` covers the three cases:

1. `git pull` fails -> `SystemExit(128)`, `pip install` never runs.
2. `git pull` ok + `pip install` fails -> `SystemExit(1)`, both steps called in order.
3. Both ok -> no `SystemExit`, both steps called in order.

Verified via the three-step dance:
- Tests fail on `main` (unfixed code does not raise `SystemExit`).
- Tests pass on the fix branch (3/3).

Test patches `builtins.print` rather than the module's `print` binding, because `print` in `ga_cli/cli.py` resolves through the builtins namespace.

## Diff scope

`ga_cli/cli.py`: +6 / -3 lines (one source file, focused on `cmd_update`).
`tests/test_ga_cli_update_fail_fast.py`: +121 lines (new test file).

Total: under 130 lines, one commit, one PR.

## Behavioural impact

- A failing `git pull` no longer cascades into a corrupted `pip install`. The shell prompt returns to the user with a non-zero exit code and the error visible on stderr.
- A successful update is unchanged.
- No new runtime dependencies; `sys` and `subprocess` are already used.
