### PR TITLE
fix(llmcore): preserve exception chain on empty-response ConnectionError

### DIFF
--- a/llmcore.py
+++ b/llmcore.py
@@ -385,7 +385,7 @@ def _stream_with_retry(sess, url, headers, payload, parse_fn):
                 try:
                     while True: chunk = next(gen); streamed = True; yield chunk
                 except StopIteration as e:
-                    if not e.value and not streamed: raise requests.ConnectionError("empty response")
+                    if not e.value and not streamed: raise requests.ConnectionError("empty response") from e
                     return e.value or []
         except (requests.Timeout, requests.ConnectionError, requests.exceptions.ChunkedEncodingError) as e:
             #pathlib.Path(__file__).parent.joinpath('temp','bad_requests.json').write_text(json.dumps({"url":url,"headers":headers,"payload":payload,"err":str(e),"t":time.time()},ensure_ascii=False),encoding='utf-8')


### PR DESCRIPTION
## Summary

The `except StopIteration` block in `_stream` (llmcore.py:388) re-raised `ConnectionError("empty response")` without preserving the original exception chain. Adding `from e` ensures the traceback shows the full causal chain, which helps diagnose intermittent empty-response issues during LLM streaming.

## Changes

- **llmcore.py:388** — `raise requests.ConnectionError("empty response")` → `raise requests.ConnectionError("empty response") from e`

One-token change (`from e`). The `ConnectionError` is caught by the outer retry handler on line 390, so runtime behavior is unchanged — only the traceback quality improves.

## Verification

- `py_compile llmcore.py` — passes
- `ruff check llmcore.py --select=B904` — passes (was the only remaining B904 in the file)
- Exception-chain test: confirms `exc.__cause__` is a `StopIteration` instance after the fix
