### PR TITLE
fix(tmwebdriver): preserve exception chain in _remote_cmd ConnectionError

### DIFF
--- a/TMWebDriver.py
+++ b/TMWebDriver.py
@@ -243,8 +243,8 @@ class TMWebDriver:
     
     def _remote_cmd(self, cmd):
         try: return requests.post(self.remote, headers={"Content-Type": "application/json"}, json=cmd, timeout=30).json()
-        except (ConnectionError, requests.exceptions.ConnectionError):
-            raise ConnectionError("TMWebDriver master未运行，看tmwebdriver_sop后台启动一个TMWebDriver")
+        except (ConnectionError, requests.exceptions.ConnectionError) as e:
+            raise ConnectionError("TMWebDriver master未运行，看tmwebdriver_sop后台启动一个TMWebDriver") from e
 
     def get_all_sessions(self):  
         if self.is_remote:


### PR DESCRIPTION
## Summary

The `_remote_cmd` method in TMWebDriver catches connection errors and re-raises with a user-friendly message, but discards the original exception. Adding `as e` + `from e` preserves the causal chain in the traceback, making it easier to diagnose whether the failure was a DNS issue, a refused connection, or a timeout.

## Changes

- **TMWebDriver.py:246-247** — capture the original exception (`as e`) and chain it (`from e`)

Two-line change. The user-facing error message is unchanged; only the traceback depth improves.

## Verification

- `py_compile TMWebDriver.py` — passes
- `ruff check TMWebDriver.py --select=B904` — passes (was the only B904 in the file)
