### PR TITLE
fix(agentmain): use pid+nanos for long-prompt temp filename

### DIFF
--- a/agentmain.py
+++ b/agentmain.py
@@ -145,7 +145,7 @@ class GenericAgent:
                 self.task_queue.task_done(); continue
             self.is_running = True
             if len(raw_query) > 2000:
-                task_file = os.path.join(script_dir, 'temp', f'user_prompt_{int(time.time())}.md')
+                task_file = os.path.join(script_dir, 'temp', f'user_prompt_{os.getpid()}_{time.time_ns()}.md')
                 with open(task_file, 'w', encoding='utf-8') as f: f.write(raw_query)
                 raw_query = f'Long user prompt saved to {task_file}. Read and execute.'
             rquery = smart_format(raw_query.replace('\n', ' '), max_str_len=200)


### PR DESCRIPTION
## 修复

`agentmain.py:148` 临时文件名使用秒级时间戳 `int(time.time())`,在并发 `--func` / `run_subagents` 同一秒内会**撞名** → 进程 A 写到 `user_prompt_1720xxx.md` 后被进程 B 覆盖;后续 `file_read` 读到的是别人任务的 prompt,产出串内容。

## 改动

1 行:`int(time.time())` → `os.getpid() + time.time_ns()`,与项目内 `code_run`(用 `tempfile.NamedTemporaryFile`)、`ga_ultraplan.py _subagent`(用全局递增序号)的一致性补齐。

```python
- task_file = os.path.join(script_dir, 'temp', f'user_prompt_{int(time.time())}.md')
+ task_file = os.path.join(script_dir, 'temp', f'user_prompt_{os.getpid()}_{time.time_ns()}.md')
```

## 验证

`/tmp/test_issue_665.py` (8 threads × 50 attempts in 1s):

| 行为 | 唯一路径 | 撞名 |
|---|---|---|
| OLD (秒级时间戳) | 1 / 50 | **49** |
| NEW (pid+nanos)   | 50 / 50 | 0 |
| NEW (8 进程)      | 30 / 30 | 0 |

线程池场景下,新方案 50/50 全唯一;旧方案 49/50 撞名。ProcessPool 也 30/30 唯一,覆盖 `run_subagents` 多子进程场景。

Closes #665
