### PR TITLE
feat(worldline): persistent checkpoint-tree rewind for tui_v2 (/rewind + /worldline)

### DIFF
--- a/frontends/continue_cmd.py
+++ b/frontends/continue_cmd.py
@@ -294,7 +294,7 @@ def _rounds_for_file(path, st):
     return n, key
 
 
-def list_sessions(exclude_pid=None, exclude_log=None):
+def list_sessions(exclude_pid=None, exclude_log=None, rewind_root=None):
     """Newest-first list of (path, mtime, preview_text, n_rounds). Preview uses head/tail window only.
 
     `exclude_log` (basename, e.g. 'model_responses_123456.txt') drops the caller's
@@ -324,6 +324,43 @@ def list_sessions(exclude_pid=None, exclude_log=None):
         valid_keys.append(key)
         out.append((f, mtime, preview, rounds))
     _save_rounds_cache(valid_keys)
+    # 【门控·worldline】树感知发现:日志空/缺失但有非空世界线树的会话(回退到起点后日志被
+    # 清空 → 上面 sz<32 跳过了)。仅当调用方显式传 rewind_root 时启用 → 其他 UI 不传,
+    # 行为逐字节不变。只读 tree.json 的 nodes/head(不依赖 worldline 模块)。
+    if rewind_root and os.path.isdir(rewind_root):
+        have = {os.path.basename(p) for p, *_ in out}
+        try:
+            keys = os.listdir(rewind_root)
+        except OSError:
+            keys = []
+        for key in keys:
+            if not key.startswith('model_responses_'):
+                continue
+            log_name = key + '.txt'
+            if log_name in have or log_name == exclude_log:
+                continue
+            log_path = os.path.join(_LOG_DIR, log_name)
+            try:                                    # 仅收"日志确实空/缺失"的(非空日志已被主循环收录)
+                if os.path.getsize(log_path) >= 32:
+                    continue
+            except OSError:
+                pass                                # 缺失也算
+            try:
+                with open(os.path.join(rewind_root, key, 'tree.json'), encoding='utf-8') as fh:
+                    d = json.load(fh)
+            except Exception:
+                continue
+            nodes = d.get('nodes') or {}
+            real = [v for v in nodes.values() if v.get('kind') != 'origin']
+            if not real:                            # 只有 origin 的空树 → 无内容,跳过
+                continue
+            try:
+                mtime = os.path.getmtime(os.path.join(rewind_root, key, 'tree.json'))
+            except OSError:
+                mtime = 0
+            head = d.get('head')
+            title = (nodes.get(head, {}).get('title') if head else '') or '（已回退至会话起点）'
+            out.append((log_path, mtime, f'[世界线] {title}', len(real)))
     out.sort(key=lambda x: x[1], reverse=True)
     return out
 _MD_ESCAPE_RE = re.compile(r'([\\`*_\[\]])')
@@ -1014,10 +1051,19 @@ def _load_history_into(agent, path):
     return f'⚠️ 非 native 格式，降级恢复 {n} 轮摘要（{name}）', False
 
 
-def continue_inplace(agent, path, agent_id=None):
+def _is_empty_log(path):
+    """日志空(<32 字节)或缺失。用于 allow_empty:回退到会话起点后日志被清空的会话。"""
+    try:
+        return os.path.getsize(path) < 32
+    except OSError:
+        return True
+
+
+def continue_inplace(agent, path, agent_id=None, allow_empty=False):
     """原地续:把 agent 的日志指回 `path` 本身,之后轮次追加到 X,延续同一会话。
     调用方应已确认空闲(session_occupant 为 None);抢锁失败(被占)返回错误。
-    返回 (msg, ok)。"""
+    `allow_empty`(仅 worldline UI 传):日志为空时不报错,按【空会话】恢复(清空对话,
+    由调用方按 `.ga_rewind` 树重连),用于"回退至会话起点"的会话。返回 (msg, ok)。"""
     try: agent.abort()
     except Exception: pass
     if not acquire_lock(path, agent_id):       # 先抢到目标锁;失败则保持现状,不丢自己的锁
@@ -1026,10 +1072,14 @@ def continue_inplace(agent, path, agent_id=None):
     if cur and os.path.basename(cur) != os.path.basename(path):
         release_lock(cur)                       # 目标到手,旧会话释放为空闲(同一文件则不放)
     _retarget_log(agent, path)
-    return _load_history_into(agent, path)
+    msg, ok = _load_history_into(agent, path)
+    if not ok and allow_empty and _is_empty_log(path):
+        _replace_backend_history(agent, [])     # 空会话:清空对话(载入失败时它没被清)
+        return '✅ 已恢复空会话（回退至会话起点；世界线树已重连）', True
+    return msg, ok
 
 
-def continue_copy(agent, path, agent_id=None):
+def continue_copy(agent, path, agent_id=None, allow_empty=False):
     """拷贝续:铸新 logid、把 `path` 内容拷进去,在副本上续;`path` 原件不动。
     用于"被占用→用户选拷贝"以及快照源。返回 (msg, ok)。"""
     try: agent.abort()
@@ -1042,7 +1092,11 @@ def continue_copy(agent, path, agent_id=None):
         pass
     acquire_lock(newp, agent_id)
     _retarget_log(agent, newp)
-    return _load_history_into(agent, newp)
+    msg, ok = _load_history_into(agent, newp)
+    if not ok and allow_empty and _is_empty_log(newp):
+        _replace_backend_history(agent, [])
+        return '✅ 已恢复空会话（回退至会话起点；世界线树已重连）', True
+    return msg, ok
 
 
 def install(cls):

--- a/frontends/continue_cmd.py
+++ b/frontends/continue_cmd.py
@@ -113,7 +113,7 @@ def _parse_native_history(pairs):
         except Exception: return None
         if not (isinstance(user_msg, dict) and user_msg.get('role') == 'user'): return None
         if not isinstance(blocks, list): return None
-        history.append(user_msg)
+        history.append(user_msg)  # runtime history 尊重日志真实 prompt(含 project-mode 当轮注入)
         history.append({'role': 'assistant', 'content': blocks})
     return history
 
@@ -164,8 +164,9 @@ def _derive_hist_info(history):
         role = m.get('role')
         if role == 'user':
             if _is_tool_result(m): continue            # tool_result 轮不是提问
-            t = _all_text(m).strip()
-            if t: out.append(f'[USER]: {t}')
+            t = strip_project_mode(_all_text(m)).strip()
+            if t and not t.startswith(_INJECT_MARKERS):
+                out.append(f'[USER]: {t}')
         elif role == 'assistant':
             txt = re.sub(r'```.*?```|<thinking>.*?</thinking>', '', _all_text(m), flags=re.DOTALL)
             mt = re.search(r'<summary>(.*?)</summary>', txt, re.DOTALL)
@@ -540,17 +541,19 @@ def handle(agent, query, display_queue):
 
 
 _INJECT_MARKERS = ('### [WORKING MEMORY]', '[SYSTEM TIPS]', '[SYSTEM]', '[System]',
-                   '[DANGER]', '### [总结提炼经验]')
+                   '[DANGER]', '### [总结提炼经验]',
+                   'Continue from where you left off')
 
-# project_mode 插件把 `\n\n---\n[PROJECT MODE: <name>]\n…\n---` 追加在用户消息末尾
-# (见 plugins/project_mode._build_injection)。它会进日志,所以 /continue 重建 UI 时
-# 必须从显示文本里剔除,只留用户原话。不能加进 _INJECT_MARKERS——那会把整块(连用户
-# 原话)一起丢弃;这里只剜掉注入这一段后缀。
-_PM_BLOCK_RE = re.compile(r"\n*-{3,}\n\[PROJECT MODE:.*?\n-{3,}\s*$", re.DOTALL)
+# project_mode 插件把 `\n\n---\n[PROJECT MODE: <name>]\n…\n---` 追加到当轮 user
+# message(见 plugins/project_mode._build_injection)。runtime history 尊重日志真实 prompt,
+# 但 UI 预览/显示与派生 history_info 需要只取用户原话。老日志的 WORKING MEMORY 里还
+# 可能嵌着已污染的 `[USER]: ... [PROJECT MODE] ... [Agent] ...`,所以剥离支持 text
+# 内任意位置与被截断的单行 title 形态。不能加进 _INJECT_MARKERS——那会把整条用户原话一起丢弃。
+_PM_BLOCK_RE = re.compile(r"\s*-{3,}\s*\[PROJECT MODE:.*?(?:\n-{3,}\s*|$)", re.DOTALL)
 
 
 def strip_project_mode(text: str) -> str:
-    """剔除用户文本尾部的 project-mode 注入块。"""
+    """剔除文本中由 project_mode 插件追加的 L1 注入块。"""
     return _PM_BLOCK_RE.sub("", text or "")
 
 

--- a/frontends/continue_cmd.py
+++ b/frontends/continue_cmd.py
@@ -118,6 +118,39 @@ def _parse_native_history(pairs):
     return history
 
 
+def _derive_hist_info(history):
+    """从 native history 重建 history_info(轮级纪要):真实用户提问 → `[USER]: …`;每条
+    assistant(=一轮) → `[Agent] <summary>`(无 summary 取首行)。与 ga.turn_end_callback /
+    worldline 树同口径。纯函数、不依赖 worldline,供续接 opt-in 恢复工作记忆(见 restore_wm)。"""
+    def _all_text(m):
+        c = m.get('content') if isinstance(m, dict) else None
+        if isinstance(c, str): return c
+        if isinstance(c, list):
+            return '\n'.join(b.get('text', '') for b in c
+                             if isinstance(b, dict) and b.get('type') == 'text')
+        return ''
+    def _is_tool_result(m):
+        c = m.get('content') if isinstance(m, dict) else None
+        return isinstance(c, list) and any(
+            isinstance(b, dict) and b.get('type') == 'tool_result' for b in c)
+    out = []
+    for m in history or []:
+        if not isinstance(m, dict): continue
+        role = m.get('role')
+        if role == 'user':
+            if _is_tool_result(m): continue            # tool_result 轮不是提问
+            t = _all_text(m).strip()
+            if t: out.append(f'[USER]: {t}')
+        elif role == 'assistant':
+            txt = re.sub(r'```.*?```|<thinking>.*?</thinking>', '', _all_text(m), flags=re.DOTALL)
+            mt = re.search(r'<summary>(.*?)</summary>', txt, re.DOTALL)
+            s = mt.group(1).strip()[:80] if (mt and mt.group(1).strip()) else ''
+            if not s:
+                s = next((ln.strip()[:80] for ln in txt.splitlines() if ln.strip()), '（无摘要）')
+            out.append(f'[Agent] {s}')
+    return out
+
+
 _PREVIEW_WIN = 32 * 1024
 
 # Content-grep budget for `/continue` search box: read at most this many bytes
@@ -1025,9 +1058,13 @@ def begin_fresh_session(agent, agent_id=None):
     _clear_conversation_state(agent)
 
 
-def _load_history_into(agent, path):
+def _load_history_into(agent, path, restore_wm=False):
     """把 `path` 解析进 backend.history(native;否则降级摘要)。镜像 restore() 的解析,
-    但不 abort/不快照(日志重指由调用方先做好)。返回 (msg, is_full)。"""
+    但不 abort/不快照(日志重指由调用方先做好)。返回 (msg, is_full)。
+
+    `restore_wm`(默认 False,仅显式传入的调用方启用,如 worldline TUI):从同一份日志
+    派生 history_info 写回 `agent.history`,使续接后工作记忆不丢。默认关闭 → 其它前端
+    行为完全不变。"""
     try:
         with open(path, encoding='utf-8', errors='replace') as fh:
             content = fh.read()
@@ -1040,6 +1077,8 @@ def _load_history_into(agent, path):
     name = os.path.basename(path)
     if history is not None:
         _replace_backend_history(agent, history)
+        if restore_wm and hasattr(agent, 'history'):
+            agent.history = _derive_hist_info(history)   # 续接恢复工作记忆(opt-in)
         return f'✅ 已恢复 {len(pairs)} 轮完整对话（{name}）', True
     from chatapp_common import _restore_native_history, _restore_text_pairs
     summary = _restore_text_pairs(content) or _restore_native_history(content)
@@ -1059,11 +1098,12 @@ def _is_empty_log(path):
         return True
 
 
-def continue_inplace(agent, path, agent_id=None, allow_empty=False):
+def continue_inplace(agent, path, agent_id=None, allow_empty=False, restore_wm=False):
     """原地续:把 agent 的日志指回 `path` 本身,之后轮次追加到 X,延续同一会话。
     调用方应已确认空闲(session_occupant 为 None);抢锁失败(被占)返回错误。
     `allow_empty`(仅 worldline UI 传):日志为空时不报错,按【空会话】恢复(清空对话,
-    由调用方按 `.ga_rewind` 树重连),用于"回退至会话起点"的会话。返回 (msg, ok)。"""
+    由调用方按 `.ga_rewind` 树重连),用于"回退至会话起点"的会话。
+    `restore_wm`(opt-in):续接后从日志派生 history_info 恢复工作记忆。返回 (msg, ok)。"""
     try: agent.abort()
     except Exception: pass
     if not acquire_lock(path, agent_id):       # 先抢到目标锁;失败则保持现状,不丢自己的锁
@@ -1072,16 +1112,17 @@ def continue_inplace(agent, path, agent_id=None, allow_empty=False):
     if cur and os.path.basename(cur) != os.path.basename(path):
         release_lock(cur)                       # 目标到手,旧会话释放为空闲(同一文件则不放)
     _retarget_log(agent, path)
-    msg, ok = _load_history_into(agent, path)
+    msg, ok = _load_history_into(agent, path, restore_wm=restore_wm)
     if not ok and allow_empty and _is_empty_log(path):
         _replace_backend_history(agent, [])     # 空会话:清空对话(载入失败时它没被清)
         return '✅ 已恢复空会话（回退至会话起点；世界线树已重连）', True
     return msg, ok
 
 
-def continue_copy(agent, path, agent_id=None, allow_empty=False):
+def continue_copy(agent, path, agent_id=None, allow_empty=False, restore_wm=False):
     """拷贝续:铸新 logid、把 `path` 内容拷进去,在副本上续;`path` 原件不动。
-    用于"被占用→用户选拷贝"以及快照源。返回 (msg, ok)。"""
+    用于"被占用→用户选拷贝"以及快照源。`restore_wm`(opt-in)同 continue_inplace。
+    返回 (msg, ok)。"""
     try: agent.abort()
     except Exception: pass
     release_current(agent)
@@ -1092,7 +1133,7 @@ def continue_copy(agent, path, agent_id=None, allow_empty=False):
         pass
     acquire_lock(newp, agent_id)
     _retarget_log(agent, newp)
-    msg, ok = _load_history_into(agent, newp)
+    msg, ok = _load_history_into(agent, newp, restore_wm=restore_wm)
     if not ok and allow_empty and _is_empty_log(newp):
         _replace_backend_history(agent, [])
         return '✅ 已恢复空会话（回退至会话起点；世界线树已重连）', True

--- a/frontends/continue_cmd.py
+++ b/frontends/continue_cmd.py
@@ -118,6 +118,31 @@ def _parse_native_history(pairs):
     return history
 
 
+def parse_native_log(path, allow_empty=False):
+    """Parse a native `model_responses_*.txt` log into backend.history.
+
+    Public wrapper around the mature `/continue` parser. It intentionally only
+    restores complete Prompt→Response pairs; dangling Prompt / partial turns keep
+    the current continue semantics and are ignored. Returns:
+    - list (possibly [] when allow_empty=True) on native success;
+    - None when the file is unreadable / non-native / empty without allow_empty.
+    """
+    try:
+        with open(path, encoding='utf-8', errors='replace') as fh:
+            content = fh.read()
+    except Exception:
+        return [] if allow_empty else None
+    pairs = _pairs(content)
+    if not pairs:
+        # Native-looking but incomplete logs (e.g. dangling Prompt without Response)
+        # have block headers but no complete pairs. For worldline's allow_empty mode
+        # this means "0 completed rounds", not "parse failed → trust live history".
+        if allow_empty and (_is_empty_log(path) or _BLOCK_RE.findall(content or '')):
+            return []
+        return None
+    return _parse_native_history(pairs)
+
+
 def _derive_hist_info(history):
     """从 native history 重建 history_info(轮级纪要):真实用户提问 → `[USER]: …`;每条
     assistant(=一轮) → `[Agent] <summary>`(无 summary 取首行)。与 ga.turn_end_callback /

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -4299,9 +4299,22 @@ class GenericAgentTUI(App[None]):
         try:
             title = (getattr(sess, "_rw_title", "") or "checkpoint").replace("\n", " ").strip()[:80]
             agent = sess.agent
-            history = agent.llmclient.backend.history
-            # 工作记忆一并入树:history_info(轮级纪要) + key_info(便签),供 rewind 硬同步。
             handler = getattr(agent, "handler", None)
+            # 喂给树的对话取【日志全量】而非压缩态 backend.history:长会话删头后 backend.history
+            # 是后缀,据它切增量会丢轮。日志只增不改,据它切永远精确(commit 内部再以树真实
+            # 长度对齐)。读/解析失败退回 backend.history(短会话二者本就相等)。
+            history = agent.llmclient.backend.history
+            log_path = getattr(agent, "log_path", "") or ""
+            if log_path:
+                try:
+                    import continue_cmd as _cc
+                    _full = _cc._parse_native_history(
+                        _cc._pairs(open(log_path, encoding="utf-8", errors="replace").read()))
+                    if _full:
+                        history = _full
+                except Exception:
+                    pass
+            # 工作记忆一并入树:history_info(轮级纪要,不受压缩裁剪) + key_info(便签),供 rewind 硬同步。
             hist_info = list(getattr(handler, "history_info", None)
                              or getattr(agent, "history", None) or [])
             key_info = (getattr(handler, "working", None) or {}).get("key_info")

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -5281,8 +5281,11 @@ class GenericAgentTUI(App[None]):
             where = "空起点" if at_origin else f"「{title}」之后（在此继续）"
         else:
             where = "空起点" if at_origin else f"「{title}」之前"
-        return (f"↩ 已回退到{where}（{label}）：清除 {removed} 条上下文，"
-                f"代码恢复 {len(res['changed'])} 个文件")
+        msg = (f"↩ 已回退到{where}（{label}）：清除 {removed} 条上下文，"
+               f"代码恢复 {len(res['changed'])} 个文件")
+        if res.get("code_error"):     # apply_code 中途失败 → 工作区可能半回退,不静默
+            msg += f"\n⚠️ 代码回退未完成（{res['code_error']}）：工作区可能处于部分回退状态，请检查后重试。"
+        return msg
 
     def _rw_sync_working_memory(self, sess, res) -> None:
         """rewind 时把 working memory(history_info 纪要 + key_info 便签)硬同步到回退点,

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass, field
 from itertools import count
 from typing import Any, Callable, Optional
 
+
 def _ensure_tui_deps() -> None:
     """Try the imports; on first miss, pip-install the wheel and retry once.
     Keeps `ga-cli` working on a fresh Python (Windows / macOS / Linux) where
@@ -1456,7 +1457,7 @@ from worldline import (
     RewindStore, restore_plan,
     ellipsize, rel_time, files_summary, kind_glyph, kind_label,
     CheckpointTree, tree_from_store, CompressedTree,
-    _order_depths, next_same_depth, nearest_depth_node, parent_sibling_first_child,
+    _order_depths, next_same_depth, nearest_depth_node,
 )
 # RewindTreeScreen 等三栏树 UI 已内联到本文件末尾(原 rewind_tree_view.py),跟随 v2 主题配色。
 
@@ -4287,42 +4288,68 @@ class GenericAgentTUI(App[None]):
         except Exception:
             pass
 
+    def _rw_log_history(self, sess: AgentSession):
+        """按 continue 的 native-log 口径读取当前会话 history。
+
+        worldline 的持久对话层以 `model_responses_*.txt` 为真相源;live backend.history
+        只是异常 fallback。cache 仅按文件 stat 避免同一版本重复解析,不改变语义。"""
+        log_path = getattr(sess.agent, "log_path", "") or ""
+        if not log_path:
+            return None
+        try:
+            st = os.stat(log_path)
+        except OSError:
+            return None
+        key = (log_path, int(st.st_size), int(getattr(st, "st_mtime_ns", int(st.st_mtime * 1_000_000_000))))
+        cache = getattr(sess, "_rw_log_hist_cache", None)
+        if isinstance(cache, dict) and cache.get("key") == key:
+            return list(cache.get("history") or [])
+        try:
+            import continue_cmd as _cc
+            hist = _cc.parse_native_log(log_path, allow_empty=True)
+        except Exception:
+            hist = None
+        if hist is None:
+            return None
+        sess._rw_log_hist_cache = {"key": key, "history": list(hist)}
+        return list(hist)
+
+    def _rw_title_from_delta(self, store, history: list, fallback: str) -> str:
+        """checkpoint 标题跟随**实际写入树的日志增量**;避免残缺/未配对 prompt 误成节点名。"""
+        try:
+            parent = store.head if store.head in store.nodes else store.root_id
+            parent_len = len(store.rebuild_history(parent)) if parent is not None else 0
+            for msg in list(history or [])[parent_len:]:
+                text = store._msg_user_text(msg).strip()
+                if text:
+                    return text.replace("\n", " ").strip()[:80]
+        except Exception:
+            pass
+        return (fallback or "checkpoint").replace("\n", " ").strip()[:80]
+
     def _rw_commit(self, sess: AgentSession) -> None:
         """用户提问段完成时落一个 checkpoint 节点(对话推进也算 checkpoint)。
 
-        title 取本次用户输入;传整条 `backend.history` 给 store —— commit 会切本轮
-        增量 `history[parent.hist_len:]` 存成 conv blob(树=真相源),恢复时按路径拼回。
-        store 故障一律静默(rewind 是旁路安全网,绝不冒泡打断任务收尾)。"""
+        对话来源正常取 native log(continue 同口径、完整 Prompt→Response pairs);只有日志读不到
+        /非 native 时才 fallback 到 live backend.history。store 故障一律静默(rewind 是旁路
+        安全网,绝不冒泡打断任务收尾)。"""
         store = getattr(sess, "store", None)
         if store is None:
             return
         try:
-            title = (getattr(sess, "_rw_title", "") or "checkpoint").replace("\n", " ").strip()[:80]
             agent = sess.agent
-            # 喂给树的对话:常态直接用 backend.history(快);仅当**检测到删头**(backend.history
-            # 被 pop 过头、与树对不上)才回退到「解析整个日志」拿全量(慢路径)。这样长会话每段
-            # 收尾不必每次解析大日志,又能在真删头时保证不丢轮(commit 内部再以树真实长度对齐)。
-            history = agent.llmclient.backend.history
-            log_path = getattr(agent, "log_path", "") or ""
-            # 廉价删头检测:删头先 pop 掉首问 → 树首问与 live 首问对不上即判定删过头。
-            try:
-                tree_first = store.first_question()
-                live_first = next((store._msg_user_text(m).strip() for m in history
-                                   if store._msg_user_text(m).strip()), None)
-                trimmed = bool(tree_first and live_first and tree_first != live_first)
-            except Exception:
-                trimmed = False
-            if trimmed and log_path:
-                try:
-                    import continue_cmd as _cc
-                    _full = _cc._parse_native_history(
-                        _cc._pairs(open(log_path, encoding="utf-8", errors="replace").read()))
-                    if _full:
-                        history = _full
-                except Exception:
-                    pass
+            history = self._rw_log_history(sess)
+            if history is None:
+                history = agent.llmclient.backend.history
+            parent = store.head if store.head in store.nodes else store.root_id
+            parent_len = len(store.rebuild_history(parent)) if parent is not None else 0
+            if len(history or []) <= parent_len:
+                store._touched.clear()  # 残缺/未配对轮不进树,本段文件触碰也不能污染下一轮
+                store.save()
+                return
+            title = self._rw_title_from_delta(store, history, getattr(sess, "_rw_title", ""))
             # 工作记忆不取 live handler.history_info(/continue 会清空它,且与树派生口径不一致);
-            # 交给 commit 从日志全量 history 统一派生 → 树的 WM 恒由日志重建、互相对齐。
+            # 交给 commit 从日志 history 统一派生 → 树的 WM 恒由日志重建、互相对齐。
             store.commit(title or "checkpoint", history=history)
             store._rw_cursor = None   # 继续提问 → 新末端成为当前,清除 rewind 游标
         except Exception:
@@ -5415,11 +5442,14 @@ class GenericAgentTUI(App[None]):
         res = restore_plan(store, node_id, mode=mode, to=to, log_path=log_path)
         if res is None:
             return "❌ 无效的 checkpoint"
-        # rewind 游标:to=before(回到 X 之前,内部 HEAD=parent)时,用户心中「当前」仍是
-        # 选中的 X → 记下供世界线面板把 ◉ 标在 X(下次打开仍停在 X)。to=at 则就在该节点,
-        # 用 HEAD 即可。继续提问(commit)时清除。
+        # rewind 游标(世界线面板 ◉「当前位置」标记):
+        # - both:to=before 时标选中节点(用户心中的「当前」是它),to=at 标 HEAD;
+        # - conv/code:HEAD 落在桥接节点上,标桥接(res["target"])。
         try:
-            store._rw_cursor = node_id if (to == "before") else None
+            if mode in ("conv", "code"):
+                store._rw_cursor = res["target"]
+            else:
+                store._rw_cursor = node_id if (to == "before") else None
         except Exception:
             pass
         removed = 0
@@ -5558,9 +5588,11 @@ class GenericAgentTUI(App[None]):
         # stream leaves `consumed` False.
         last_user_text = None
         consumed = False
+        assistant_len = 0
         for m in reversed(sess.messages):
             if m.role == "assistant" and (m.content or "").strip():
                 consumed = True
+                assistant_len = len(m.content or "")
             elif m.role == "user":
                 last_user_text = m.content
                 break
@@ -6709,7 +6741,8 @@ class GenericAgentTUI(App[None]):
             try: item = dq.get(timeout=0.25)
             except queue.Empty: continue
             if "next" in item:
-                buf += str(item.get("next") or "")
+                piece = str(item.get("next") or "")
+                buf += piece
                 self.call_from_thread(self._on_stream, agent_id, task_id, buf, False)
             if "done" in item:
                 done_text = str(item.get("done") or buf)
@@ -8080,6 +8113,10 @@ def render_tree(ct: CompressedTree, selected_key: int) -> List[RenderRow]:
         lbl_style = f"bold {C_FG} on {C_ALT_BG}" if key == selected_key else (
             base if d.depth == sel_depth else C_MUTED)
         line.append(ct.label(key), style=lbl_style)
+        _en = ct.end_node(key)
+        if getattr(_en, "rw_tag", None):
+            line.append(f"（{_en.rw_tag}）",
+                        style=C_AMBER if key == selected_key else C_DIM)
         line.append(f"   {rel_time(ct.end_node(key).ago)}", style=C_DIM)
         rows.append(RenderRow(key=key, depth=d.depth, text=line, node_start=node_start))
         kids = d.children
@@ -8466,6 +8503,8 @@ class RewindTreeScreen(ModalScreen):
                         style=(C_CYAN if self.focus_right else C_DIM) if active else C_DIM)
             line.append(f"{g} ", style=C_GREEN if active else gs)
             line.append(ellipsize(n.title, 54), style=rs)
+            if n.rw_tag:
+                line.append(f"（{n.rw_tag}）", style=C_AMBER if active else C_DIM)
             line.append(f"   {rel_time(n.ago)}", style=C_DIM)
             lines.append(line); idxs.append(i)
         # 末尾占位项(尚未创建,用括号标注);圆点字形,颜色同普通记录(new)/绿(current)。

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -4299,7 +4299,6 @@ class GenericAgentTUI(App[None]):
         try:
             title = (getattr(sess, "_rw_title", "") or "checkpoint").replace("\n", " ").strip()[:80]
             agent = sess.agent
-            handler = getattr(agent, "handler", None)
             # 喂给树的对话取【日志全量】而非压缩态 backend.history:长会话删头后 backend.history
             # 是后缀,据它切增量会丢轮。日志只增不改,据它切永远精确(commit 内部再以树真实
             # 长度对齐)。读/解析失败退回 backend.history(短会话二者本就相等)。
@@ -4314,12 +4313,9 @@ class GenericAgentTUI(App[None]):
                         history = _full
                 except Exception:
                     pass
-            # 工作记忆一并入树:history_info(轮级纪要,不受压缩裁剪) + key_info(便签),供 rewind 硬同步。
-            hist_info = list(getattr(handler, "history_info", None)
-                             or getattr(agent, "history", None) or [])
-            key_info = (getattr(handler, "working", None) or {}).get("key_info")
-            store.commit(title or "checkpoint", history=history,
-                         hist_info=hist_info, key_info=key_info)
+            # 工作记忆不取 live handler.history_info(/continue 会清空它,且与树派生口径不一致);
+            # 交给 commit 从日志全量 history 统一派生 → 树的 WM 恒由日志重建、互相对齐。
+            store.commit(title or "checkpoint", history=history)
             store._rw_cursor = None   # 继续提问 → 新末端成为当前,清除 rewind 游标
         except Exception:
             pass

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -4299,12 +4299,20 @@ class GenericAgentTUI(App[None]):
         try:
             title = (getattr(sess, "_rw_title", "") or "checkpoint").replace("\n", " ").strip()[:80]
             agent = sess.agent
-            # 喂给树的对话取【日志全量】而非压缩态 backend.history:长会话删头后 backend.history
-            # 是后缀,据它切增量会丢轮。日志只增不改,据它切永远精确(commit 内部再以树真实
-            # 长度对齐)。读/解析失败退回 backend.history(短会话二者本就相等)。
+            # 喂给树的对话:常态直接用 backend.history(快);仅当**检测到删头**(backend.history
+            # 被 pop 过头、与树对不上)才回退到「解析整个日志」拿全量(慢路径)。这样长会话每段
+            # 收尾不必每次解析大日志,又能在真删头时保证不丢轮(commit 内部再以树真实长度对齐)。
             history = agent.llmclient.backend.history
             log_path = getattr(agent, "log_path", "") or ""
-            if log_path:
+            # 廉价删头检测:删头先 pop 掉首问 → 树首问与 live 首问对不上即判定删过头。
+            try:
+                tree_first = store.first_question()
+                live_first = next((store._msg_user_text(m).strip() for m in history
+                                   if store._msg_user_text(m).strip()), None)
+                trimmed = bool(tree_first and live_first and tree_first != live_first)
+            except Exception:
+                trimmed = False
+            if trimmed and log_path:
                 try:
                     import continue_cmd as _cc
                     _full = _cc._parse_native_history(

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -5912,6 +5912,15 @@ class GenericAgentTUI(App[None]):
             except Exception:
                 _log_hist = []
             sess.store.reconcile(_log_hist)
+            # 续接后恢复工作记忆【仅 TUI】:continue_cmd 把 handler.history_info 清空了,这里从
+            # 日志派生 history_info 写回 agent.history(下次 run 建 handler 时即成为其 history_info)。
+            # 与树 / live 会话同口径(都从日志派生),消除「续接不管 WM」的不一致。不碰 continue_cmd
+            # → 不影响 Telegram/Discord/Streamlit 等其它前端。
+            try:
+                if _log_hist and hasattr(sess.agent, "history"):
+                    sess.agent.history = sess.store._derive_hist_info(_log_hist)
+            except Exception:
+                pass
         except Exception:
             pass
         def _finish():

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -5881,9 +5881,9 @@ class GenericAgentTUI(App[None]):
         import continue_cmd as _cc
         try:
             if copy:
-                result, ok = _cc.continue_copy(sess.agent, path, sess.agent_id, allow_empty=True)
+                result, ok = _cc.continue_copy(sess.agent, path, sess.agent_id, allow_empty=True, restore_wm=True)
             else:
-                result, ok = _cc.continue_inplace(sess.agent, path, sess.agent_id, allow_empty=True)
+                result, ok = _cc.continue_inplace(sess.agent, path, sess.agent_id, allow_empty=True, restore_wm=True)
         except Exception as e:
             msg = f"❌ 恢复失败: {e}"
             self._system(msg); return msg
@@ -5912,15 +5912,8 @@ class GenericAgentTUI(App[None]):
             except Exception:
                 _log_hist = []
             sess.store.reconcile(_log_hist)
-            # 续接后恢复工作记忆【仅 TUI】:continue_cmd 把 handler.history_info 清空了,这里从
-            # 日志派生 history_info 写回 agent.history(下次 run 建 handler 时即成为其 history_info)。
-            # 与树 / live 会话同口径(都从日志派生),消除「续接不管 WM」的不一致。不碰 continue_cmd
-            # → 不影响 Telegram/Discord/Streamlit 等其它前端。
-            try:
-                if _log_hist and hasattr(sess.agent, "history"):
-                    sess.agent.history = sess.store._derive_hist_info(_log_hist)
-            except Exception:
-                pass
+            # 续接恢复工作记忆已由 continue_cmd 的 restore_wm=True 在加载日志时做掉
+            # (派生 history_info 写回 agent.history),此处不再重复。
         except Exception:
             pass
         def _finish():

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -4298,8 +4298,15 @@ class GenericAgentTUI(App[None]):
             return
         try:
             title = (getattr(sess, "_rw_title", "") or "checkpoint").replace("\n", " ").strip()[:80]
-            history = sess.agent.llmclient.backend.history
-            store.commit(title or "checkpoint", history=history)
+            agent = sess.agent
+            history = agent.llmclient.backend.history
+            # 工作记忆一并入树:history_info(轮级纪要) + key_info(便签),供 rewind 硬同步。
+            handler = getattr(agent, "handler", None)
+            hist_info = list(getattr(handler, "history_info", None)
+                             or getattr(agent, "history", None) or [])
+            key_info = (getattr(handler, "working", None) or {}).get("key_info")
+            store.commit(title or "checkpoint", history=history,
+                         hist_info=hist_info, key_info=key_info)
             store._rw_cursor = None   # 继续提问 → 新末端成为当前,清除 rewind 游标
         except Exception:
             pass
@@ -5406,6 +5413,7 @@ class GenericAgentTUI(App[None]):
         if res["history"] is not None:           # 对话有变更(both/conv)
             hist[:] = res["history"]
             removed = max(0, old_len - len(res["history"]))
+            self._rw_sync_working_memory(sess, res)  # 纪要/便签随对话硬同步回退点
             self._rw_rebuild_display(sess)        # 从重写后的投影重组界面历史消息
         self._remount_current_session()
         self._refresh_topbar()
@@ -5420,6 +5428,29 @@ class GenericAgentTUI(App[None]):
             where = "空起点" if at_origin else f"「{title}」之前"
         return (f"↩ 已回退到{where}（{label}）：清除 {removed} 条上下文，"
                 f"代码恢复 {len(res['changed'])} 个文件")
+
+    def _rw_sync_working_memory(self, sess, res) -> None:
+        """rewind 时把 working memory(history_info 纪要 + key_info 便签)硬同步到回退点,
+        与 backend.history 一致 —— 消灭旧 rewind「历史回退了、纪要没回」的串味。
+
+        WM 注入(`_get_anchor_prompt`)读的是 handler.history_info,故就地 [:] 替换它;
+        agent.history 指向同一列表,一并对齐。老树无 WM 记录时 res 给 None → 跳过,
+        不动现场纪要(向后兼容)。纪要是旁路,故障静默,绝不打断恢复。"""
+        try:
+            agent = sess.agent
+            handler = getattr(agent, "handler", None)
+            hi = res.get("hist_info")
+            if hi is not None and handler is not None and isinstance(
+                    getattr(handler, "history_info", None), list):
+                handler.history_info[:] = list(hi)       # 就地替换:WM 注入读的就是它
+                try: agent.history = handler.history_info  # 让 agent.history 指向同一列表
+                except Exception: pass
+            ki = res.get("key_info")
+            if ki is not None and handler is not None and isinstance(
+                    getattr(handler, "working", None), dict):
+                handler.working["key_info"] = ki
+        except Exception:
+            pass
 
     def _rw_rebuild_display(self, sess) -> None:
         """rewind 后重组**界面历史消息**:从已重写成新 HEAD 路径的投影日志重新解析

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -1456,8 +1456,8 @@ from export_cmd import last_assistant_text, export_to_temp, wrap_for_clipboard
 from worldline import (
     RewindStore, restore_plan,
     ellipsize, rel_time, files_summary, kind_glyph, kind_label,
-    CheckpointTree, tree_from_store, CompressedTree,
-    _order_depths, next_same_depth, nearest_depth_node,
+    tree_from_store, CompressedTree,
+    _order_depths, nearest_depth_node,
 )
 # RewindTreeScreen 等三栏树 UI 已内联到本文件末尾(原 rewind_tree_view.py),跟随 v2 主题配色。
 
@@ -3536,260 +3536,6 @@ C_LAVENDER = C_PURPLE      # lane 配色 → 跟主题紫
 C_RED      = "#e5534b"     # diff 删除行(固定语义色)
 
 
-def _rw_rel_time(ago_s):
-    """粗粒度相对时间(不精确到秒);ago_s 为 None 时返回空串。"""
-    if ago_s is None:
-        return ""
-    if ago_s < 60:
-        return "刚刚"
-    m = ago_s // 60
-    if m < 60:
-        return f"{m} 分钟前"
-    h = m // 60
-    if h < 24:
-        return f"{h} 小时前"
-    return f"{h // 24} 天前"
-
-
-def _rw_files_summary(files):
-    if not files:
-        return ""
-    if len(files) <= 3:
-        return "、".join(files)
-    return "、".join(files[:3]) + f" (+{len(files) - 3})"
-
-
-def _rw_user_text(content):
-    """从一条 history 消息的 content 里取用户可见文本。"""
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        for b in content:
-            if isinstance(b, dict) and b.get("type") == "text" and b.get("text"):
-                return b["text"]
-    return ""
-
-
-def _rw_files_in_range(history, lo, hi):
-    """该提问段内经 file_write / file_patch 改动的文件名(去重,顺序保留)。
-    与「code_run 暂不追踪」的后端决策一致——只认结构化文件工具的 path。"""
-    seen = []
-    for m in history[lo:hi]:
-        if m.get("role") != "assistant":
-            continue
-        c = m.get("content")
-        if not isinstance(c, list):
-            continue
-        for b in c:
-            if (isinstance(b, dict) and b.get("type") == "tool_use"
-                    and b.get("name") in ("file_write", "file_patch")):
-                p = (b.get("input") or {}).get("path")
-                if p:
-                    base = os.path.basename(str(p))
-                    if base not in seen:
-                        seen.append(base)
-    return seen
-
-
-def _rw_collect(sess):
-    """从一个 session 构造 rewind 节点(oldest→newest),末尾追加一个合成的
-    HEAD「当前位置」节点(n=None → 恢复是 no-op)。
-
-    节点 = 真实用户提问边界(与 _rewindable_turns 同源),故节点的 `n` 可直接
-    传给 _do_rewind(n)。时间戳来自 _install_rw_time_hook 按 history 长度打的点;
-    没有记录(如 /continue 恢复来的旧会话)则相对时间为空。"""
-    history = sess.agent.llmclient.backend.history
-    bounds = []
-    for i, m in enumerate(history):
-        if m.get("role") != "user":
-            continue
-        c = m.get("content")
-        if isinstance(c, list) and any(
-                isinstance(b, dict) and b.get("type") == "tool_result" for b in c):
-            continue  # tool 回填,不是真实提问
-        txt = _rw_user_text(c)
-        if txt and txt.strip():
-            bounds.append((i, txt))
-
-    times = getattr(sess, "_rw_times", {}) or {}
-    now = time.time()
-
-    def ago_at(hi):
-        ks = [k for k in times if k <= hi]
-        if not ks:
-            return None
-        return int(max(0, now - times[max(ks)]))
-
-    nodes = []
-    total = len(bounds)
-    for p, (idx, txt) in enumerate(bounds):
-        nxt = bounds[p + 1][0] if p + 1 < total else len(history)
-        title = txt.replace("\n", " ").strip()[:80] or "（空）"
-        nodes.append({
-            "n": total - p,                       # _do_rewind(n):1 = 最近一次提问
-            "title": title,
-            "files": _rw_files_in_range(history, idx, nxt),
-            "ago": ago_at(nxt),
-            "kind": "edit",
-        })
-    nodes.append({
-        "n": None, "title": "当前位置", "files": [],
-        "ago": ago_at(len(history)), "kind": "current",
-    })
-    return nodes
-
-
-def _rw_changed_files(store, node_id):
-    """该节点相对父节点变更的文件名(basename,去重)——列表/详情的文件摘要。"""
-    nd = store.nodes[node_id]
-    par = nd.get("parent")
-    pf = store.nodes[par]["files"] if par in store.nodes else {}
-    out = []
-    for k, v in nd["files"].items():
-        if pf.get(k) != v:
-            b = os.path.basename(k)
-            if b not in out:
-                out.append(b)
-    return out
-
-
-def _rw_node_line(title, files, ago, *, current, glyph):
-    line = Text()
-    line.append(glyph + " ", style=(f"bold {C_GREEN}" if current else C_BLUE))
-    line.append(title or "（空）", style=(f"bold {C_GREEN}" if current else C_FG))
-    t = _rw_rel_time(ago)
-    if t:
-        line.append(f"   {t}", style=C_DIM)
-    fs = _rw_files_summary(files)
-    if fs:
-        line.append(f"   {fs}", style=C_DIM)
-    return line
-
-
-def _rw_entries_linear(sess):
-    """线性时间线条目 `[(Text, payload)]` + 默认选中索引。
-
-    有真实 store → root→HEAD 链（payload = node_id，恢复 = 对话+代码）；否则回退到
-    history 现算（payload = 回退轮数 n / None，仅对话恢复，兼容尚无 checkpoint 的会话）。"""
-    store = getattr(sess, "store", None)
-    if store is not None and store.nodes and store.head in store.nodes:
-        now = time.time()
-        entries = []
-        for nid in store.linear_path():
-            nd = store.nodes[nid]
-            cur = nid == store.head
-            entries.append((
-                _rw_node_line(nd["title"], _rw_changed_files(store, nid),
-                              int(now - nd.get("created", now)),
-                              current=cur, glyph=("●" if cur else "○")),
-                nid,
-            ))
-        return entries, len(entries) - 1
-    entries = []
-    for nd in _rw_collect(sess):
-        cur = nd["kind"] == "current"
-        line = Text()
-        if cur:
-            line.append("● 当前位置", style=f"bold {C_GREEN}")
-        else:
-            line.append(f"↩ 回退 {nd['n']} 轮  ", style=C_AMBER)
-            line.append(nd["title"], style=C_FG)
-        t = _rw_rel_time(nd["ago"])
-        if t:
-            line.append(f"   {t}", style=C_DIM)
-        fs = _rw_files_summary(nd["files"])
-        if fs:
-            line.append(f"   {fs}", style=C_DIM)
-        entries.append((line, nd["n"]))
-    return entries, len(entries) - 1
-
-
-def _rw_entries_tree(sess):
-    """树状条目 `[(Text, payload)]` + 默认选中(HEAD)索引。DFS 走真实 store 树,
-    用 ├─/╰─ 连线 + 缩进表达分支(fork 后即可见);无 store 时回退到线性。"""
-    store = getattr(sess, "store", None)
-    if not (store is not None and store.nodes and store.root_id in store.nodes):
-        return _rw_entries_linear(sess)
-    now = time.time()
-    entries = []
-    sel = [0]
-
-    def dfs(nid, prefix, is_last, depth):
-        nd = store.nodes[nid]
-        cur = nid == store.head
-        line = Text()
-        if prefix:
-            line.append(prefix, style=C_DIM)
-        if depth > 0:
-            line.append("╰─ " if is_last else "├─ ", style=C_DIM)
-        line.append("● " if cur else "○ ", style=(f"bold {C_GREEN}" if cur else C_BLUE))
-        line.append(nd["title"] or "（空）", style=(f"bold {C_GREEN}" if cur else C_FG))
-        t = _rw_rel_time(int(now - nd.get("created", now)))
-        if t:
-            line.append(f"   {t}", style=C_DIM)
-        fs = _rw_files_summary(_rw_changed_files(store, nid))
-        if fs:
-            line.append(f"   {fs}", style=C_DIM)
-        if cur:
-            sel[0] = len(entries)
-        entries.append((line, nid))
-        child_prefix = prefix + ("   " if is_last else "│  ") if depth > 0 else prefix
-        kids = [c for c in nd["children"] if c in store.nodes]
-        for i, c in enumerate(kids):
-            dfs(c, child_prefix, i == len(kids) - 1, depth + 1)
-
-    dfs(store.root_id, "", True, 0)
-    return entries, sel[0]
-
-
-class RewindScreen(ModalScreen):
-    """checkpoint 选择面板(时间线 / 树共用)。`entries = [(Text, payload)]`;
-    Esc 取消(dismiss None);Enter/点击 dismiss 该条 payload(store 节点 id 或
-    回退轮数 n)。打开时默认选中当前(HEAD)。"""
-
-    CSS = """
-    RewindScreen { align: center middle; }
-    RewindScreen > Vertical {
-        width: 96; max-width: 92%; height: auto; max-height: 80%;
-        background: $ga-alt-bg; border: solid $ga-border; padding: 1 2;
-    }
-    RewindScreen .rw-head { color: $ga-fg; padding: 0 0 1 0; }
-    RewindScreen OptionList {
-        background: $ga-alt-bg; color: $ga-fg; height: auto; max-height: 1fr; padding: 0;
-    }
-    RewindScreen OptionList > .option-list--option-highlighted {
-        background: $ga-sel-bg; color: $ga-fg;
-    }
-    """
-    BINDINGS = [Binding("escape", "cancel", "Cancel", show=False)]
-
-    def __init__(self, entries, select_idx, title) -> None:
-        super().__init__()
-        # NB: 不要用 self._nodes —— 那是 Textual 的子节点 NodeList,覆盖会崩。
-        self._entries = entries
-        self._select = select_idx
-        self._title = title
-
-    def compose(self) -> ComposeResult:
-        with Vertical():
-            yield Static(self._title, classes="rw-head")
-            yield OptionList(id="rw-list")
-
-    def on_mount(self) -> None:
-        ol = self.query_one(OptionList)
-        for text, _payload in self._entries:
-            ol.add_option(Option(text))
-        if self._entries:
-            ol.highlighted = max(0, min(self._select, len(self._entries) - 1))
-        ol.focus()
-
-    def on_option_list_option_selected(self, ev) -> None:
-        self.dismiss(self._entries[ev.option_index][1])
-
-    def action_cancel(self) -> None:
-        self.dismiss(None)
-
-
 class GenericAgentTUI(App[None]):
 
     CSS = _MAIN_CSS
@@ -5486,16 +5232,6 @@ class GenericAgentTUI(App[None]):
         # 三栏全屏可视化器(§3–§7):左压缩树 / 右上折叠段 / 右下详情+操作。
         self.push_screen(RewindTreeScreen(store), self._on_rewind_tree_result)
 
-    def _on_rewind_pick(self, payload) -> None:
-        # 面板回调:None=取消;str=store 节点 id(恢复对话+代码);int=history 回退轮数。
-        if payload is None:
-            return
-        sess = self.current
-        if isinstance(payload, str):
-            self._system(self._rw_restore_node(sess, payload))
-        else:
-            self._system(self._do_rewind(payload))
-
     def _on_rewind_tree_result(self, result) -> None:
         # 三栏屏回调:None=取消/已内联处理(diff/delete);dict=恢复请求。
         if not isinstance(result, dict) or result.get("action") != "restore":
@@ -5664,11 +5400,9 @@ class GenericAgentTUI(App[None]):
         # stream leaves `consumed` False.
         last_user_text = None
         consumed = False
-        assistant_len = 0
         for m in reversed(sess.messages):
             if m.role == "assistant" and (m.content or "").strip():
                 consumed = True
-                assistant_len = len(m.content or "")
             elif m.role == "user":
                 last_user_text = m.content
                 break
@@ -8388,7 +8122,6 @@ class RewindTreeScreen(ModalScreen):
         self.focus_right = False
         # 默认聚焦到「当前位置」(见 _default_seg_idx)。
         self.seg_idx = self._default_seg_idx()
-        self._diff_for: Optional[str] = None  # 正在内联展示 diff 的节点 id
 
     # ---- 当前位置:就一个游标。有游标=回退到的那个节点;没有=末端 tip ----
     def _cursor(self):
@@ -8486,7 +8219,6 @@ class RewindTreeScreen(ModalScreen):
         if not keep_focus:
             self.focus_right = False
         self.seg_idx = self._default_seg_idx()
-        self._diff_for = None
         self.refresh_all()
 
     def refresh_all(self) -> None:
@@ -8745,14 +8477,12 @@ class RewindTreeScreen(ModalScreen):
     def _move_right(self, delta: int) -> None:
         n = self._seg_max_idx()               # 索引 0..n,n=tip(无 tip 的 origin 段则到末项)
         self.seg_idx = max(0, min(self.seg_idx + delta, n))
-        self._diff_for = None
         self._refresh_rtop(); self._refresh_rbot(); self._refresh_status()
 
     def _set_focus(self, right: bool) -> None:
         self.focus_right = right
         if right:
             self.seg_idx = min(self.seg_idx, self._seg_max_idx())  # 越界落到 tip(或末项)
-        self._diff_for = None
         self._refresh_rtop(); self._refresh_rbot(); self._refresh_status()
         self._refresh_focus_frame()
 
@@ -8820,7 +8550,6 @@ class RewindTreeScreen(ModalScreen):
         self.sel_key = self._disp_key_for_node(self._current_node()) or flat[0]
         self.focus_right = False
         self.seg_idx = self._default_seg_idx()
-        self._diff_for = None
         self.refresh_all()
 
     def action_cancel(self) -> None:
@@ -8850,7 +8579,6 @@ class RewindTreeScreen(ModalScreen):
             return
         self.focus_right = True
         self.seg_idx = max(0, min(ev.option_index, self._seg_max_idx()))
-        self._diff_for = None
         self._refresh_rtop(); self._refresh_rbot(); self._refresh_status()
         self._refresh_focus_frame()
 

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -5285,13 +5285,12 @@ class GenericAgentTUI(App[None]):
         if sess.status == "running":
             self._system("Cannot rewind while running. /stop first."); return
         store = getattr(sess, "store", None)
-        history = sess.agent.llmclient.backend.history
-        # 先对账:让树对齐当前对话(顺带防外部 UI 改写日志的灾难),再按树的线性路径
-        # 建卡片,每个选项 = 一个真实节点 → 选中即可持久回退。
+        # 不在会话内对账:树由 _rw_commit 每轮提交,始终 ⊇ 当前对话;且此刻 backend.history
+        # 是压缩/删头后的 live,拿它对账会被误判「分歧」而弃树(见 worldline.reconcile)。
+        # 对账统一只在 /continue(全量日志刚载入、未压缩)时做。直接按树的线性路径建卡片,
+        # 每个选项 = 一个真实节点 → 选中即可持久回退。
         nodes = []   # [(node_id, title)] 最近→最旧,不含 origin
         if store is not None:
-            try: store.reconcile(history)
-            except Exception: pass
             if store.nodes and store.head in store.nodes:
                 for nid in store.linear_path():
                     if store.nodes[nid].get("kind") == "origin":
@@ -5357,14 +5356,11 @@ class GenericAgentTUI(App[None]):
         store = getattr(sess, "store", None)
         if store is None:
             self._system("No rewindable checkpoints."); return
-        # 打开即对账:把 live history 中树尚未记录的尾部(别的 UI 续聊时追加的)吸收进树。
-        # 这是防灾的单一咽喉点——restore 只能从已打开的世界线屏发起,对账后树恒 ⊇ 日志,
-        # 故随后任何 rewind 都不可能用陈旧树 rewrite_projection 抹掉外部轮次。
-        # 也统一了「空 store / 老会话」:n=0 即把整条历史合成为 conv-only 主干(界面不降级)。
-        try:
-            store.reconcile(sess.agent.llmclient.backend.history)
-        except Exception:
-            pass  # 对账失败不阻断;下面守卫兜底
+        # 不在会话内对账:树由 _rw_commit 每轮提交,打开世界线时已 ⊇ 当前对话;此刻
+        # backend.history 是压缩/删头后的 live,拿它对账会被误判分歧而弃树(见 reconcile)。
+        # 对账统一只在 /continue(全量日志刚载入、未压缩)时做;外部 UI 改写日志的灾难由
+        # 「每会话锁 + 心跳判活」拦截,不再依赖此处对账。空 store/老会话由 continue 路径
+        # 的对账建树,本处仅守卫:无节点则无可回退。
         if not (store.nodes and store.root_id in store.nodes):
             self._system("No rewindable checkpoints."); return  # 连一轮真实提问都没有
         # 三栏全屏可视化器(§3–§7):左压缩树 / 右上折叠段 / 右下详情+操作。
@@ -5892,10 +5888,17 @@ class GenericAgentTUI(App[None]):
                 old_root = os.path.normpath(os.path.join(
                     temp_dir, '.ga_rewind', RewindStore.key_for_log(path)))
                 sess.store.resume_from(old_root)
-            # 接管后立即对账:此刻 backend.history 已是日志全量(continue_* 末尾 _load_history_into)。
-            # 若源日志曾被不更新树的 UI 续写,树会滞后于日志 → 在这里吸收尾部,使树 ⊇ 日志,
-            # 杜绝之后 rewind 用陈旧树回写、抹掉外部轮次的灾难。
-            sess.store.reconcile(sess.agent.llmclient.backend.history)
+            # 接管后立即对账【日志 ↔ 树】。对账的基准是**日志**(全量真相源),不是压缩态
+            # backend.history —— 后者是有损派生物,拿它对账会让全量的树去迁就残缺内存(假
+            # 分歧弃树的根因)。这里显式从日志解析全量历史喂入,即便将来 continue 流程变化
+            # 或内存被压缩,对账恒以日志为准。用途:源日志若被不更新树的 UI 续写,树会滞后
+            # → 吸收尾部使树 ⊇ 日志,杜绝之后 rewind 用陈旧树回写、抹掉外部轮次的灾难。
+            try:
+                _log_hist = _cc._parse_native_history(
+                    _cc._pairs(open(new_log, encoding='utf-8', errors='replace').read())) or []
+            except Exception:
+                _log_hist = []
+            sess.store.reconcile(_log_hist)
         except Exception:
             pass
         def _finish():

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -5505,6 +5505,10 @@ class GenericAgentTUI(App[None]):
         return turns
 
     def _do_rewind(self, n: int) -> str:
+        """【降级兜底·非持久】纯内存截断 backend.history。仅在【没有 checkpoint 树】时用
+        (store 创建失败 / 会话刚开还没 commit)。缺陷:砍的是压缩态内存——够不到已删头的轮、
+        留下的是被截断的残骸、不恢复文件、不回退 working memory。有树时一律走持久的
+        树重建路径(_rw_restore_node → restore_plan),不要用本方法。"""
         sess = self.current
         turns = self._rewindable_turns()
         if not (1 <= n <= len(turns)):
@@ -5530,7 +5534,7 @@ class GenericAgentTUI(App[None]):
                 inp.focus()
                 self._resize_input(inp)
             except Exception: pass
-        return f"已回退 {n} 轮（移除 {removed} 条历史）"
+        return f"↩ 已回退 {n} 轮（内存级·不持久，移除 {removed} 条历史）"
 
     def _cmd_clear(self, args, raw):
         self.current.messages.clear()

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -58,7 +58,7 @@ try:
     from textual import events
     from textual.app import App, ComposeResult
     from textual.binding import Binding
-    from textual.containers import Horizontal, Vertical, VerticalScroll
+    from textual.containers import Horizontal, ScrollableContainer, Vertical, VerticalScroll
     from textual.geometry import Region
     from textual.message import Message
     from textual.screen import ModalScreen
@@ -1452,6 +1452,13 @@ from review_cmd import handle as review_handle
 from continue_cmd import list_sessions as continue_list, extract_ui_messages as continue_extract
 import workspace_cmd
 from export_cmd import last_assistant_text, export_to_temp, wrap_for_clipboard
+from worldline import (
+    RewindStore, restore_plan,
+    ellipsize, rel_time, files_summary, kind_glyph, kind_label,
+    CheckpointTree, tree_from_store, CompressedTree,
+    _order_depths, next_same_depth, nearest_depth_node, parent_sibling_first_child,
+)
+# RewindTreeScreen 等三栏树 UI 已内联到本文件末尾(原 rewind_tree_view.py),跟随 v2 主题配色。
 
 # Cross-platform clipboard copy for /export clip. Mirrors tui_v3's native-tool
 # strategy but stays local to v2 so the Textual frontend has no dependency on
@@ -2053,7 +2060,8 @@ COMMANDS = [
     ("/close",    "",                 "关闭当前会话"),
     ("/rename",   "<name>",           "重命名当前会话（持久化）"),
     ("/branch",   "[name]",           "从当前会话分支"),
-    ("/rewind",   "[n]",              "回退最近 n 轮"),
+    ("/rewind",   "[n]",              "回退面板（时间线）/ 直接回退 n 轮"),
+    ("/worldline", "",                "世界线 — checkpoint 树状回退（打开即选中当前节点）"),
     ("/clear",    "",                 "清空显示（不动 LLM 历史）"),
     ("/stop",     "",                 "中止当前任务"),
     ("/llm",      "[n]",              "查看 / 切换模型"),
@@ -3495,6 +3503,282 @@ class ThemePicker(ModalScreen):
         self.dismiss()
 
 
+# ===========================================================================
+# /rewind 面板 — 会话 checkpoint 的时间线 / 树状可视化 + 对话恢复
+#
+# GA 没有真正的 rewind 后端(checkpoint 树是从 LLM history 现算的),所以这里的
+# 「节点」= 用户提问边界(与既有 /rewind 的 _rewindable_turns 同源),每个节点的
+# `n` 直接喂给 _do_rewind(n)。「恢复对话」= 把 backend.history 截断回该提问之前
+# (复用既有 _do_rewind,仅在 agent 空闲时允许);restore code / fork / diff /
+# delete 需要文件快照后端,本版为占位(详见需求文档 §9 的「暂缓」决策)。
+# ===========================================================================
+
+# tui_v2 主题色(C_FG/C_DIM/C_GREEN/C_BLUE 随主题刷新,这里直接复用模块全局);
+# 补几个 v2 未定义的固定色。
+C_ALT_BG   = "#21262d"
+C_AMBER    = "#f0883e"
+# 世界线树(/worldline)配色:除 diff 删除红是固定语义色外,其余跟随 v2 主题(_palette)。
+C_BG       = _palette["bg"]
+C_BORDER   = _palette["border"]
+C_CYAN     = C_BLUE        # 聚焦高亮 → 跟主题蓝
+C_LAVENDER = C_PURPLE      # lane 配色 → 跟主题紫
+C_RED      = "#e5534b"     # diff 删除行(固定语义色)
+
+
+def _rw_rel_time(ago_s):
+    """粗粒度相对时间(不精确到秒);ago_s 为 None 时返回空串。"""
+    if ago_s is None:
+        return ""
+    if ago_s < 60:
+        return "刚刚"
+    m = ago_s // 60
+    if m < 60:
+        return f"{m} 分钟前"
+    h = m // 60
+    if h < 24:
+        return f"{h} 小时前"
+    return f"{h // 24} 天前"
+
+
+def _rw_files_summary(files):
+    if not files:
+        return ""
+    if len(files) <= 3:
+        return "、".join(files)
+    return "、".join(files[:3]) + f" (+{len(files) - 3})"
+
+
+def _rw_user_text(content):
+    """从一条 history 消息的 content 里取用户可见文本。"""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        for b in content:
+            if isinstance(b, dict) and b.get("type") == "text" and b.get("text"):
+                return b["text"]
+    return ""
+
+
+def _rw_files_in_range(history, lo, hi):
+    """该提问段内经 file_write / file_patch 改动的文件名(去重,顺序保留)。
+    与「code_run 暂不追踪」的后端决策一致——只认结构化文件工具的 path。"""
+    seen = []
+    for m in history[lo:hi]:
+        if m.get("role") != "assistant":
+            continue
+        c = m.get("content")
+        if not isinstance(c, list):
+            continue
+        for b in c:
+            if (isinstance(b, dict) and b.get("type") == "tool_use"
+                    and b.get("name") in ("file_write", "file_patch")):
+                p = (b.get("input") or {}).get("path")
+                if p:
+                    base = os.path.basename(str(p))
+                    if base not in seen:
+                        seen.append(base)
+    return seen
+
+
+def _rw_collect(sess):
+    """从一个 session 构造 rewind 节点(oldest→newest),末尾追加一个合成的
+    HEAD「当前位置」节点(n=None → 恢复是 no-op)。
+
+    节点 = 真实用户提问边界(与 _rewindable_turns 同源),故节点的 `n` 可直接
+    传给 _do_rewind(n)。时间戳来自 _install_rw_time_hook 按 history 长度打的点;
+    没有记录(如 /continue 恢复来的旧会话)则相对时间为空。"""
+    history = sess.agent.llmclient.backend.history
+    bounds = []
+    for i, m in enumerate(history):
+        if m.get("role") != "user":
+            continue
+        c = m.get("content")
+        if isinstance(c, list) and any(
+                isinstance(b, dict) and b.get("type") == "tool_result" for b in c):
+            continue  # tool 回填,不是真实提问
+        txt = _rw_user_text(c)
+        if txt and txt.strip():
+            bounds.append((i, txt))
+
+    times = getattr(sess, "_rw_times", {}) or {}
+    now = time.time()
+
+    def ago_at(hi):
+        ks = [k for k in times if k <= hi]
+        if not ks:
+            return None
+        return int(max(0, now - times[max(ks)]))
+
+    nodes = []
+    total = len(bounds)
+    for p, (idx, txt) in enumerate(bounds):
+        nxt = bounds[p + 1][0] if p + 1 < total else len(history)
+        title = txt.replace("\n", " ").strip()[:80] or "（空）"
+        nodes.append({
+            "n": total - p,                       # _do_rewind(n):1 = 最近一次提问
+            "title": title,
+            "files": _rw_files_in_range(history, idx, nxt),
+            "ago": ago_at(nxt),
+            "kind": "edit",
+        })
+    nodes.append({
+        "n": None, "title": "当前位置", "files": [],
+        "ago": ago_at(len(history)), "kind": "current",
+    })
+    return nodes
+
+
+def _rw_changed_files(store, node_id):
+    """该节点相对父节点变更的文件名(basename,去重)——列表/详情的文件摘要。"""
+    nd = store.nodes[node_id]
+    par = nd.get("parent")
+    pf = store.nodes[par]["files"] if par in store.nodes else {}
+    out = []
+    for k, v in nd["files"].items():
+        if pf.get(k) != v:
+            b = os.path.basename(k)
+            if b not in out:
+                out.append(b)
+    return out
+
+
+def _rw_node_line(title, files, ago, *, current, glyph):
+    line = Text()
+    line.append(glyph + " ", style=(f"bold {C_GREEN}" if current else C_BLUE))
+    line.append(title or "（空）", style=(f"bold {C_GREEN}" if current else C_FG))
+    t = _rw_rel_time(ago)
+    if t:
+        line.append(f"   {t}", style=C_DIM)
+    fs = _rw_files_summary(files)
+    if fs:
+        line.append(f"   {fs}", style=C_DIM)
+    return line
+
+
+def _rw_entries_linear(sess):
+    """线性时间线条目 `[(Text, payload)]` + 默认选中索引。
+
+    有真实 store → root→HEAD 链（payload = node_id，恢复 = 对话+代码）；否则回退到
+    history 现算（payload = 回退轮数 n / None，仅对话恢复，兼容尚无 checkpoint 的会话）。"""
+    store = getattr(sess, "store", None)
+    if store is not None and store.nodes and store.head in store.nodes:
+        now = time.time()
+        entries = []
+        for nid in store.linear_path():
+            nd = store.nodes[nid]
+            cur = nid == store.head
+            entries.append((
+                _rw_node_line(nd["title"], _rw_changed_files(store, nid),
+                              int(now - nd.get("created", now)),
+                              current=cur, glyph=("●" if cur else "○")),
+                nid,
+            ))
+        return entries, len(entries) - 1
+    entries = []
+    for nd in _rw_collect(sess):
+        cur = nd["kind"] == "current"
+        line = Text()
+        if cur:
+            line.append("● 当前位置", style=f"bold {C_GREEN}")
+        else:
+            line.append(f"↩ 回退 {nd['n']} 轮  ", style=C_AMBER)
+            line.append(nd["title"], style=C_FG)
+        t = _rw_rel_time(nd["ago"])
+        if t:
+            line.append(f"   {t}", style=C_DIM)
+        fs = _rw_files_summary(nd["files"])
+        if fs:
+            line.append(f"   {fs}", style=C_DIM)
+        entries.append((line, nd["n"]))
+    return entries, len(entries) - 1
+
+
+def _rw_entries_tree(sess):
+    """树状条目 `[(Text, payload)]` + 默认选中(HEAD)索引。DFS 走真实 store 树,
+    用 ├─/╰─ 连线 + 缩进表达分支(fork 后即可见);无 store 时回退到线性。"""
+    store = getattr(sess, "store", None)
+    if not (store is not None and store.nodes and store.root_id in store.nodes):
+        return _rw_entries_linear(sess)
+    now = time.time()
+    entries = []
+    sel = [0]
+
+    def dfs(nid, prefix, is_last, depth):
+        nd = store.nodes[nid]
+        cur = nid == store.head
+        line = Text()
+        if prefix:
+            line.append(prefix, style=C_DIM)
+        if depth > 0:
+            line.append("╰─ " if is_last else "├─ ", style=C_DIM)
+        line.append("● " if cur else "○ ", style=(f"bold {C_GREEN}" if cur else C_BLUE))
+        line.append(nd["title"] or "（空）", style=(f"bold {C_GREEN}" if cur else C_FG))
+        t = _rw_rel_time(int(now - nd.get("created", now)))
+        if t:
+            line.append(f"   {t}", style=C_DIM)
+        fs = _rw_files_summary(_rw_changed_files(store, nid))
+        if fs:
+            line.append(f"   {fs}", style=C_DIM)
+        if cur:
+            sel[0] = len(entries)
+        entries.append((line, nid))
+        child_prefix = prefix + ("   " if is_last else "│  ") if depth > 0 else prefix
+        kids = [c for c in nd["children"] if c in store.nodes]
+        for i, c in enumerate(kids):
+            dfs(c, child_prefix, i == len(kids) - 1, depth + 1)
+
+    dfs(store.root_id, "", True, 0)
+    return entries, sel[0]
+
+
+class RewindScreen(ModalScreen):
+    """checkpoint 选择面板(时间线 / 树共用)。`entries = [(Text, payload)]`;
+    Esc 取消(dismiss None);Enter/点击 dismiss 该条 payload(store 节点 id 或
+    回退轮数 n)。打开时默认选中当前(HEAD)。"""
+
+    CSS = """
+    RewindScreen { align: center middle; }
+    RewindScreen > Vertical {
+        width: 96; max-width: 92%; height: auto; max-height: 80%;
+        background: $ga-alt-bg; border: solid $ga-border; padding: 1 2;
+    }
+    RewindScreen .rw-head { color: $ga-fg; padding: 0 0 1 0; }
+    RewindScreen OptionList {
+        background: $ga-alt-bg; color: $ga-fg; height: auto; max-height: 1fr; padding: 0;
+    }
+    RewindScreen OptionList > .option-list--option-highlighted {
+        background: $ga-sel-bg; color: $ga-fg;
+    }
+    """
+    BINDINGS = [Binding("escape", "cancel", "Cancel", show=False)]
+
+    def __init__(self, entries, select_idx, title) -> None:
+        super().__init__()
+        # NB: 不要用 self._nodes —— 那是 Textual 的子节点 NodeList,覆盖会崩。
+        self._entries = entries
+        self._select = select_idx
+        self._title = title
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Static(self._title, classes="rw-head")
+            yield OptionList(id="rw-list")
+
+    def on_mount(self) -> None:
+        ol = self.query_one(OptionList)
+        for text, _payload in self._entries:
+            ol.add_option(Option(text))
+        if self._entries:
+            ol.highlighted = max(0, min(self._select, len(self._entries) - 1))
+        ol.focus()
+
+    def on_option_list_option_selected(self, ev) -> None:
+        self.dismiss(self._entries[ev.option_index][1])
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
 class GenericAgentTUI(App[None]):
 
     CSS = _MAIN_CSS
@@ -3566,6 +3850,8 @@ class GenericAgentTUI(App[None]):
             "new": self._cmd_new, "switch": self._cmd_switch, "close": self._cmd_close,
             "rename": self._cmd_rename,
             "branch": self._cmd_branch, "rewind": self._cmd_rewind, "clear": self._cmd_clear,
+            "worldline": self._cmd_rewind_tree,        # 世界线(树状回退)
+            "rewind-tree": self._cmd_rewind_tree,      # 旧名,保留为静默别名
             "stop": self._cmd_stop, "llm": self._cmd_llm, "model": self._cmd_model,
             "effort": self._cmd_effort,
             "export": self._cmd_export,
@@ -3789,9 +4075,21 @@ class GenericAgentTUI(App[None]):
         except Exception:
             pass
         sess = AgentSession(agent_id=agent_id, name=name or f"agent-{agent_id}", agent=agent)
+        # Rewind 后端:每 session 一个 checkpoint 树 + blob 库,key 对齐 agent.log_path
+        # (GA 稳定会话身份)。cwd = temp(与 GA handler 解析相对路径的基准一致,
+        # 见 agentmain GenericAgentHandler(..., temp))。store 挂到 agent 上供全局
+        # tool_before 钩子按 agent 路由。
+        try:
+            temp_dir = os.path.normpath(os.path.join(FRONTENDS_DIR, '..', 'temp'))
+            log_path = getattr(agent, 'log_path', '') or f'sess_{os.getpid()}_{agent_id}'
+            sess.store = RewindStore.for_log(temp_dir, log_path, temp_dir)
+            agent._rw_store = sess.store
+        except Exception:
+            sess.store = None
+        self._install_rw_tool_hook()
         try:
             from continue_cmd import acquire_birth_lock
-            acquire_birth_lock(agent, agent_id)   # 原地复原:出生持锁,使占用检测对本会话可见
+            acquire_birth_lock(agent, agent_id)   # 原地复原:出生持锁,占用检测可见
         except Exception:
             pass
         thread = threading.Thread(target=agent.run, name=f"ga-tui-agent-{agent_id}", daemon=True)
@@ -3802,6 +4100,7 @@ class GenericAgentTUI(App[None]):
         self._install_ask_user_hook(sess)
         self._install_intervene_replay_hook(sess)
         self._install_write_snapshot_hook()
+        self._install_rw_time_hook(sess)
         self._refresh_all()
         return sess
 
@@ -3954,6 +4253,76 @@ class GenericAgentTUI(App[None]):
         except Exception:
             pass
 
+
+    _rw_tool_hook_installed = False
+
+    def _install_rw_tool_hook(self) -> None:
+        """全局注册一次 `tool_before` 钩子(plugins.hooks):在 file_write/file_patch
+        真写盘**之前**,把目标文件的「改前内容」存进对应 session 的 store(track_pre_edit)。
+
+        注册表是全局的(非 per-session),回调对所有 agent 触发 → 靠 ctx 的
+        `self.parent`(GenericAgent)上挂的 `_rw_store` 路由到正确 session。
+        回调跑在 agent 线程;每 agent 独占自己的 store,无跨线程竞争。"""
+        if GenericAgentTUI._rw_tool_hook_installed:
+            return
+        try:
+            from plugins import hooks as _ph
+
+            def _rw_tool_before(ctx):
+                try:
+                    if (ctx or {}).get("tool_name") not in ("file_write", "file_patch"):
+                        return ctx
+                    handler = ctx.get("self")
+                    args = ctx.get("args") or {}
+                    path = args.get("path")
+                    store = getattr(getattr(handler, "parent", None), "_rw_store", None)
+                    if store is not None and path:
+                        store.track_pre_edit(handler._get_abs_path(path))
+                except Exception:
+                    pass
+                return ctx
+
+            _ph.register("tool_before")(_rw_tool_before)
+            GenericAgentTUI._rw_tool_hook_installed = True
+        except Exception:
+            pass
+
+    def _rw_commit(self, sess: AgentSession) -> None:
+        """用户提问段完成时落一个 checkpoint 节点(对话推进也算 checkpoint)。
+
+        title 取本次用户输入;传整条 `backend.history` 给 store —— commit 会切本轮
+        增量 `history[parent.hist_len:]` 存成 conv blob(树=真相源),恢复时按路径拼回。
+        store 故障一律静默(rewind 是旁路安全网,绝不冒泡打断任务收尾)。"""
+        store = getattr(sess, "store", None)
+        if store is None:
+            return
+        try:
+            title = (getattr(sess, "_rw_title", "") or "checkpoint").replace("\n", " ").strip()[:80]
+            history = sess.agent.llmclient.backend.history
+            store.commit(title or "checkpoint", history=history)
+            store._rw_cursor = None   # 继续提问 → 新末端成为当前,清除 rewind 游标
+        except Exception:
+            pass
+
+    def _install_rw_time_hook(self, sess: AgentSession) -> None:
+        """Stamp wall-clock per turn-end, keyed by LLM-history length, so the
+        /rewind panels can show coarse relative time. GA stores no timestamps;
+        nodes predating this session (e.g. restored via /continue) show none.
+        Hook runs in the agent thread — dict writes are GIL-safe."""
+        agent = sess.agent
+        sess._rw_times = {}
+        try:
+            hooks = getattr(agent, "_turn_end_hooks", None)
+            if hooks is None:
+                hooks = agent._turn_end_hooks = {}
+            def _hook(ctx, _s=sess, _a=agent):
+                try: _s._rw_times[len(_a.llmclient.backend.history)] = time.time()
+                except Exception: pass
+            hooks["_ga_tui_rw_time"] = _hook
+        except Exception:
+            pass
+
+
     def _install_ask_user_hook(self, sess: AgentSession) -> None:
         """Capture ask_user INTERRUPT payloads from agent_loop's turn_end hook.
 
@@ -3992,6 +4361,10 @@ class GenericAgentTUI(App[None]):
         self._system(f"Created session #{sess.agent_id} — {sess.name}")
 
     def action_prev_session(self) -> None:
+        # ctrl+up 是 app 级 priority 绑定,会盖过 ModalScreen;世界线屏激活时把它
+        # 转交给屏内「移动非聚焦窗↑」(否则在三栏里 ctrl+↑ 变成切换会话)。
+        if isinstance(self.screen, RewindTreeScreen):
+            self.screen.action_other_up(); return
         ids = sorted(self.sessions.keys())
         if len(ids) <= 1: return
         i = ids.index(self.current_id)
@@ -3999,6 +4372,8 @@ class GenericAgentTUI(App[None]):
         self._refresh_all()
 
     def action_next_session(self) -> None:
+        if isinstance(self.screen, RewindTreeScreen):
+            self.screen.action_other_down(); return
         ids = sorted(self.sessions.keys())
         if len(ids) <= 1: return
         i = ids.index(self.current_id)
@@ -4282,6 +4657,10 @@ class GenericAgentTUI(App[None]):
         return t
 
     def action_complete_command(self) -> None:
+        # `tab` 是 app 级 priority 绑定(命令补全),会盖过 ModalScreen 的 on_key;
+        # 世界线屏激活时把 Tab 转交给它的「切聚焦」(否则 Tab 在三栏里被补全吞掉)。
+        if isinstance(self.screen, RewindTreeScreen):
+            self.screen.action_focus_toggle(); return
         palette = self.query_one("#palette", OptionList)
         if not palette.has_class("-visible"):
             return
@@ -4891,34 +5270,171 @@ class GenericAgentTUI(App[None]):
         self._system(f"Branched #{old.agent_id} → #{new.agent_id} ({n} msgs).")
 
     def _cmd_rewind(self, args, raw):
+        # 外观:对话流内联选择卡片(旧版样式)。行为:有世界线树时走【持久】通道
+        # (_rw_restore_node→restore_plan,仅对话,落盘 tree HEAD + 重写投影日志,
+        # continue 后不复活);无树才兜底用内存级 _do_rewind(非持久)。代码恢复 /
+        # 分支树视图走 /worldline。
         sess = self.current
         if sess.status == "running":
             self._system("Cannot rewind while running. /stop first."); return
-        turns = self._rewindable_turns()
-        if not turns:
-            self._system("No rewindable turns."); return
-        if args:
+        store = getattr(sess, "store", None)
+        history = sess.agent.llmclient.backend.history
+        # 先对账:让树对齐当前对话(顺带防外部 UI 改写日志的灾难),再按树的线性路径
+        # 建卡片,每个选项 = 一个真实节点 → 选中即可持久回退。
+        nodes = []   # [(node_id, title)] 最近→最旧,不含 origin
+        if store is not None:
+            try: store.reconcile(history)
+            except Exception: pass
+            if store.nodes and store.head in store.nodes:
+                for nid in store.linear_path():
+                    if store.nodes[nid].get("kind") == "origin":
+                        continue
+                    nodes.append((nid, store.nodes[nid].get("title") or "（空）"))
+                nodes.reverse()
+        if nodes:                                   # 持久路径
+            payloads = [nid for nid, _ in nodes]
+            previews = [t for _, t in nodes]
+            durable = True
+        else:                                       # 兜底:无 store/无真实提问 → 内存级
+            turns = self._rewindable_turns()
+            if not turns:
+                self._system("No rewindable turns."); return
+            rec = list(reversed(turns))
+            payloads = [i + 1 for i in range(len(rec))]   # 回退轮数 n
+            previews = [p for _, p in rec]
+            durable = False
+        total = len(payloads)
+        if args:                                    # /rewind n 直接回退,不弹卡片
             try: n = int(args[0])
-            except ValueError: self._system("Usage: /rewind <n>"); return
-            if n < 1 or n > len(turns):
-                self._system(f"Invalid: 1-{len(turns)}"); return
-            self._system(self._do_rewind(n))
+            except ValueError: self._system("Usage: /rewind [n]"); return
+            if n < 1 or n > total:
+                self._system(f"Invalid: 1-{total}"); return
+            if durable:
+                self._system(self._rw_restore_node(sess, payloads[n - 1], mode="conv", to="before"))
+            else:
+                self._system(self._do_rewind(payloads[n - 1]))
             return
         LIMIT = 20
-        recent = list(reversed(turns))[:LIMIT]
         choices = []
-        for offset, (_, prev) in enumerate(recent, 1):
-            preview = (prev or "（空）").replace("\n", " ").strip()[:60]
-            choices.append((f"回退 {offset} 轮 · {preview}", offset))
+        for offset in range(1, min(total, LIMIT) + 1):
+            preview = (previews[offset - 1] or "（空）").replace("\n", " ").strip()[:60]
+            choices.append((f"回退 {offset} 轮 · {preview}", payloads[offset - 1]))
         head = "选择回退到的轮次 (↑/↓ 移动，→/Enter 确认，Esc 取消)"
-        if len(turns) > LIMIT:
-            head += f"  [仅显示最近 {LIMIT}/{len(turns)}]"
-        msg = ChatMessage(
-            role="system", content=head, kind="choice", choices=choices,
-            on_select=lambda v: self._do_rewind(v),
-        )
+        if total > LIMIT:
+            head += f"  [仅显示最近 {LIMIT}/{total}]"
+        if durable:
+            on_sel = lambda v: self._rw_restore_node(sess, v, mode="conv", to="before")
+        else:
+            on_sel = lambda v: self._do_rewind(v)
+        msg = ChatMessage(role="system", content=head, kind="choice",
+                          choices=choices, on_select=on_sel)
         sess.messages.append(msg)
         self._refresh_messages()
+
+    def _cmd_rewind_tree(self, args, raw):
+        sess = self.current
+        if sess.status == "running":
+            self._system("Cannot rewind while running. /stop first."); return
+        store = getattr(sess, "store", None)
+        if store is None:
+            self._system("No rewindable checkpoints."); return
+        # 打开即对账:把 live history 中树尚未记录的尾部(别的 UI 续聊时追加的)吸收进树。
+        # 这是防灾的单一咽喉点——restore 只能从已打开的世界线屏发起,对账后树恒 ⊇ 日志,
+        # 故随后任何 rewind 都不可能用陈旧树 rewrite_projection 抹掉外部轮次。
+        # 也统一了「空 store / 老会话」:n=0 即把整条历史合成为 conv-only 主干(界面不降级)。
+        try:
+            store.reconcile(sess.agent.llmclient.backend.history)
+        except Exception:
+            pass  # 对账失败不阻断;下面守卫兜底
+        if not (store.nodes and store.root_id in store.nodes):
+            self._system("No rewindable checkpoints."); return  # 连一轮真实提问都没有
+        # 三栏全屏可视化器(§3–§7):左压缩树 / 右上折叠段 / 右下详情+操作。
+        self.push_screen(RewindTreeScreen(store), self._on_rewind_tree_result)
+
+    def _on_rewind_pick(self, payload) -> None:
+        # 面板回调:None=取消;str=store 节点 id(恢复对话+代码);int=history 回退轮数。
+        if payload is None:
+            return
+        sess = self.current
+        if isinstance(payload, str):
+            self._system(self._rw_restore_node(sess, payload))
+        else:
+            self._system(self._do_rewind(payload))
+
+    def _on_rewind_tree_result(self, result) -> None:
+        # 三栏屏回调:None=取消/已内联处理(diff/delete);dict=恢复请求。
+        if not isinstance(result, dict) or result.get("action") != "restore":
+            return
+        self._system(self._rw_restore_node(self.current, result.get("node"),
+                                           mode=result.get("mode", "both"),
+                                           to=result.get("to", "before")))
+
+    def _rw_restore_node(self, sess, node_id, mode: str = "both", to: str = "before") -> str:
+        """恢复到某节点(薄封装)。**编排在 `worldline.restore_plan`**(UI 无关:算出回退后
+        的对话/文件/prefill,并落地——改文件 + 移 HEAD + 重写投影);本方法只做 TUI 侧刷新:
+        把 history 赋回 backend、重组界面消息、prefill 输入框、重挂。
+
+        to: before(回到该提问之前 + prefill) / at(在该节点继续,无 prefill);
+        mode: both/conv/code。需 agent 空闲(调用方已保证)。"""
+        store = getattr(sess, "store", None)
+        log_path = getattr(sess.agent, "log_path", "") or ""
+        hist = sess.agent.llmclient.backend.history
+        old_len = len(hist)
+        res = restore_plan(store, node_id, mode=mode, to=to, log_path=log_path)
+        if res is None:
+            return "❌ 无效的 checkpoint"
+        # rewind 游标:to=before(回到 X 之前,内部 HEAD=parent)时,用户心中「当前」仍是
+        # 选中的 X → 记下供世界线面板把 ◉ 标在 X(下次打开仍停在 X)。to=at 则就在该节点,
+        # 用 HEAD 即可。继续提问(commit)时清除。
+        try:
+            store._rw_cursor = node_id if (to == "before") else None
+        except Exception:
+            pass
+        removed = 0
+        if res["history"] is not None:           # 对话有变更(both/conv)
+            hist[:] = res["history"]
+            removed = max(0, old_len - len(res["history"]))
+            self._rw_rebuild_display(sess)        # 从重写后的投影重组界面历史消息
+        self._remount_current_session()
+        self._refresh_topbar()
+        self._refresh_sidebar()
+        if res["prefill"]:
+            self._rw_prefill_input(res["prefill"])
+        label = {"both": "对话+代码", "conv": "仅对话", "code": "仅代码"}.get(mode, mode)
+        at_origin, title = res["at_origin"], res["title"]
+        if to == "at":
+            where = "空起点" if at_origin else f"「{title}」之后（在此继续）"
+        else:
+            where = "空起点" if at_origin else f"「{title}」之前"
+        return (f"↩ 已回退到{where}（{label}）：清除 {removed} 条上下文，"
+                f"代码恢复 {len(res['changed'])} 个文件")
+
+    def _rw_rebuild_display(self, sess) -> None:
+        """rewind 后重组**界面历史消息**:从已重写成新 HEAD 路径的投影日志重新解析
+        (复用 /continue 的 `extract_ui_messages`,与其它视角同一套渲染),替换
+        `sess.messages`。随后由 `_remount_current_session` 重挂显示。
+
+        没这步的话,backend.history 已回退但屏幕上还停留在旧对话。故障静默降级。"""
+        log_path = getattr(sess.agent, "log_path", "") or ""
+        if not log_path:
+            return
+        try:
+            rebuilt = [ChatMessage(role=h["role"], content=h["content"])
+                       for h in continue_extract(log_path)]
+            sess.messages.clear()
+            sess.messages.extend(rebuilt)
+        except Exception:
+            pass
+
+    def _rw_prefill_input(self, text: str) -> None:
+        try:
+            inp = self.query_one("#input", InputArea)
+            inp.text = text
+            inp.move_cursor((inp.document.line_count - 1, len(text.split("\n")[-1])))
+            inp.focus()
+            self._resize_input(inp)
+        except Exception:
+            pass
 
     def _rewindable_turns(self) -> list[tuple[int, str]]:
         history = self.current.agent.llmclient.backend.history
@@ -5225,13 +5741,18 @@ class GenericAgentTUI(App[None]):
         display_text = raw.strip() if (raw or "").strip() else "/review"
         self.submit_user_message(prompt, display_text=display_text)
 
+    def _rw_rewind_root(self):
+        """世界线树根目录(temp/.ga_rewind),供 continue_list 树感知发现"已回退至起点"的空会话。"""
+        return os.path.join(os.path.normpath(os.path.join(FRONTENDS_DIR, '..', 'temp')), '.ga_rewind')
+
     def _cmd_continue(self, args, raw):
         sess = self.current
         m = re.match(r"/continue\s+(\S.*?)\s*$", (raw or "").strip())
         if m:
             token = m.group(1)
             if token.isdigit():
-                sessions = continue_list(exclude_log=os.path.basename(getattr(sess.agent, "log_path", "") or ""))
+                sessions = continue_list(exclude_log=os.path.basename(getattr(sess.agent, "log_path", "") or ""),
+                                 rewind_root=self._rw_rewind_root())
                 idx = int(token) - 1
                 if not (0 <= idx < len(sessions)):
                     self._system(f"❌ 索引越界（有效范围 1-{len(sessions)}）"); return
@@ -5250,7 +5771,8 @@ class GenericAgentTUI(App[None]):
                 self._system(f"❌ 找不到名为 {token!r} 的会话"); return
             self._do_continue_restore(path)
             return
-        sessions = continue_list(exclude_log=os.path.basename(getattr(sess.agent, "log_path", "") or ""))
+        sessions = continue_list(exclude_log=os.path.basename(getattr(sess.agent, "log_path", "") or ""),
+                                 rewind_root=self._rw_rewind_root())
         if not sessions:
             self._system("❌ 没有可恢复的历史会话"); return
         choices = []
@@ -5307,9 +5829,9 @@ class GenericAgentTUI(App[None]):
         import continue_cmd as _cc
         try:
             if copy:
-                result, ok = _cc.continue_copy(sess.agent, path, sess.agent_id)
+                result, ok = _cc.continue_copy(sess.agent, path, sess.agent_id, allow_empty=True)
             else:
-                result, ok = _cc.continue_inplace(sess.agent, path, sess.agent_id)
+                result, ok = _cc.continue_inplace(sess.agent, path, sess.agent_id, allow_empty=True)
         except Exception as e:
             msg = f"❌ 恢复失败: {e}"
             self._system(msg); return msg
@@ -5317,6 +5839,22 @@ class GenericAgentTUI(App[None]):
             self._system(result); return result
         # 原地:new_log == path(接管原文件);拷贝:new_log 是内容相同的新副本。
         new_log = getattr(sess.agent, "log_path", "") or ""
+        # 世界线树:重建 store 指向新 log_path;拷贝时再 resume_from 把源会话的树搬过来
+        # (原地直接指向 X 那棵树,无需搬)。
+        try:
+            temp_dir = os.path.normpath(os.path.join(FRONTENDS_DIR, '..', 'temp'))
+            sess.store = RewindStore.for_log(temp_dir, new_log, temp_dir)
+            sess.agent._rw_store = sess.store
+            if copy:
+                old_root = os.path.normpath(os.path.join(
+                    temp_dir, '.ga_rewind', RewindStore.key_for_log(path)))
+                sess.store.resume_from(old_root)
+            # 接管后立即对账:此刻 backend.history 已是日志全量(continue_* 末尾 _load_history_into)。
+            # 若源日志曾被不更新树的 UI 续写,树会滞后于日志 → 在这里吸收尾部,使树 ⊇ 日志,
+            # 杜绝之后 rewind 用陈旧树回写、抹掉外部轮次的灾难。
+            sess.store.reconcile(sess.agent.llmclient.backend.history)
+        except Exception:
+            pass
         def _finish():
             sess.messages.clear()
             # Plan state belongs to the *previous* conversation. Clearing it
@@ -6071,6 +6609,7 @@ class GenericAgentTUI(App[None]):
         sess.current_task_id = tid
         sess.buffer = ""
         sess.status = "running"
+        sess._rw_title = text  # checkpoint 标题 = 本次用户输入(段末 commit 用)
         image_paths = list(images or [])
         visible_text = text if display_text is None else display_text
         sess.messages.append(ChatMessage("user", visible_text, image_paths=image_paths))
@@ -6142,6 +6681,7 @@ class GenericAgentTUI(App[None]):
             s.current_display_queue = None
         self._update_assistant(agent_id, text, task_id=task_id, done=done, refresh_chrome=True)
         if done:
+            self._rw_commit(s)   # 落 checkpoint 节点(文件改动已由 tool_before 钩子追踪)
             self._update_plan_state(s, text)
             self._drain_ask_user_events(s)
 
@@ -7408,6 +7948,734 @@ def _warn_mintty():
         )
         if not os.environ.get('GA_TUI_FORCE'):
             raise SystemExit(1)
+
+
+
+#============================================================================
+# worldline three-pane tree UI (inlined from rewind_tree_view.py; colors follow v2 theme)
+#============================================================================
+LANE_COLORS = [C_BLUE, C_PURPLE, C_GREEN, C_CYAN, C_LAVENDER, C_AMBER]
+
+
+def lane_color(depth: int) -> str:
+    return LANE_COLORS[depth % len(LANE_COLORS)]
+
+
+KIND_COLOR = {"current": C_GREEN, "rewind": C_AMBER, "origin": C_FG}
+
+
+def kind_style(kind: str):
+    """(字形, 颜色, 标签):字形/标签取自后端语义,颜色由前端配色决定。
+    保留 3 元组形态,render_tree / 详情区调用点无需改动。"""
+    return kind_glyph(kind), KIND_COLOR.get(kind, C_FG), kind_label(kind)
+
+
+@dataclass
+class RenderRow:
+    key: int
+    depth: int
+    text: Text
+    node_start: int
+
+
+def render_tree(ct: CompressedTree, selected_key: int) -> List[RenderRow]:
+    rows: List[RenderRow] = []
+    sel_depth = ct.disp[selected_key].depth if selected_key in ct.disp else 0
+
+    def node_style(key: int, depth: int) -> tuple[str, str]:
+        d = ct.disp[key]
+        base = C_DIM if d.kind == "fold" else kind_style(ct.tree.nodes[d.node_id].kind)[1]
+        if key == selected_key:
+            return base, f"bold {base} on {C_ALT_BG}"
+        if depth == sel_depth:
+            return base, base
+        return base, C_DIM
+
+    def dfs(key: int, is_last: bool, prefix_active: List[bool]) -> None:
+        d = ct.disp[key]
+        line = Text()
+        for col, active in enumerate(prefix_active):
+            if not active:
+                line.append("   ")
+                continue
+            style = lane_color(col) if col == sel_depth else C_DIM
+            line.append("│  ", style=style)
+        if d.parent_key is not None:
+            connector = "╰─ " if is_last else "├─ "
+            cstyle = lane_color(d.depth) if d.depth == sel_depth else C_DIM
+            line.append(connector, style=cstyle)
+        base, gstyle = node_style(key, d.depth)
+        node_start = line.cell_len
+        line.append(ct.glyph(key), style=gstyle)
+        line.append(" ")
+        lbl_style = f"bold {C_FG} on {C_ALT_BG}" if key == selected_key else (
+            base if d.depth == sel_depth else C_MUTED)
+        line.append(ct.label(key), style=lbl_style)
+        line.append(f"   {rel_time(ct.end_node(key).ago)}", style=C_DIM)
+        rows.append(RenderRow(key=key, depth=d.depth, text=line, node_start=node_start))
+        kids = d.children
+        child_prefix = prefix_active + [not is_last]
+        for i, ck in enumerate(kids):
+            dfs(ck, i == len(kids) - 1, child_prefix)
+
+    for i, rk in enumerate(ct.roots):
+        dfs(rk, i == len(ct.roots) - 1, [])
+    return rows
+
+# ------------------------------------------------------- Textual 部件
+class ClickableTree(Static):
+    class NodeClicked(Message):
+        def __init__(self, key: int) -> None:
+            self.key = key
+            super().__init__()
+
+    def __init__(self, **kw) -> None:
+        super().__init__("", **kw)
+        self.rows: List[RenderRow] = []
+
+    def set_rows(self, rows: List[RenderRow]) -> None:
+        self.rows = rows
+        body = Text("\n").join(r.text for r in rows) if rows else Text("")
+        body.no_wrap = True  # 禁折行:窄窗靠横向 viewport,绝不折行(否则连线错位)
+        self.update(body)
+
+    def on_click(self, event) -> None:
+        off = event.get_content_offset(self)
+        if off is None:
+            return
+        if 0 <= off.y < len(self.rows) and off.x >= self.rows[off.y].node_start:
+            event.stop()
+            self.post_message(self.NodeClicked(self.rows[off.y].key))
+
+
+class ClickableList(Static):
+    class SegClicked(Message):
+        def __init__(self, index: int) -> None:
+            self.index = index
+            super().__init__()
+
+    def __init__(self, **kw) -> None:
+        super().__init__("", **kw)
+        self.idxs: List[Optional[int]] = []
+
+    def set_content(self, text: Text, idxs: List[Optional[int]]) -> None:
+        self.idxs = idxs
+        self.update(text)
+
+    def on_click(self, event) -> None:
+        off = event.get_content_offset(self)
+        if off is None:
+            return
+        y = off.y
+        if 0 <= y < len(self.idxs) and self.idxs[y] is not None:
+            event.stop()
+            self.post_message(self.SegClicked(self.idxs[y]))
+
+
+class RestoreModeScreen(ModalScreen):
+    """CC 式回退模式选择弹窗:在世界线里 Enter 选中节点后弹出,选恢复模式。
+
+    dismiss 返回 `"both"|"conv"|"code"` 或 None(取消)。`to` 决定文案:
+    `at`=在此节点继续(HEAD→该节点);`before`=回到该提问之前。"""
+
+    CSS = f"""
+    RestoreModeScreen {{ align: center middle; }}
+    #rmode_box {{
+        width: 50; height: auto; padding: 1 2;
+        border: round {C_GREEN}; background: {C_SEL_BG};
+    }}
+    RestoreModeScreen Static {{ background: transparent; }}
+    """
+    BINDINGS = [
+        Binding("up,k", "up", "↑", priority=True),
+        Binding("down,j", "down", "↓", priority=True),
+        Binding("enter", "confirm", "确认", priority=True),
+        Binding("c", "pick_conv", "仅对话", priority=True),
+        Binding("o", "pick_code", "仅代码", priority=True),
+        Binding("escape", "cancel", "取消", priority=True),
+    ]
+    _OPTS = [("both", "恢复对话 + 代码"), ("conv", "仅对话"), ("code", "仅代码")]
+
+    def __init__(self, title: str, to: str) -> None:
+        super().__init__()
+        self._title = title
+        self._to = to
+        self.sel = 0
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="rmode_box"):
+            yield Static("", id="rmode_body")
+
+    def on_mount(self) -> None:
+        self._redraw()
+
+    def _redraw(self) -> None:
+        body = Text()
+        verb = "在此继续会话" if self._to == "at" else "回到此提问之前"
+        body.append(f"{verb}：", style=C_BLUE)
+        body.append(f"{ellipsize(self._title, 28)}\n\n", style=f"bold {C_FG}")
+        for i, (_, lbl) in enumerate(self._OPTS):
+            active = i == self.sel
+            body.append("▶ " if active else "  ", style=C_GREEN if active else C_DIM)
+            body.append(lbl + "\n",
+                        style=f"bold {C_FG} on {C_ALT_BG}" if active else C_MUTED)
+        body.append("\n↑↓ 选择   Enter 确认   c 仅对话   o 仅代码   Esc 取消", style=C_DIM)
+        self.query_one("#rmode_body", Static).update(body)
+
+    def action_up(self) -> None:
+        self.sel = (self.sel - 1) % len(self._OPTS); self._redraw()
+
+    def action_down(self) -> None:
+        self.sel = (self.sel + 1) % len(self._OPTS); self._redraw()
+
+    def action_confirm(self) -> None:
+        self.dismiss(self._OPTS[self.sel][0])
+
+    def action_pick_conv(self) -> None:
+        self.dismiss("conv")
+
+    def action_pick_code(self) -> None:
+        self.dismiss("code")
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
+class RewindTreeScreen(ModalScreen):
+    """三栏全屏 checkpoint 浏览器(世界线)。dismiss 结果:
+    `{"action":"restore","mode":"both"|"conv"|"code","node":nid,"to":"before"|"at"}`
+    或 None(取消)。`to=before`=回到该提问之前(prefill);`to=at`=在该节点继续
+    (HEAD→该节点,无 prefill,= tip「当前位置/新分支」)。
+    diff / delete 在屏内直接读/改 store(delete 后重建树)。"""
+
+    CSS = f"""
+    RewindTreeScreen {{ background: {C_BG}; }}
+    * {{
+        scrollbar-background: {C_BG};
+        scrollbar-color: {C_BORDER};
+        scrollbar-color-hover: {C_DIM};
+        scrollbar-color-active: {C_DIM};
+        scrollbar-corner-color: {C_BG};
+    }}
+    /* ModalScreen defaults to height:auto + a centered dialog box, which
+       collapses our %/fr-based three-pane layout into a small popup. Force the
+       screen to fill the terminal and give the top Horizontal the full height so
+       the panes' percentages resolve against a real size again. */
+    RewindTreeScreen {{ height: 100%; overflow: hidden; }}
+    RewindTreeScreen > Horizontal {{ height: 1fr; width: 100%; }}
+    #rw3_left {{
+        width: 44%; height: 1fr; border: round {C_BORDER}; border-title-color: {C_GREEN};
+        padding: 0 1; overflow-x: auto; overflow-y: auto;
+    }}
+    #rw3_lefttree {{ width: auto; height: auto; }}
+    #rw3_right {{ width: 1fr; height: 1fr; }}
+    #rw3_rtop {{
+        height: 50%; border: round {C_BORDER}; border-title-color: {C_BLUE};
+        padding: 0 1; overflow-y: auto;
+    }}
+    #rw3_rbot {{
+        height: 1fr; border: round {C_BORDER}; border-title-color: {C_PURPLE};
+        padding: 0 1;
+    }}
+    #rw3_rbot_body {{ height: auto; }}
+    #rw3_diff {{ height: 1fr; overflow-y: auto; overflow-x: auto; scrollbar-size-vertical: 1; }}
+    #rw3_diff_body {{ height: auto; width: auto; }}
+    RewindTreeScreen Static {{ background: transparent; }}
+    #rw3_status {{ height: 1; color: {C_DIM}; padding: 0 1; }}
+    """
+    BINDINGS = [
+        # 上下 = 移动**聚焦**窗口(左树按整树视觉行序 / 右上段内含 tip)。
+        Binding("up,k", "up", "↑", priority=True),
+        Binding("down,j", "down", "↓", priority=True),
+        # Ctrl+↑↓ = 移动**非聚焦**窗口(ctrl 在部分终端不可靠 → PgUp/PgDn、[ ] 兜底)。
+        Binding("ctrl+up,pageup,left_square_bracket", "other_up", "非聚焦↑", priority=True),
+        Binding("ctrl+down,pagedown,right_square_bracket", "other_down", "非聚焦↓", priority=True),
+        # ←/→ = 左树切换层级(列);Tab = 翻转聚焦框(另由 on_key 兜底,见下)。
+        Binding("left,h", "level_up", "上层", priority=True),
+        Binding("right,l", "level_down", "下层", priority=True),
+        Binding("tab", "focus_toggle", "切聚焦", priority=True),
+        # Enter:左聚焦 → 进入右侧节点选择;右聚焦 → 弹回退模式窗。
+        Binding("enter", "enter", "进入/回退", priority=True),
+        Binding("x", "delete", "删除子树"),
+        Binding("escape", "cancel", "取消"),
+    ]
+
+    def __init__(self, store) -> None:
+        super().__init__()
+        self.store = store
+        self.ct = CompressedTree(tree_from_store(store, __import__("time").time()))
+        self._mark_current()
+        flat = self.ct.flatten()
+        # 打开即聚焦到「当前位置」所在的显示节点(折叠组)。
+        self.sel_key = self._disp_key_for_node(self._current_node()) or (flat[0] if flat else 0)
+        self.focus_right = False
+        # 默认聚焦到「当前位置」(见 _default_seg_idx)。
+        self.seg_idx = self._default_seg_idx()
+        self._diff_for: Optional[str] = None  # 正在内联展示 diff 的节点 id
+
+    # ---- 当前位置:就一个游标。有游标=回退到的那个节点;没有=末端 tip ----
+    def _cursor(self):
+        """rewind 游标 = 被截断回退到的那个节点(用户心中的「当前位置」)。集成层在
+        rewind 时记到 store._rw_cursor,继续提问时清除。无效/无 → None(当前=末端 tip)。
+
+        一致性:从「当前位置」再进去要重现当前视图。rewind 到 X→视图=parent(X)前;
+        从 X 进去=rewind 到 X=同样视图 ✓。所以当前位置就是 X 本身。"""
+        cur = getattr(self.store, "_rw_cursor", None)
+        return cur if (cur and cur in self.store.nodes) else None
+
+    def _current_node(self):
+        """开屏定位用的「当前位置」节点:游标 or HEAD。"""
+        return self._cursor() or self.store.head
+
+    def _mark_current(self) -> None:
+        """◉「当前」只两种落点:有游标→标在游标节点;无游标→不标节点(末端 tip 承载)。
+        先撤掉 tree_from_store 给 HEAD 的自动 current。"""
+        head, nodes = self.store.head, self.ct.tree.nodes
+        if head in nodes:
+            nodes[head].kind = self.store.nodes.get(head, {}).get("kind") or "edit"
+        cur = self._cursor()
+        if cur and cur in nodes:
+            nodes[cur].kind = "current"
+
+    def _default_seg_idx(self) -> int:
+        """▶ 默认落「当前位置」:有游标→游标节点;无游标→末端 tip。"""
+        seg = self._current_seg()
+        if not seg:
+            return 0
+        cur = self._cursor()
+        if cur:
+            idx = seg.index(cur) if cur in seg else len(seg)
+        else:
+            idx = len(seg)
+        return min(idx, self._seg_max_idx(seg))   # 无 tip 的 origin 段:落到末项而非占位项
+
+    def _disp_key_for_node(self, node_id) -> Optional[int]:
+        """找包含 node_id 的显示节点 key(真实节点本身 / 折叠段含它)。"""
+        if node_id is None:
+            return None
+        for k, d in self.ct.disp.items():
+            if d.kind == "real" and d.node_id == node_id:
+                return k
+            if d.kind == "fold" and node_id in d.seg:
+                return k
+        return None
+
+    def _seg_of(self, key) -> List[str]:
+        d = self.ct.disp.get(key)
+        if d is None:
+            return []
+        return list(d.seg) if d.kind == "fold" else [d.node_id]
+
+    def compose(self) -> ComposeResult:
+        with Horizontal():
+            with ScrollableContainer(id="rw3_left"):
+                yield ClickableTree(id="rw3_lefttree")
+            with Vertical(id="rw3_right"):
+                with VerticalScroll(id="rw3_rtop"):
+                    yield ClickableList(id="rw3_rtop_body")
+                with Vertical(id="rw3_rbot"):
+                    yield Static("", id="rw3_rbot_body")
+                    with VerticalScroll(id="rw3_diff"):
+                        yield Static("", id="rw3_diff_body")
+        yield Static("", id="rw3_status")
+
+    def on_mount(self) -> None:
+        self.query_one("#rw3_left").border_title = "世界线 · 全局压缩树"
+        self.query_one("#rw3_rtop").border_title = "被折叠的节点"
+        self.query_one("#rw3_rbot").border_title = "详情 / 操作"
+        self.query_one("#rw3_rtop").can_focus = False
+        # 左栏设为可聚焦并**抓住焦点**:让本 modal 真正持有键盘。否则全部子组件
+        # can_focus=False → 焦点留在下层输入框,Tab 会被输入框的命令补全吃掉、屏的
+        # on_key 收不到(↑↓ 靠 priority binding 才照常生效)。聚焦框仍由
+        # _refresh_focus_frame 手动画(亮青边框),与 Textual 默认 focus 视觉无关。
+        left = self.query_one("#rw3_left")
+        left.can_focus = True
+        left.focus()
+        self.refresh_all()
+
+    # ---- 联动 ----
+    def _set_left_selection(self, key: int, keep_focus: bool = False) -> None:
+        """选中左树某显示节点。keep_focus=True 时不夺回聚焦(供 Ctrl 移动非聚焦左树)。
+        右上默认选中「当前(绿)记录」或最后一条真实记录(见 _default_seg_idx)。"""
+        self.sel_key = key
+        if not keep_focus:
+            self.focus_right = False
+        self.seg_idx = self._default_seg_idx()
+        self._diff_for = None
+        self.refresh_all()
+
+    def refresh_all(self) -> None:
+        rows = render_tree(self.ct, self.sel_key)
+        self.query_one("#rw3_lefttree", ClickableTree).set_rows(rows)
+        self._refresh_rtop()
+        self._refresh_rbot()
+        self._refresh_status()
+        self._refresh_focus_frame()
+        sel_idx = next((i for i, r in enumerate(rows) if r.key == self.sel_key), 0)
+        self._follow_left(rows, sel_idx)
+
+    def _refresh_focus_frame(self) -> None:
+        """聚焦框:聚焦窗口边框高亮(亮青),另一个用普通边框色。"""
+        try:
+            left = self.query_one("#rw3_left")
+            rtop = self.query_one("#rw3_rtop")
+            left.styles.border = ("round", C_BORDER if self.focus_right else C_CYAN)
+            rtop.styles.border = ("round", C_CYAN if self.focus_right else C_BORDER)
+        except Exception:
+            pass
+
+    def _follow_left(self, rows, sel_idx) -> None:
+        self._ensure_line_visible("#rw3_left", sel_idx)
+        try:
+            c = self.query_one("#rw3_left")
+            w = c.scrollable_size.width
+            if w <= 0 or sel_idx >= len(rows):
+                return
+            sx = int(c.scroll_offset.x)
+            x0 = rows[sel_idx].node_start
+            x1 = rows[sel_idx].text.cell_len
+            if x0 < sx or x0 >= sx + w:
+                c.scroll_to(x=max(0, x0 - 2), animate=False)
+            elif x1 > sx + w:
+                c.scroll_to(x=max(0, min(x0 - 2, x1 - w + 1)), animate=False)
+        except Exception:
+            pass
+
+    def _ensure_line_visible(self, selector, y) -> None:
+        try:
+            c = self.query_one(selector)
+            h = c.scrollable_size.height
+            if h <= 0:
+                return
+            sy = int(c.scroll_offset.y)
+            if y < sy:
+                c.scroll_to(y=y, animate=False)
+            elif y >= sy + h:
+                c.scroll_to(y=y - h + 1, animate=False)
+        except Exception:
+            pass
+
+    def _current_seg(self) -> List[str]:
+        return self._seg_of(self.sel_key)
+
+    def _tip_kind(self) -> str:
+        """末尾 tip 的语义:HEAD 是叶 且就是本段末端 → current(当前位置·自此继续);
+        否则 → new(自此另起一条对话)。HEAD 有后代(rewind 未继续)时,当前位置标在那个
+        中间节点本身(◉),tip 一律是 new。"""
+        if self._cursor():
+            return "new"               # 当前在游标节点(◉),末端一律 new
+        seg = self._current_seg()
+        # 无游标:本段末端就是 HEAD → 末端 tip 即「当前位置·自此继续」。
+        return "current" if (seg and seg[-1] == self.store.head) else "new"
+
+    def _seg_has_tip(self, seg=None) -> bool:
+        """段末是否显示「自此继续」占位项。会话起点(origin)不显示:选中 origin 项本身
+        即回到空起点,与「自此继续」语义重复。"""
+        seg = self._current_seg() if seg is None else seg
+        return not (seg and self.ct.tree.nodes[seg[-1]].kind == "origin")
+
+    def _seg_max_idx(self, seg=None) -> int:
+        """seg_idx 上界:有 tip → len(seg)(可停在占位项);无 tip → 最后一条真实项。"""
+        seg = self._current_seg() if seg is None else seg
+        return len(seg) if self._seg_has_tip(seg) else max(0, len(seg) - 1)
+
+    def _refresh_rtop(self) -> None:
+        d = self.ct.disp[self.sel_key]
+        seg = self._current_seg()
+        lines: List[Text] = []
+        idxs: List[Optional[int]] = []   # 行 → seg 索引(tip = len(seg)),None=不可选
+        lines.append(Text("选中某条提问可回退到其之前；末尾一项则从当前位置继续", style=C_DIM)); idxs.append(None)
+        lines.append(Text("")); idxs.append(None)
+        for i, nid in enumerate(seg):
+            n = self.ct.tree.nodes[nid]
+            active = i == self.seg_idx
+            g, gs, _ = kind_style(n.kind)
+            rs = (f"bold {C_FG} on {C_ALT_BG}" if active and self.focus_right
+                  else (C_FG if active else C_MUTED))
+            line = Text()
+            line.append("▶ " if active else "  ",
+                        style=(C_CYAN if self.focus_right else C_DIM) if active else C_DIM)
+            line.append(f"{g} ", style=C_GREEN if active else gs)
+            line.append(ellipsize(n.title, 54), style=rs)
+            line.append(f"   {rel_time(n.ago)}", style=C_DIM)
+            lines.append(line); idxs.append(i)
+        # 末尾占位项(尚未创建,用括号标注);圆点字形,颜色同普通记录(new)/绿(current)。
+        # 会话起点(origin)不显示此占位项(_seg_has_tip):选中 origin 项本身即回到空起点。
+        if self._seg_has_tip(seg):
+            tip_i = len(seg)
+            tk = self._tip_kind()
+            tip_active = tip_i == self.seg_idx
+            tlabel = "（当前位置 · 自此继续）" if tk == "current" else "（自此继续会话）"
+            glyph = "◉" if tk == "current" else "●"     # 当前位置用 ◉(同节点当前标记)
+            base = C_GREEN if tk == "current" else C_FG
+            trs = (f"bold {C_FG} on {C_ALT_BG}" if tip_active and self.focus_right
+                   else (base if tip_active else C_DIM))
+            tline = Text()
+            tline.append("▶ " if tip_active else "  ",
+                         style=(C_CYAN if self.focus_right else C_DIM) if tip_active else C_DIM)
+            tline.append(f"{glyph} ", style=C_GREEN if (tip_active or tk == "current") else C_DIM)
+            tline.append(tlabel, style=trs)
+            lines.append(tline); idxs.append(tip_i)
+        self.query_one("#rw3_rtop_body", ClickableList).set_content(
+            Text("\n").join(lines), idxs)
+
+    def _target_node(self) -> Optional[str]:
+        """diff/delete 的目标节点:右上选中段内节点 > 当前显示节点的叶(tip 也归叶)。"""
+        seg = self._current_seg()
+        if self.focus_right and self.seg_idx < len(seg):
+            return seg[self.seg_idx]
+        return seg[-1] if seg else None
+
+    def _restore_spec(self) -> "tuple[Optional[str], str]":
+        """恢复目标 (node_id, to):
+        - 段内节点(seg_idx<len) → ('before') 回到该提问之前 + prefill;
+        - tip(seg_idx==len)     → ('at') 在叶继续(HEAD→叶,无 prefill)。"""
+        seg = self._current_seg()
+        if not seg:
+            return None, "at"
+        if self.focus_right and self.seg_idx < len(seg):
+            return seg[self.seg_idx], "before"
+        return seg[-1], "at"
+
+    def _refresh_rbot(self) -> None:
+        seg = self._current_seg()
+        on_tip = self.seg_idx >= len(seg)
+        body = Text()
+        if on_tip:
+            tk = self._tip_kind()
+            tail = self.ct.tree.nodes[seg[-1]] if seg else None
+            if tk == "current":
+                body.append("（当前位置）\n", style=f"bold {C_GREEN}")
+                body.append("  已处于该对话最新处，发送消息即可继续。\n", style=C_MUTED)
+            else:
+                body.append("（自此继续会话）\n", style=f"bold {C_FG}")
+                body.append("  从这条记录之后继续对话。\n", style=C_MUTED)
+            if tail is not None:
+                body.append(f"  续接于      {ellipsize(tail.title, 40)}\n", style=C_MUTED)
+                body.append(f"  时间        {rel_time(tail.ago)}\n", style=C_MUTED)
+        else:
+            nid = seg[self.seg_idx]
+            n = self.ct.tree.nodes[nid]
+            _, color, kind_label = kind_style(n.kind)
+            body.append(f"{n.title}\n", style=f"bold {color}")
+            if kind_label:
+                body.append(f"  类型        {kind_label}\n", style=C_MUTED)
+            body.append(f"  时间        {rel_time(n.ago)}\n", style=C_MUTED)
+            body.append(f"  改动文件    {files_summary(n.files)}\n", style=C_MUTED)
+            body.append("  回退至此    清除本次提问及其后内容\n", style=C_DIM)
+
+        body.append("\n操作  ", style=C_DIM)
+        body.append(" Enter " + ("选择回退方式" if self.focus_right else "进入右栏选择"),
+                    style=f"{C_FG} on {C_SEL_BG}")
+        body.append("   x 删除节点\n", style=C_DIM)
+        body.append("(回退前自动保存还原点)", style=C_DIM)
+        self.query_one("#rw3_rbot_body", Static).update(body)
+        # 下方可滚动 diff 视窗:选中节点 vs 父节点(上一个状态)的逐行改动。
+        self._refresh_diff(None if on_tip else seg[self.seg_idx])
+
+    _DIFF_MAX_LINES = 500   # diff 视窗最多渲染这么多行,防超长文件卡渲染
+
+    def _render_node_diff(self, node_id):
+        """选中节点 vs 父节点的逐行 diff。返回 (Text, 总增行, 总删行)。"""
+        from difflib import SequenceMatcher
+        out = Text()
+        ins = dele = 0
+        emitted = 0
+        capped = False
+        for fi, f in enumerate(self.store.node_diff(node_id)):
+            a, b = f["old"].splitlines(), f["new"].splitlines()
+            groups = SequenceMatcher(None, a, b, autojunk=False).get_grouped_opcodes(3)
+            if not groups:
+                continue
+            if out:
+                out.append("\n")
+            out.append(f"{f['rel']}\n", style=f"bold {C_BLUE}")
+            for gi, group in enumerate(groups):
+                if gi:
+                    out.append("   ⋮\n", style=C_DIM)
+                for tag, i1, i2, j1, j2 in group:
+                    if tag == "equal":
+                        for k in range(i1, i2):
+                            if emitted < self._DIFF_MAX_LINES:
+                                out.append(f"   {a[k]}\n", style=C_MUTED); emitted += 1
+                            else:
+                                capped = True
+                    else:
+                        for k in range(i1, i2):
+                            dele += 1
+                            if emitted < self._DIFF_MAX_LINES:
+                                out.append(f" - {a[k]}\n", style=C_RED); emitted += 1
+                            else:
+                                capped = True
+                        for k in range(j1, j2):
+                            ins += 1
+                            if emitted < self._DIFF_MAX_LINES:
+                                out.append(f" + {b[k]}\n", style=C_GREEN); emitted += 1
+                            else:
+                                capped = True
+        if capped:
+            out.append(f"  …（已截断，仅显示前 {self._DIFF_MAX_LINES} 行）\n", style=C_AMBER)
+        return out, ins, dele
+
+    def _refresh_diff(self, node_id) -> None:
+        dbody = Text()
+        if node_id is None:                      # 占位项(自此继续/当前位置):diff 视窗留空
+            pass
+        else:
+            diff, ins, dele = self._render_node_diff(node_id)
+            dbody.append(f"+{ins} ", style=f"bold {C_GREEN}")
+            dbody.append(f"-{dele}", style=f"bold {C_RED}")
+            dbody.append("   本次改动（对比上一个状态）\n", style=C_DIM)
+            dbody.append(diff if (ins or dele) else Text("  本次无文件改动（仅对话）", style=C_DIM))
+        self.query_one("#rw3_diff_body", Static).update(dbody)
+        try:
+            self.query_one("#rw3_diff").scroll_home(animate=False)   # 切节点后回到 diff 顶部
+        except Exception:
+            pass
+
+    def _refresh_status(self) -> None:
+        where = "右栏" if self.focus_right else "左树"
+        self.query_one("#rw3_status", Static).update(Text(
+            f" 聚焦:{where} | 共 {len(self.ct.flatten())}/{len(self.ct.tree.nodes)} | "
+            f"↑↓ 当前栏   Ctrl↑↓(/PgUp·Dn/[ ]) 另一栏   ←→ 切层级   Tab 切聚焦   "
+            f"Enter 进入/回退   x 删   Esc", style=C_DIM))
+
+    # ---- 导航:上下=聚焦窗 / Ctrl上下=非聚焦窗 / Tab·←→=切聚焦 ----
+    def action_up(self) -> None:
+        if self.focus_right: self._move_right(-1)
+        else: self._move_left(-1, keep_focus=False)
+
+    def action_down(self) -> None:
+        if self.focus_right: self._move_right(+1)
+        else: self._move_left(+1, keep_focus=False)
+
+    def action_other_up(self) -> None:
+        if self.focus_right: self._move_left(-1, keep_focus=True)
+        else: self._move_right(-1)
+
+    def action_other_down(self) -> None:
+        if self.focus_right: self._move_left(+1, keep_focus=True)
+        else: self._move_right(+1)
+
+    def _move_left(self, delta: int, keep_focus: bool) -> None:
+        order = self.ct.flatten()
+        if self.sel_key not in order:
+            return
+        i = order.index(self.sel_key)
+        j = max(0, min(i + delta, len(order) - 1))
+        if j != i:
+            self._set_left_selection(order[j], keep_focus=keep_focus)
+
+    def _move_right(self, delta: int) -> None:
+        n = self._seg_max_idx()               # 索引 0..n,n=tip(无 tip 的 origin 段则到末项)
+        self.seg_idx = max(0, min(self.seg_idx + delta, n))
+        self._diff_for = None
+        self._refresh_rtop(); self._refresh_rbot(); self._refresh_status()
+        self._ensure_line_visible("#rw3_rtop", self.seg_idx + 3)
+
+    def _set_focus(self, right: bool) -> None:
+        self.focus_right = right
+        if right:
+            self.seg_idx = min(self.seg_idx, self._seg_max_idx())  # 越界落到 tip(或末项)
+        self._diff_for = None
+        self._refresh_rtop(); self._refresh_rbot(); self._refresh_status()
+        self._refresh_focus_frame()
+
+    def action_focus_toggle(self) -> None:
+        self._set_focus(not self.focus_right)
+
+    def on_key(self, event) -> None:
+        # Tab 兜底:真终端里 Tab 会被 Textual 的焦点遍历系统吃掉(headless 正常),
+        # 故在 on_key 直接拦截,prevent_default 阻止默认焦点移动。
+        if event.key in ("tab", "shift+tab"):
+            event.prevent_default()
+            event.stop()
+            self.action_focus_toggle()
+
+    def _order(self):
+        return _order_depths(self.ct)
+
+    def action_level_up(self) -> None:
+        # ←:左树切到上一层级(列);回到左聚焦。
+        self._set_left_selection(nearest_depth_node(self._order(), self.sel_key, -1))
+
+    def action_level_down(self) -> None:
+        self._set_left_selection(nearest_depth_node(self._order(), self.sel_key, +1))
+
+    def action_enter(self) -> None:
+        # 左聚焦:进入右侧节点选择;右聚焦:弹回退模式窗。
+        if not self.focus_right:
+            self._set_focus(True)
+        else:
+            self._open_restore_popup()
+
+    # ---- 操作 actions ----
+    def _open_restore_popup(self) -> None:
+        """右聚焦时 Enter:弹 CC 式回退模式窗,选定后再 dismiss(带 mode + to)。"""
+        node_id, to = self._restore_spec()
+        if node_id is None:
+            return
+        self._pending = (node_id, to)
+        title = self.ct.tree.nodes[node_id].title if node_id in self.ct.tree.nodes else ""
+        self.app.push_screen(RestoreModeScreen(title, to), self._on_mode_picked)
+
+    def _on_mode_picked(self, mode) -> None:
+        if not mode:
+            return
+        node_id, to = getattr(self, "_pending", (None, "at"))
+        if node_id is None:
+            return
+        self.dismiss({"action": "restore", "mode": mode, "node": node_id, "to": to})
+
+    def action_delete(self) -> None:
+        tgt = self._target_node()
+        if tgt is None or tgt == self.store.root_id:
+            return  # 不删根
+        try:
+            self.store.delete_subtree(tgt)
+        except Exception:
+            return
+        # 重建压缩树;选中落回当前位置所在显示节点
+        self.ct = CompressedTree(tree_from_store(self.store, __import__("time").time()))
+        self._mark_current()
+        flat = self.ct.flatten()
+        if not flat:
+            self.dismiss(None)  # 树空了
+            return
+        self.sel_key = self._disp_key_for_node(self._current_node()) or flat[0]
+        self.focus_right = False
+        self.seg_idx = self._default_seg_idx()
+        self._diff_for = None
+        self.refresh_all()
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    # ---- 点击 ----
+    def on_click(self, event) -> None:
+        # 点击不同区域切聚焦框:点到节点/条目时各自 handler 已 stop 并设好聚焦,
+        # 这里兜住「点到面板空白处」也能切聚焦。
+        try:
+            x, y = event.screen_x, event.screen_y
+            if self.query_one("#rw3_left").region.contains(x, y):
+                if self.focus_right:
+                    self._set_focus(False)
+            elif self.query_one("#rw3_rtop").region.contains(x, y):
+                if not self.focus_right:
+                    self._set_focus(True)
+        except Exception:
+            pass
+
+    def on_clickable_tree_node_clicked(self, msg) -> None:
+        self._set_left_selection(msg.key)
+
+    def on_clickable_list_seg_clicked(self, msg) -> None:
+        self.focus_right = True
+        self.seg_idx = max(0, min(msg.index, self._seg_max_idx()))
+        self._diff_for = None
+        self._refresh_rtop(); self._refresh_rbot(); self._refresh_status()
+        self._refresh_focus_frame()
+        self._ensure_line_visible("#rw3_rtop", self.seg_idx + 3)
 
 
 def main(argv: Optional[list[str]] = None) -> int:

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -5270,10 +5270,10 @@ class GenericAgentTUI(App[None]):
         self._system(f"Branched #{old.agent_id} → #{new.agent_id} ({n} msgs).")
 
     def _cmd_rewind(self, args, raw):
-        # 外观:对话流内联选择卡片(旧版样式)。行为:有世界线树时走【持久】通道
-        # (_rw_restore_node→restore_plan,仅对话,落盘 tree HEAD + 重写投影日志,
-        # continue 后不复活);无树才兜底用内存级 _do_rewind(非持久)。代码恢复 /
-        # 分支树视图走 /worldline。
+        # 外观:对话流内联选择卡片(旧版样式)。行为:有世界线树时走【持久】通道——
+        # 选中提问后弹 RestoreModeScreen(复用 /worldline 那套)选 对话/代码/两者,再
+        # _rw_restore_node→restore_plan(落盘 tree HEAD + 重写投影日志,continue 后不复活)。
+        # 无树才兜底内存级 _do_rewind(非持久,仅对话)。分支树视图 / diff 走 /worldline。
         sess = self.current
         if sess.status == "running":
             self._system("Cannot rewind while running. /stop first."); return
@@ -5310,7 +5310,7 @@ class GenericAgentTUI(App[None]):
             if n < 1 or n > total:
                 self._system(f"Invalid: 1-{total}"); return
             if durable:
-                self._system(self._rw_restore_node(sess, payloads[n - 1], mode="conv", to="before"))
+                self._rewind_pick_mode(sess, payloads[n - 1])   # 弹模式窗后回退
             else:
                 self._system(self._do_rewind(payloads[n - 1]))
             return
@@ -5323,13 +5323,25 @@ class GenericAgentTUI(App[None]):
         if total > LIMIT:
             head += f"  [仅显示最近 {LIMIT}/{total}]"
         if durable:
-            on_sel = lambda v: self._rw_restore_node(sess, v, mode="conv", to="before")
+            on_sel = lambda v: self._rewind_pick_mode(sess, v)
         else:
             on_sel = lambda v: self._do_rewind(v)
         msg = ChatMessage(role="system", content=head, kind="choice",
                           choices=choices, on_select=on_sel)
         sess.messages.append(msg)
         self._refresh_messages()
+
+    def _rewind_pick_mode(self, sess, node_id) -> None:
+        """选中要回退到的提问后,弹 RestoreModeScreen(复用 /worldline 的模式选择窗)选
+        对话/代码/两者,再走持久回退 _rw_restore_node(to='before')。取消(返回 None)则不回退。"""
+        store = getattr(sess, "store", None)
+        title = ""
+        if store is not None and node_id in getattr(store, "nodes", {}):
+            title = store.nodes[node_id].get("title") or ""
+        def _after(mode):
+            if mode:
+                self._system(self._rw_restore_node(sess, node_id, mode=mode, to="before"))
+        self.push_screen(RestoreModeScreen(title, "before"), _after)
 
     def _cmd_rewind_tree(self, args, raw):
         sess = self.current

--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -1941,6 +1941,16 @@ class ChatMessage:
     # mounts (multi_choice only). Used by /scheduler so already-running
     # services show up checked, making "untick = stop" discoverable (bug#4).
     preselected_indices: list[int] = field(default_factory=list)
+    # Non-searchable choice cards only: highlight (and scroll to) this option
+    # index on first mount instead of the default row 0. `/rewind` uses it to
+    # open focused on the newest entry at the bottom. None → default (top).
+    initial_highlight: Optional[int] = None
+    # When True, selecting an option fires on_select but does NOT auto-collapse
+    # the card into a "✓ …" breadcrumb — on_select owns the card's lifecycle.
+    # `/rewind` uses it so picking an entry opens the mode picker with the list
+    # still mounted: confirm → on_select clears the card + rewinds; Esc → the
+    # list stays put (no misleading "✓ selected" when nothing was rewound).
+    defer_collapse: bool = False
     # Optional lazy-render hints for choice pickers with huge option counts
     # (e.g. /continue across thousands of sessions). Default is empty / 0,
     # so every existing call site keeps the eager-mount behavior bit-for-bit.
@@ -4607,6 +4617,17 @@ class GenericAgentTUI(App[None]):
         ids = list(self.sessions)
         i = ids.index(sid)
         next_id = ids[i + 1] if i + 1 < len(ids) else ids[i - 1]
+        # 释放被移除会话的日志锁：否则它仍留在心跳的 _held_locks 里被持续续活，
+        # 占用检测永远判其"活着"，之后无法对该日志原地 /continue。先 abort 停掉
+        # 可能仍在写日志的 agent，避免"锁已释放但仍在写"的冲突窗口（对齐 begin_fresh_session）。
+        dropped = self.sessions.get(sid)
+        if dropped is not None:
+            try: dropped.agent.abort()
+            except Exception: pass
+            try:
+                from continue_cmd import release_current
+                release_current(dropped.agent)
+            except Exception: pass
         del self.sessions[sid]
         self.current_id = next_id
         self._last_title = ""  # force title refresh on next call
@@ -5165,6 +5186,12 @@ class GenericAgentTUI(App[None]):
                 result_text = msg.on_select(value)
             except Exception as e:
                 result_text = f"❌ 失败: {type(e).__name__}: {e}"
+        # 延迟折叠卡片(如 /rewind):on_select 已接管卡片生命周期(弹模式窗;确认才清卡片+
+        # 回退,Esc 则原样保留列表)。不在此折叠成「✓」,避免"选了却没回退"的误导。
+        if getattr(msg, "defer_collapse", False):
+            if result_text:                      # on_select 异常时仍反馈,不静默吞掉
+                self._system(result_text)
+            return
         # PR #466 (upstream 8ae3645): if on_select rebuilt the message
         # container (e.g. /rewind picker → _do_rewind → _remount_current_session
         # detaches every widget under #messages), the captured anchors are
@@ -5175,7 +5202,10 @@ class GenericAgentTUI(App[None]):
                 and hasattr(anchor_guard, 'is_mounted')
                 and not anchor_guard.is_mounted):
             return
-        display = (result_text or label).strip() or label
+        # label 可能是 rich Text(如 /rewind 的带色三列)——取其纯文本再 strip,
+        # 折叠后的「✓ …」行用纯文本即可(颜色只需在实时列表里)。
+        lbl = label if isinstance(label, str) else getattr(label, "plain", str(label))
+        display = (result_text or lbl).strip() or lbl
         msg.selected_label = display
         msg.content = display
         container = self.query_one("#messages", VerticalScroll)
@@ -5333,64 +5363,110 @@ class GenericAgentTUI(App[None]):
         # 是压缩/删头后的 live,拿它对账会被误判「分歧」而弃树(见 worldline.reconcile)。
         # 对账统一只在 /continue(全量日志刚载入、未压缩)时做。直接按树的线性路径建卡片,
         # 每个选项 = 一个真实节点 → 选中即可持久回退。
-        nodes = []   # [(node_id, title)] 最近→最旧,不含 origin
-        if store is not None:
-            if store.nodes and store.head in store.nodes:
-                for nid in store.linear_path():
-                    if store.nodes[nid].get("kind") == "origin":
-                        continue
-                    nodes.append((nid, store.nodes[nid].get("title") or "（空）"))
-                nodes.reverse()
-        if nodes:                                   # 持久路径
-            payloads = [nid for nid, _ in nodes]
-            previews = [t for _, t in nodes]
-            durable = True
-        else:                                       # 兜底:无 store/无真实提问 → 内存级
+        durable = False
+        now = time.time()
+        items = []   # 最近→最旧,每项 {payload, prompt, ago, ins, dele}
+        if store is not None and store.nodes and store.head in store.nodes:
+            path = []
+            for nid in store.linear_path():                 # 旧→新
+                nd = store.nodes[nid]
+                if nd.get("kind") == "origin":
+                    continue
+                title = nd.get("title") or "（空）"
+                try:
+                    title = store._strip_project_mode(title).replace("\n", " ").strip() or "（空）"
+                except Exception:
+                    pass
+                try:
+                    ins, dele = store.node_line_delta(nid)
+                except Exception:
+                    ins = dele = 0
+                path.append({"payload": nid, "prompt": title,
+                             "ago": int(max(0, now - nd.get("created", now))),
+                             "ins": ins, "dele": dele})
+            items = list(reversed(path))                    # → 最近→最旧
+            durable = bool(items)
+        if not items:                                       # 兜底:无 store/无真实提问 → 内存级
             turns = self._rewindable_turns()
             if not turns:
                 self._system("No rewindable turns."); return
-            rec = list(reversed(turns))
-            payloads = [i + 1 for i in range(len(rec))]   # 回退轮数 n
-            previews = [p for _, p in rec]
+            items = [{"payload": i + 1, "prompt": p, "ago": None, "ins": 0, "dele": 0}
+                     for i, (_, p) in enumerate(reversed(turns))]   # 最近→最旧;payload=回退轮数 n
             durable = False
-        total = len(payloads)
-        if args:                                    # /rewind n 直接回退,不弹卡片
+        total = len(items)
+        if args:                                            # /rewind n 直接回退,不弹卡片
             try: n = int(args[0])
             except ValueError: self._system("Usage: /rewind [n]"); return
             if n < 1 or n > total:
                 self._system(f"Invalid: 1-{total}"); return
             if durable:
-                self._rewind_pick_mode(sess, payloads[n - 1])   # 弹模式窗后回退
+                self._rewind_pick_mode(sess, items[n - 1]["payload"])   # 弹模式窗后回退
             else:
-                self._system(self._do_rewind(payloads[n - 1]))
+                self._system(self._do_rewind(items[n - 1]["payload"]))
             return
         LIMIT = 20
-        choices = []
-        for offset in range(1, min(total, LIMIT) + 1):
-            preview = (previews[offset - 1] or "（空）").replace("\n", " ").strip()[:60]
-            choices.append((f"回退 {offset} 轮 · {preview}", payloads[offset - 1]))
-        head = "选择回退到的轮次 (↑/↓ 移动，→/Enter 确认，Esc 取消)"
+        # 卡片:取最近 LIMIT 条,倒序展示(越往下越新),打开即聚焦到底部(最新)。
+        card = list(reversed(items[:LIMIT]))                # → 最旧→最新
+        choices = [(self._rewind_label(it, durable), it["payload"]) for it in card]
+        head = "选择回退到的提问（越往下越新；↑/↓ 移动，→/Enter 确认，Esc 取消）"
         if total > LIMIT:
             head += f"  [仅显示最近 {LIMIT}/{total}]"
-        if durable:
-            on_sel = lambda v: self._rewind_pick_mode(sess, v)
-        else:
-            on_sel = lambda v: self._do_rewind(v)
         msg = ChatMessage(role="system", content=head, kind="choice",
-                          choices=choices, on_select=on_sel)
+                          choices=choices, on_select=None,
+                          initial_highlight=len(choices) - 1)
+        if durable:
+            # 延迟折叠:选中只弹模式窗、列表卡片留着。确认 → _rewind_pick_mode 清卡片+回退;
+            # Esc → 卡片原样留在列表(不折叠成误导性的「✓ 已选中」)。
+            msg.defer_collapse = True
+            msg.on_select = lambda v, _m=msg: self._rewind_pick_mode(sess, v, _m)
+        else:
+            msg.on_select = lambda v: self._do_rewind(v)
         sess.messages.append(msg)
         self._refresh_messages()
 
-    def _rewind_pick_mode(self, sess, node_id) -> None:
+    def _rewind_label(self, it, durable) -> "Text":
+        """一行:用户 prompt(定宽) · 上次会话时间 · 代码变动行数(+新增 -删除)。
+        定宽让时间/行数两列对齐(CJK 按显示格计);非持久(无 store)只显示 prompt。
+        返回 rich Text:+新增 绿、-删除 红、无改动显示暗色「（无改动）」。"""
+        from rich.cells import set_cell_size
+        # 先 ellipsize(超长截断并加「…」)再补齐到定宽——直接 set_cell_size 会硬切、无省略号。
+        p = set_cell_size(ellipsize(it.get("prompt") or "（空）", 40), 40)
+        t = Text(no_wrap=True, overflow="ellipsis")
+        if not durable or it.get("ago") is None:
+            t.append(p.rstrip())
+            return t
+        t.append(p)
+        t.append("  ")
+        t.append(set_cell_size(rel_time(it["ago"]), 8), style=C_DIM)
+        t.append("  ")
+        ins, dele = it["ins"], it["dele"]
+        if not (ins or dele):
+            t.append("（无改动）", style=C_DIM)
+        else:
+            t.append(f"+{ins}", style=C_GREEN)
+            t.append(" ")
+            t.append(f"-{dele}", style=C_RED)
+        return t
+
+    def _rewind_pick_mode(self, sess, node_id, card=None) -> None:
         """选中要回退到的提问后,弹 RestoreModeScreen(复用 /worldline 的模式选择窗)选
-        对话/代码/两者,再走持久回退 _rw_restore_node(to='before')。取消(返回 None)则不回退。"""
+        对话/代码/两者,再走持久回退 _rw_restore_node(to='before')。
+        card:发起本次选择的 /rewind 列表卡片(defer_collapse)。确认回退 → 先清掉它(不留
+        「✓」)再回退;Esc 取消(mode=None) → 什么都不做,列表卡片仍在 → 焦点自动回到列表。"""
         store = getattr(sess, "store", None)
         title = ""
         if store is not None and node_id in getattr(store, "nodes", {}):
             title = store.nodes[node_id].get("title") or ""
+            try:
+                title = store._strip_project_mode(title).replace("\n", " ").strip()
+            except Exception:
+                pass
         def _after(mode):
             if mode:
+                if card is not None:
+                    self._cancel_choice(card)   # 清掉列表卡片(不留误导性「✓」),再回退
                 self._system(self._rw_restore_node(sess, node_id, mode=mode, to="before"))
+            # mode is None(Esc 取消):不输出任何提示,列表卡片保留,焦点回到 /rewind 列表
         self.push_screen(RestoreModeScreen(title, "before"), _after)
 
     def _cmd_rewind_tree(self, args, raw):
@@ -7850,7 +7926,14 @@ class GenericAgentTUI(App[None]):
                         pass
                 self.call_after_refresh(_focus_input)
             else:
-                self.call_after_refresh(widget.focus)
+                def _focus_plain(w=widget, hi=m.initial_highlight):
+                    try:
+                        if hi is not None and getattr(w, "option_count", 0):
+                            w.highlighted = max(0, min(hi, w.option_count - 1))
+                        w.focus()
+                    except Exception:
+                        pass
+                self.call_after_refresh(_focus_plain)
             return
 
         if m.kind in ("choice", "multi_choice"):  # selected_label is not None
@@ -8154,30 +8237,6 @@ class ClickableTree(Static):
             self.post_message(self.NodeClicked(self.rows[off.y].key))
 
 
-class ClickableList(Static):
-    class SegClicked(Message):
-        def __init__(self, index: int) -> None:
-            self.index = index
-            super().__init__()
-
-    def __init__(self, **kw) -> None:
-        super().__init__("", **kw)
-        self.idxs: List[Optional[int]] = []
-
-    def set_content(self, text: Text, idxs: List[Optional[int]]) -> None:
-        self.idxs = idxs
-        self.update(text)
-
-    def on_click(self, event) -> None:
-        off = event.get_content_offset(self)
-        if off is None:
-            return
-        y = off.y
-        if 0 <= y < len(self.idxs) and self.idxs[y] is not None:
-            event.stop()
-            self.post_message(self.SegClicked(self.idxs[y]))
-
-
 class RestoreModeScreen(ModalScreen):
     """CC 式回退模式选择弹窗:在世界线里 Enter 选中节点后弹出,选恢复模式。
 
@@ -8270,14 +8329,26 @@ class RewindTreeScreen(ModalScreen):
     RewindTreeScreen {{ height: 100%; overflow: hidden; }}
     RewindTreeScreen > Horizontal {{ height: 1fr; width: 100%; }}
     #rw3_left {{
-        width: 44%; height: 1fr; border: round {C_BORDER}; border-title-color: {C_GREEN};
+        width: 60%; height: 1fr; border: round {C_BORDER}; border-title-color: {C_GREEN};
         padding: 0 1; overflow-x: auto; overflow-y: auto;
     }}
     #rw3_lefttree {{ width: auto; height: auto; }}
-    #rw3_right {{ width: 1fr; height: 1fr; }}
+    #rw3_right {{ width: 40%; height: 1fr; }}
     #rw3_rtop {{
         height: 50%; border: round {C_BORDER}; border-title-color: {C_BLUE};
-        padding: 0 1; overflow-y: auto;
+        padding: 0 1;
+    }}
+    #rw3_rtop_hint {{ height: auto; color: {C_DIM}; }}
+    #rw3_rtop_body {{
+        height: 1fr; background: transparent; border: none; padding: 0;
+        scrollbar-size-vertical: 1; scrollbar-gutter: stable;
+    }}
+    #rw3_rtop_body > .option-list--option {{ padding: 0; background: transparent; color: {C_FG}; }}
+    #rw3_rtop_body > .option-list--option-highlighted {{
+        background: {C_SEL_BG}; color: {C_DIM}; text-style: none;
+    }}
+    #rw3_rtop_body.rt-active > .option-list--option-highlighted {{
+        background: {C_ALT_BG}; color: {C_FG}; text-style: bold;
     }}
     #rw3_rbot {{
         height: 1fr; border: round {C_BORDER}; border-title-color: {C_PURPLE};
@@ -8377,8 +8448,9 @@ class RewindTreeScreen(ModalScreen):
             with ScrollableContainer(id="rw3_left"):
                 yield ClickableTree(id="rw3_lefttree")
             with Vertical(id="rw3_right"):
-                with VerticalScroll(id="rw3_rtop"):
-                    yield ClickableList(id="rw3_rtop_body")
+                with Vertical(id="rw3_rtop"):
+                    yield Static("", id="rw3_rtop_hint")
+                    yield OptionList(id="rw3_rtop_body")
                 with Vertical(id="rw3_rbot"):
                     yield Static("", id="rw3_rbot_body")
                     with VerticalScroll(id="rw3_diff"):
@@ -8390,6 +8462,9 @@ class RewindTreeScreen(ModalScreen):
         self.query_one("#rw3_rtop").border_title = "被折叠的节点"
         self.query_one("#rw3_rbot").border_title = "详情 / 操作"
         self.query_one("#rw3_rtop").can_focus = False
+        self.query_one("#rw3_rtop_body").can_focus = False   # 键盘焦点恒在左树；此列仅受控渲染+鼠标
+        self.query_one("#rw3_rtop_hint", Static).update(
+            Text("选中提问回退到其之前，末项从当前继续", style=C_DIM))
         # 左栏设为可聚焦并**抓住焦点**:让本 modal 真正持有键盘。否则全部子组件
         # can_focus=False → 焦点留在下层输入框,Tab 会被输入框的命令补全吃掉、屏的
         # on_key 收不到(↑↓ 靠 priority binding 才照常生效)。聚焦框仍由
@@ -8397,6 +8472,10 @@ class RewindTreeScreen(ModalScreen):
         left = self.query_one("#rw3_left")
         left.can_focus = True
         left.focus()
+        self.refresh_all()
+
+    def on_resize(self, event) -> None:
+        # 栏宽变化 → 重裁 rtop 行宽、重算左树横向跟踪，避免按旧宽度裁剪
         self.refresh_all()
 
     # ---- 联动 ----
@@ -8486,46 +8565,41 @@ class RewindTreeScreen(ModalScreen):
         return len(seg) if self._seg_has_tip(seg) else max(0, len(seg) - 1)
 
     def _refresh_rtop(self) -> None:
-        d = self.ct.disp[self.sel_key]
+        # 受控 OptionList：option 序号 == seg 序号（tip = len(seg)）。选中态由
+        # OptionList 的 highlighted 整项高亮 + 自动滚动到高亮负责——折行时整块选中、
+        # 滑窗跟踪与点击映射都由控件保证，不再靠「1 行 = 1 项」的脆弱手写逻辑。
         seg = self._current_seg()
-        lines: List[Text] = []
-        idxs: List[Optional[int]] = []   # 行 → seg 索引(tip = len(seg)),None=不可选
-        lines.append(Text("选中某条提问可回退到其之前；末尾一项则从当前位置继续", style=C_DIM)); idxs.append(None)
-        lines.append(Text("")); idxs.append(None)
-        for i, nid in enumerate(seg):
-            n = self.ct.tree.nodes[nid]
-            active = i == self.seg_idx
-            g, gs, _ = kind_style(n.kind)
-            rs = (f"bold {C_FG} on {C_ALT_BG}" if active and self.focus_right
-                  else (C_FG if active else C_MUTED))
-            line = Text()
-            line.append("▶ " if active else "  ",
-                        style=(C_CYAN if self.focus_right else C_DIM) if active else C_DIM)
-            line.append(f"{g} ", style=C_GREEN if active else gs)
-            line.append(ellipsize(n.title, 54), style=rs)
-            if n.rw_tag:
-                line.append(f"（{n.rw_tag}）", style=C_AMBER if active else C_DIM)
-            line.append(f"   {rel_time(n.ago)}", style=C_DIM)
-            lines.append(line); idxs.append(i)
-        # 末尾占位项(尚未创建,用括号标注);圆点字形,颜色同普通记录(new)/绿(current)。
-        # 会话起点(origin)不显示此占位项(_seg_has_tip):选中 origin 项本身即回到空起点。
+        ol = self.query_one("#rw3_rtop_body", OptionList)
+        ol.set_class(self.focus_right, "rt-active")   # 聚焦右栏 → 高亮更亮
+        opts = [Option(self._rtop_line(nid)) for nid in seg]
         if self._seg_has_tip(seg):
-            tip_i = len(seg)
-            tk = self._tip_kind()
-            tip_active = tip_i == self.seg_idx
-            tlabel = "（当前位置 · 自此继续）" if tk == "current" else "（自此继续会话）"
-            glyph = "◉" if tk == "current" else "●"     # 当前位置用 ◉(同节点当前标记)
-            base = C_GREEN if tk == "current" else C_FG
-            trs = (f"bold {C_FG} on {C_ALT_BG}" if tip_active and self.focus_right
-                   else (base if tip_active else C_DIM))
-            tline = Text()
-            tline.append("▶ " if tip_active else "  ",
-                         style=(C_CYAN if self.focus_right else C_DIM) if tip_active else C_DIM)
-            tline.append(f"{glyph} ", style=C_GREEN if (tip_active or tk == "current") else C_DIM)
-            tline.append(tlabel, style=trs)
-            lines.append(tline); idxs.append(tip_i)
-        self.query_one("#rw3_rtop_body", ClickableList).set_content(
-            Text("\n").join(lines), idxs)
+            opts.append(Option(self._rtop_tip_line()))
+        ol.clear_options()
+        if opts:
+            ol.add_options(opts)
+            ol.highlighted = max(0, min(self.seg_idx, len(opts) - 1))
+
+    def _rtop_line(self, nid) -> Text:
+        """段内节点的一行（不含选中态；高亮由 OptionList 绘制）。"""
+        n = self.ct.tree.nodes[nid]
+        g, gs, _ = kind_style(n.kind)
+        line = Text()
+        line.append(f"{g} ", style=gs)
+        line.append(ellipsize(n.title, 40))
+        if n.rw_tag:
+            line.append(f"（{n.rw_tag}）", style=C_AMBER)
+        line.append(f"   {rel_time(n.ago)}", style=C_DIM)
+        return line
+
+    def _rtop_tip_line(self) -> Text:
+        """末尾占位项（当前位置 / 自此继续）。"""
+        tk = self._tip_kind()
+        label = "（当前位置 · 自此继续）" if tk == "current" else "（自此继续会话）"
+        glyph = "◉" if tk == "current" else "●"
+        t = Text()
+        t.append(f"{glyph} ", style=C_GREEN if tk == "current" else C_DIM)
+        t.append(label, style=C_GREEN if tk == "current" else C_FG)
+        return t
 
     def _target_node(self) -> Optional[str]:
         """diff/delete 的目标节点:右上选中段内节点 > 当前显示节点的叶(tip 也归叶)。"""
@@ -8559,8 +8633,7 @@ class RewindTreeScreen(ModalScreen):
                 body.append("（自此继续会话）\n", style=f"bold {C_FG}")
                 body.append("  从这条记录之后继续对话。\n", style=C_MUTED)
             if tail is not None:
-                body.append(f"  续接于      {ellipsize(tail.title, 40)}\n", style=C_MUTED)
-                body.append(f"  时间        {rel_time(tail.ago)}\n", style=C_MUTED)
+                body.append(f"  续接于      {ellipsize(tail.title, 30)}\n", style=C_MUTED)
         else:
             nid = seg[self.seg_idx]
             n = self.ct.tree.nodes[nid]
@@ -8568,15 +8641,9 @@ class RewindTreeScreen(ModalScreen):
             body.append(f"{n.title}\n", style=f"bold {color}")
             if kind_label:
                 body.append(f"  类型        {kind_label}\n", style=C_MUTED)
-            body.append(f"  时间        {rel_time(n.ago)}\n", style=C_MUTED)
             body.append(f"  改动文件    {files_summary(n.files)}\n", style=C_MUTED)
-            body.append("  回退至此    清除本次提问及其后内容\n", style=C_DIM)
 
-        body.append("\n操作  ", style=C_DIM)
-        body.append(" Enter " + ("选择回退方式" if self.focus_right else "进入右栏选择"),
-                    style=f"{C_FG} on {C_SEL_BG}")
-        body.append("   x 删除节点\n", style=C_DIM)
-        body.append("(回退前自动保存还原点)", style=C_DIM)
+        body.append("\n(回退前自动保存还原点)", style=C_DIM)
         self.query_one("#rw3_rbot_body", Static).update(body)
         # 下方可滚动 diff 视窗:选中节点 vs 父节点(上一个状态)的逐行改动。
         self._refresh_diff(None if on_tip else seg[self.seg_idx])
@@ -8642,11 +8709,12 @@ class RewindTreeScreen(ModalScreen):
             pass
 
     def _refresh_status(self) -> None:
-        where = "右栏" if self.focus_right else "左树"
-        self.query_one("#rw3_status", Static).update(Text(
-            f" 聚焦:{where} | 共 {len(self.ct.flatten())}/{len(self.ct.tree.nodes)} | "
-            f"↑↓ 当前栏   Ctrl↑↓(/PgUp·Dn/[ ]) 另一栏   ←→ 切层级   Tab 切聚焦   "
-            f"Enter 进入/回退   x 删   Esc", style=C_DIM))
+        enter = "Enter 回退到此" if self.focus_right else "Enter 进入右栏"
+        t = Text(style=C_DIM)
+        t.append(" ↑↓ 移动 · Ctrl+↑↓ 移动另一栏 · ←→ 切换层级 · Tab 切换焦点 · ")
+        t.append(enter, style=C_FG)
+        t.append(" · x 删除节点 · Esc 关闭")
+        self.query_one("#rw3_status", Static).update(t)
 
     # ---- 导航:上下=聚焦窗 / Ctrl上下=非聚焦窗 / Tab·←→=切聚焦 ----
     def action_up(self) -> None:
@@ -8679,7 +8747,6 @@ class RewindTreeScreen(ModalScreen):
         self.seg_idx = max(0, min(self.seg_idx + delta, n))
         self._diff_for = None
         self._refresh_rtop(); self._refresh_rbot(); self._refresh_status()
-        self._ensure_line_visible("#rw3_rtop", self.seg_idx + 3)
 
     def _set_focus(self, right: bool) -> None:
         self.focus_right = right
@@ -8777,13 +8844,15 @@ class RewindTreeScreen(ModalScreen):
     def on_clickable_tree_node_clicked(self, msg) -> None:
         self._set_left_selection(msg.key)
 
-    def on_clickable_list_seg_clicked(self, msg) -> None:
+    def on_option_list_option_selected(self, ev) -> None:
+        # 鼠标点击右栏某项 → 选中该 seg（不触发回退；回退走 Enter/action_enter）。
+        if ev.option_list.id != "rw3_rtop_body":
+            return
         self.focus_right = True
-        self.seg_idx = max(0, min(msg.index, self._seg_max_idx()))
+        self.seg_idx = max(0, min(ev.option_index, self._seg_max_idx()))
         self._diff_for = None
         self._refresh_rtop(); self._refresh_rbot(); self._refresh_status()
         self._refresh_focus_frame()
-        self._ensure_line_visible("#rw3_rtop", self.seg_idx + 3)
 
 
 def main(argv: Optional[list[str]] = None) -> int:

--- a/frontends/worldline.py
+++ b/frontends/worldline.py
@@ -1,0 +1,968 @@
+"""GA 世界线(Rewind / checkpoint)统一后端 —— **UI 无关,单文件,tui/gui 共用**。
+
+三块合一(本文件不含任何 Textual/前端交互逻辑,只产数据与做存储):
+  1. **持久化**(`RewindStore`):content-addressable blob + checkpoint 树 + 全持久化。
+     - 统一 **checkpoint 树**;**content-addressable blob**(内容 sha256 去重);
+     - 只追 `file_write`/`file_patch`(路径由调用方在 `tool_before` 钩子喂入);
+     - **global baseline**(每文件「首次改前」)解决「回退到该文件被追踪之前」。
+  2. **视图模型 + 压缩**(`CheckpointTree`/`tree_from_store`/`CompressedTree`):把真实
+     store 投影成只读树并强制折叠线性段,供任何前端渲染。
+  3. **导航数学 + 恢复编排**(`next_same_depth`/`nearest_depth_node`/`restore_plan`):
+     纯计算;`restore_plan` 算出回退后的 history/文件/prefill 并落地(改文件+移 HEAD+
+     重写投影),前端只管把结果刷到自己的界面。
+
+参考 Claude Code file-history 思路,按 GA 改造。纯 Python、可离线测试;线程安全交调用方
+(agent 跑在子线程,约定仅 agent 空闲时 restore)。详见需求文档(ga_rewind_tui_requirements)。
+"""
+from __future__ import annotations
+
+import difflib
+import hashlib
+import json
+import os
+import shutil
+import time
+from datetime import datetime
+import zlib
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from rich.cells import cell_len, set_cell_size
+
+# 该值为 None 表示「该版本文件不存在」（对应 CC 的 backupFileName: null）。
+_ABSENT = None
+
+
+class RewindStore:
+    """一个 session 的 checkpoint 树 + blob 库。
+
+    用法（典型时序）：
+        store = RewindStore(root, cwd)
+        # 改前（tool_before 钩子，file_write/file_patch 执行前）：
+        store.track_pre_edit(abs_path)
+        # ...工具实际写盘...
+        # 段末（用户提问边界 / turn 收尾）：
+        store.commit("修复 stdout", hist_len=42)
+        # 浏览 / 恢复：
+        store.apply_code(node_id)        # 把工作区还原到该节点
+        store.rewind_head(node_id)       # 只移 HEAD（下次 commit 即从此分叉）
+    """
+
+    def __init__(self, root: str, cwd: str) -> None:
+        self.root = os.path.abspath(root)
+        self.cwd = os.path.abspath(cwd)
+        self.objects_dir = os.path.join(self.root, "objects")
+        self.tree_path = os.path.join(self.root, "tree.json")
+
+        # id -> {parent, children[], title, created, kind, hist_len, files{rel: hash|None}}
+        self.nodes: dict[str, dict] = {}
+        self.head: str | None = None
+        self.root_id: str | None = None
+        self._seq = 0
+        # 全局：每个被追踪文件的「首次改前」状态（hash 或 None=当时不存在）。
+        self.baseline: dict[str, str | None] = {}
+        self.tracked: set[str] = set()
+
+        # 段内暂存：本段触碰过的相对路径（commit 时落定）。
+        self._touched: set[str] = set()
+        # 最近一次 restore 的 redo 点（内存级软保险②），结构同 node.files。
+        self._redo: dict | None = None
+
+        self.load()
+        if self.nodes:
+            self._ensure_origin()  # 迁移:旧树(无 origin)挂一个「会话起点」根
+
+    # --------------------------------------------------------------- origin
+    def _ensure_origin(self) -> None:
+        """保证存在一个虚拟根「会话起点」(空状态):所有真实 checkpoint 都是它的
+        后代。幂等。第一次 commit / 迁移旧树 / resume 时调用。
+
+        - 它代表「第一轮对话之前」,使「回退到第一个会话之前」= 普通地 rewind 到它;
+        - files={} + hist_len=0 → apply_code(origin) 经 baseline 回退 = 还原到空起点;
+        - 它是唯一真根 → 不会出现 forest / head=None。"""
+        if any(nd.get("kind") == "origin" for nd in self.nodes.values()):
+            if self.head is None:
+                self.head = self.root_id
+            return
+        oid = "origin"
+        while oid in self.nodes:
+            oid += "_"
+        tops = self.top_level_nodes()
+        self.nodes[oid] = {"parent": None, "children": list(tops),
+                           "title": "会话起点", "created": time.time(),
+                           "kind": "origin", "hist_len": 0, "files": {}}
+        for t in tops:
+            self.nodes[t]["parent"] = oid
+        self.root_id = oid
+        if self.head is None:
+            self.head = oid
+
+    # ------------------------------------------------------------------ paths
+    def key(self, abs_path: str) -> str:
+        """绝对路径在 cwd 下 → 存相对（参考 CC maybeShortenFilePath）；否则原样。"""
+        ap = os.path.abspath(abs_path)
+        try:
+            if os.path.commonpath([ap, self.cwd]) == self.cwd:
+                return os.path.relpath(ap, self.cwd).replace(os.sep, "/")
+        except ValueError:
+            pass  # 跨盘符（Windows）等：commonpath 抛错 → 用绝对路径
+        return ap.replace(os.sep, "/")
+
+    def _abs(self, rel: str) -> str:
+        if os.path.isabs(rel) or (len(rel) > 1 and rel[1] == ":"):
+            return os.path.normpath(rel)
+        return os.path.normpath(os.path.join(self.cwd, rel))
+
+    # ------------------------------------------------------------------ blobs
+    def _put_blob(self, data: bytes) -> str:
+        h = hashlib.sha256(data).hexdigest()
+        p = os.path.join(self.objects_dir, h[:2], h)
+        if not os.path.exists(p):
+            os.makedirs(os.path.dirname(p), exist_ok=True)
+            tmp = p + ".tmp"
+            with open(tmp, "wb") as f:
+                f.write(zlib.compress(data, 6))
+            os.replace(tmp, p)
+        return h
+
+    def _get_blob(self, h: str) -> bytes:
+        with open(os.path.join(self.objects_dir, h[:2], h), "rb") as f:
+            return zlib.decompress(f.read())
+
+    def _snapshot(self, abs_path: str) -> str | None:
+        """当前内容 → blob hash；文件不存在 → None。"""
+        try:
+            with open(abs_path, "rb") as f:
+                data = f.read()
+        except (FileNotFoundError, NotADirectoryError, IsADirectoryError, PermissionError):
+            return _ABSENT
+        return self._put_blob(data)
+
+    # --------------------------------------------------------------- tracking
+    def track_pre_edit(self, abs_path: str) -> None:
+        """改前埋点：首次见到该文件时记下它的「改前」状态作 baseline。
+
+        幂等——同一文件同段内多次调用只在首次抓 baseline（file_patch 连改不会
+        覆盖原始版本，对应 CC trackEdit 的 v1 保护）。"""
+        rel = self.key(abs_path)
+        self._touched.add(rel)
+        if rel not in self.baseline:
+            self.baseline[rel] = self._snapshot(abs_path)  # 改前内容，可能是 None
+            self.tracked.add(rel)
+
+    def commit(self, title: str, hist_len: int | None = None, kind: str = "edit",
+               history: list | None = None) -> str:
+        """段末落节点：继承 HEAD.files，把本段触碰文件的「改后」内容写进新节点。
+
+        `history` 给定时(对话树化)：切 `history[parent.hist_len:当前]` 为本轮对话增量，
+        存成 content-addressable conv blob，节点记其 hash + `hist_len=len(history)`。
+        此刻索引可靠 → 增量精确，恢复时沿路径拼回即可，不再靠会漂的绝对下标。
+
+        无触碰文件时也会落节点（纯对话推进也是 checkpoint）。返回新节点 id。"""
+        self._ensure_origin()        # 第一次提交前先确保有「会话起点」根
+        parent = self.head           # 至少是 origin,永不为 None
+        files = dict(self.nodes[parent]["files"]) if parent is not None else {}
+        for rel in self._touched:
+            files[rel] = self._snapshot(self._abs(rel))  # 改后内容，删除则 None
+
+        conv = None
+        if history is not None:
+            parent_len = self.nodes[parent].get("hist_len") if parent is not None else 0
+            parent_len = parent_len or 0          # None(旧节点) / origin → 0
+            delta = list(history[parent_len:])
+            hist_len = len(history)
+            conv = self._put_blob(
+                json.dumps(delta, ensure_ascii=False, default=str).encode("utf-8"))
+
+        nid = self._new_id()
+        self.nodes[nid] = {
+            "parent": parent,
+            "children": [],
+            "title": title,
+            "created": time.time(),
+            "kind": kind,
+            "hist_len": hist_len,
+            "files": files,
+            "conv": conv,
+        }
+        if parent is not None:
+            self.nodes[parent]["children"].append(nid)
+        elif self.root_id is None or self.root_id not in self.nodes:
+            self.root_id = nid   # 只认第一个根;rewind-到-根之前再提交会产生第二个顶层节点(forest)
+        self.head = nid
+        self._touched.clear()
+        self.save()
+        return nid
+
+    # ------------------------------------------------------------- navigation
+    def rewind_head(self, node_id) -> None:
+        """移动 HEAD(不动文件)。从非叶 HEAD 下次 commit 即 append 子节点 = fork。
+        node_id=None 表示「回到根之前」(空起点),下次 commit 产生新的顶层节点。"""
+        if node_id is not None and node_id not in self.nodes:
+            raise KeyError(node_id)
+        self.head = node_id
+        self.save()
+
+    def top_level_nodes(self) -> list[str]:
+        """所有顶层节点(parent 为 None 或父已不存在)。通常一个 root,rewind-到-根
+        之前再提交会出现多个(forest)。"""
+        return [nid for nid, nd in self.nodes.items()
+                if nd.get("parent") is None or nd.get("parent") not in self.nodes]
+
+    def _target_state(self, node_id: str, rel: str):
+        """文件 rel 在 node_id 时应有的状态：节点 files 里有就用它，否则回退到
+        baseline（CC 的 first-version）。返回 (known: bool, hash_or_None)。"""
+        files = self.nodes[node_id]["files"]
+        if rel in files:
+            return True, files[rel]
+        if rel in self.baseline:
+            return True, self.baseline[rel]
+        return False, None
+
+    def apply_code(self, node_id) -> list[tuple[str, str]]:
+        """把工作区文件还原到 node_id 的状态。`node_id=None` → 还原到 baseline
+        (任何 checkpoint 之前的原始状态,用于「回退到根之前」)。
+
+        - **只动本 store 追踪过的路径**（self.tracked），绝不碰未记录文件（软保险①）。
+        - restore 前先把这些路径的当前内容存进 redo 点（软保险②）——误覆盖也能找回。
+        返回 [(rel, action)]，action ∈ {restored, deleted}。"""
+        if node_id is not None and node_id not in self.nodes:
+            raise KeyError(node_id)
+
+        # 软保险②：redo 点（记录当前 = 即将被覆盖的状态）。
+        redo_files: dict[str, str | None] = {}
+        for rel in self.tracked:
+            redo_files[rel] = self._snapshot(self._abs(rel))
+        self._redo = {"from": self.head, "files": redo_files}
+
+        changed: list[tuple[str, str]] = []
+        for rel in self.tracked:
+            if node_id is None:
+                known = rel in self.baseline
+                target = self.baseline.get(rel)
+            else:
+                known, target = self._target_state(node_id, rel)
+            if not known:
+                continue
+            ap = self._abs(rel)
+            cur = self._snapshot(ap)
+            if cur == target:
+                continue
+            if target is _ABSENT:
+                try:
+                    os.remove(ap)
+                    changed.append((rel, "deleted"))
+                except FileNotFoundError:
+                    pass
+            else:
+                os.makedirs(os.path.dirname(ap) or ".", exist_ok=True)
+                with open(ap, "wb") as f:
+                    f.write(self._get_blob(target))
+                changed.append((rel, "restored"))
+        return changed
+
+    def diff(self, node_id: str) -> list[dict]:
+        """选中节点 vs 当前工作区，逐文件变更摘要（恢复到该节点会发生什么）。
+
+        返回 [{rel, action, insertions, deletions}]，仅列出会变的文件。
+        action: restore（覆盖）/ delete（删除）/ create（重建被删文件）。"""
+        if node_id not in self.nodes:
+            raise KeyError(node_id)
+        out: list[dict] = []
+        for rel in sorted(self.tracked):
+            known, target = self._target_state(node_id, rel)
+            if not known:
+                continue
+            cur = self._snapshot(self._abs(rel))
+            if cur == target:
+                continue
+            old = self._text(cur)        # 当前工作区内容
+            new = self._text(target)     # 该节点内容（恢复目标）
+            ins = dele = 0
+            for line in difflib.ndiff(old.splitlines(), new.splitlines()):
+                if line.startswith("+ "):
+                    ins += 1
+                elif line.startswith("- "):
+                    dele += 1
+            if target is _ABSENT:
+                action = "delete"
+            elif cur is _ABSENT:
+                action = "create"
+            else:
+                action = "restore"
+            out.append({"rel": rel, "action": action, "insertions": ins, "deletions": dele})
+        return out
+
+    def node_diff(self, node_id) -> list[dict]:
+        """选中节点 vs **父节点**的逐文件内容 diff(= 这次 checkpoint 改了什么)。
+        返回 [{rel, old, new}](文本),仅含两者不同的文件;父缺失/文件不存在 → 空文本。
+        供 UI 渲染逐行 diff(区别于 `diff()` 的"节点 vs 当前工作区"计数摘要)。"""
+        if node_id not in self.nodes:
+            return []
+        nd = self.nodes[node_id]
+        par = nd.get("parent")
+        pf = self.nodes[par]["files"] if par in self.nodes else {}
+        nf = nd.get("files") or {}
+        out: list[dict] = []
+        for rel in sorted(set(nf) | set(pf)):
+            nh = nf.get(rel)
+            # 「上一个状态」:父节点记录过就用它;父节点没有(本节点首次触碰该文件)→
+            # 回退到 baseline(首次改前内容,CC first-version)。否则被 file_patch 修改的
+            # 已有文件会因父节点无记录而被误显示成整文件新增,而非真正的逐行 diff。
+            ph = pf[rel] if rel in pf else self.baseline.get(rel)
+            if nh == ph:
+                continue
+            out.append({"rel": rel, "old": self._text(ph), "new": self._text(nh)})
+        return out
+
+    def _text(self, h: str | None) -> str:
+        if h is _ABSENT:
+            return ""
+        try:
+            return self._get_blob(h).decode("utf-8", "replace")
+        except Exception:
+            return ""
+
+    # --------------------------------------------------------- delete + gc
+    def delete_subtree(self, node_id: str) -> list[str]:
+        """删除节点及其整棵子树（不能删 HEAD 祖先路径上的节点 / root 由调用方把关）。
+        返回被删的节点 id 列表。删后做一次 blob GC。"""
+        if node_id not in self.nodes:
+            raise KeyError(node_id)
+        victims: list[str] = []
+
+        def collect(nid: str) -> None:
+            victims.append(nid)
+            for c in list(self.nodes[nid]["children"]):
+                collect(c)
+
+        collect(node_id)
+        parent = self.nodes[node_id]["parent"]
+        if parent is not None:
+            self.nodes[parent]["children"] = [
+                c for c in self.nodes[parent]["children"] if c != node_id
+            ]
+        for nid in victims:
+            self.nodes.pop(nid, None)
+        if node_id == self.root_id:
+            self.root_id = None
+        if self.head in victims:
+            self.head = parent  # HEAD 被删 → 退到父
+        self._gc()
+        self.save()
+        return victims
+
+    def _gc(self) -> int:
+        """删除无人引用的 blob。返回删除数。"""
+        referenced: set[str] = set()
+        for node in self.nodes.values():
+            for h in node["files"].values():
+                if h is not _ABSENT:
+                    referenced.add(h)
+            ch = node.get("conv")          # 对话增量 blob 也是引用
+            if ch:
+                referenced.add(ch)
+        for h in self.baseline.values():
+            if h is not _ABSENT:
+                referenced.add(h)
+        if self._redo:
+            for h in self._redo["files"].values():
+                if h is not _ABSENT:
+                    referenced.add(h)
+        removed = 0
+        if not os.path.isdir(self.objects_dir):
+            return 0
+        for sub in os.listdir(self.objects_dir):
+            d = os.path.join(self.objects_dir, sub)
+            if not os.path.isdir(d):
+                continue
+            for h in os.listdir(d):
+                if h not in referenced:
+                    try:
+                        os.remove(os.path.join(d, h))
+                        removed += 1
+                    except OSError:
+                        pass
+        return removed
+
+    # ------------------------------------------------------------ persistence
+    def save(self) -> None:
+        os.makedirs(self.root, exist_ok=True)
+        payload = {
+            "nodes": self.nodes,
+            "head": self.head,
+            "root": self.root_id,
+            "seq": self._seq,
+            "baseline": self.baseline,
+            "tracked": sorted(self.tracked),
+        }
+        tmp = self.tree_path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False, default=str)
+        # 崩溃兜底：替换前把上一份完好的 tree.json 留作 .bak（load 损坏时回退它）。
+        if os.path.exists(self.tree_path):
+            try:
+                shutil.copyfile(self.tree_path, self.tree_path + ".bak")
+            except OSError:
+                pass
+        os.replace(tmp, self.tree_path)
+
+    def load(self) -> None:
+        """加载树。主文件损坏/缺失 → 回退 .bak；都不行 → 留空 store（降级，不抛）。"""
+        for path in (self.tree_path, self.tree_path + ".bak"):
+            if not os.path.exists(path):
+                continue
+            try:
+                with open(path, encoding="utf-8") as f:
+                    d = json.load(f)
+            except Exception:
+                continue   # 损坏 → 尝试下一个候选
+            self.nodes = d.get("nodes", {})
+            self.head = d.get("head")
+            self.root_id = d.get("root")
+            self._seq = d.get("seq", 0)
+            self.baseline = d.get("baseline", {})
+            self.tracked = set(d.get("tracked", []))
+            return
+
+    def _new_id(self) -> str:
+        self._seq += 1
+        return f"v{self._seq}"
+
+    # ---------------------------------------------------------- session key
+    @staticmethod
+    def key_for_log(log_path: str) -> str:
+        """会话 key = log_path 的 basename 去扩展名,如 `model_responses_123456`。
+        这是 GA 唯一稳定、/continue 据以识别会话的身份(task_dir 是 PID 级、重启即变,
+        不能用)。"""
+        return os.path.splitext(os.path.basename(log_path))[0]
+
+    @classmethod
+    def for_log(cls, temp_dir: str, log_path: str, cwd: str) -> "RewindStore":
+        """按 GA 的 log_path 落到 `temp/.ga_rewind/<key>/`。"""
+        root = os.path.join(temp_dir, ".ga_rewind", cls.key_for_log(log_path))
+        return cls(root, cwd)
+
+    def resume_from(self, old_root: str) -> bool:
+        """/continue 续接:把旧会话的 rewind 目录接到本 store(贴近 CC 的
+        copyFileHistoryForResume)。
+
+        GA 每个新 agent 生成新 log_path → 新 key,旧会话的树/blob 默认看不到;
+        这里在新 key 下重建:① 接管旧 tree.json(仅当本 store 尚为空);
+        ② blob 内容寻址,直接 hardlink(同名即同内容,跳过;失败回退 copy)。
+        返回是否接管成功。"""
+        if not os.path.isdir(old_root) or os.path.abspath(old_root) == self.root:
+            return False
+        old_tree = os.path.join(old_root, "tree.json")
+        if not self.nodes and os.path.exists(old_tree):
+            try:
+                with open(old_tree, encoding="utf-8") as f:
+                    d = json.load(f)
+                self.nodes = d.get("nodes", {})
+                self.head = d.get("head")
+                self.root_id = d.get("root")
+                self._seq = d.get("seq", 0)
+                self.baseline = d.get("baseline", {})
+                self.tracked = set(d.get("tracked", []))
+            except Exception:
+                return False
+        old_objects = os.path.join(old_root, "objects")
+        if os.path.isdir(old_objects):
+            for sub in os.listdir(old_objects):
+                sd = os.path.join(old_objects, sub)
+                if not os.path.isdir(sd):
+                    continue
+                dd = os.path.join(self.objects_dir, sub)
+                os.makedirs(dd, exist_ok=True)
+                for h in os.listdir(sd):
+                    dst = os.path.join(dd, h)
+                    if os.path.exists(dst):
+                        continue  # 内容寻址:同名即同内容
+                    src = os.path.join(sd, h)
+                    try:
+                        os.link(src, dst)          # hardlink 不占额外空间
+                    except OSError:
+                        try:
+                            shutil.copyfile(src, dst)  # 跨盘/不支持 → 回退 copy
+                        except OSError:
+                            pass
+        if self.nodes:
+            self._ensure_origin()  # 旧树若无 origin,迁移补上
+        self.save()
+        return True
+
+    # ------------------------------------------------------------------ views
+    def linear_path(self) -> list[str]:
+        """root → HEAD 的线性路径（节点 id），供 /rewind 时间线展示。"""
+        return self.path_to(self.head)
+
+    def path_to(self, node_id) -> list[str]:
+        """root → node_id 的节点 id 列表（含两端）。node_id 缺失 → []。"""
+        if node_id is None or node_id not in self.nodes:
+            return []
+        chain: list[str] = []
+        cur: str | None = node_id
+        while cur is not None and cur in self.nodes:
+            chain.append(cur)
+            cur = self.nodes[cur].get("parent")
+        chain.reverse()
+        return chain
+
+    # ----------------------------------------------------------- conversation
+    def _node_conv(self, node_id) -> list:
+        """单节点的对话增量（list）。无 conv / 读失败 → []（容错降级）。"""
+        h = self.nodes.get(node_id, {}).get("conv")
+        if not h:
+            return []
+        try:
+            data = json.loads(self._get_blob(h).decode("utf-8"))
+            return data if isinstance(data, list) else []
+        except Exception:
+            return []
+
+    def rebuild_history(self, node_id) -> list:
+        """沿 root→node_id 拼接各节点对话增量，整体重建 `backend.history`。
+
+        这是「树=真相源」的恢复入口：选任意节点（含旁支）都能精确还原其对话，
+        不依赖内存里那条线性 history。origin / 无 conv 的节点贡献空增量。"""
+        hist: list = []
+        for nid in self.path_to(node_id):
+            hist.extend(self._node_conv(nid))
+        return hist
+
+    # ----------------------------------------------------- 对账(防外部改写灾难)
+    @staticmethod
+    def _msg_user_text(msg) -> str:
+        """真实用户提问文本;非 user / 纯 tool_result 回填 → ""(不算提问边界)。"""
+        if not isinstance(msg, dict) or msg.get("role") != "user":
+            return ""
+        c = msg.get("content")
+        if isinstance(c, str):
+            return c
+        if isinstance(c, list):
+            if any(isinstance(b, dict) and b.get("type") == "tool_result" for b in c):
+                return ""
+            return " ".join(b.get("text", "") for b in c
+                            if isinstance(b, dict) and b.get("type") == "text")
+        return ""
+
+    @classmethod
+    def _turn_sig(cls, msgs) -> list:
+        """一段消息的「对话身份」= 其中真实用户提问的文本序列(跳过 tool_result 轮,
+        故不含注入的易变内容)。用于 reconcile 判两段是否同一对话。"""
+        return [t for t in (cls._msg_user_text(m).strip() for m in msgs) if t]
+
+    def reconcile(self, history: list) -> int:
+        """把 live history 里树尚未记录的尾部轮次吸收成 conv-only 节点,使树追平日志。
+        供「带 worldline 的 UI」在打开世界线 / 接管日志前调用 —— 别的(不更新树的)
+        UI 往同一日志追加后,若不对账,树会滞后;一旦在滞后状态 rewind,
+        `rewrite_projection` 会拿陈旧树回写、**抹掉那些外部轮次**(灾难性丢失)。
+        对账后树恒 ⊇ 日志,故 rewind 物理上不可能 clobber 未见过的轮次。
+
+        **安全闸**:仅当树 HEAD 路径与 history 前缀是「同一段对话」才在其上 append;
+        否则判为分歧(用户问了不同的问题),HEAD 退回 origin 另起一条顶层 trunk 容纳
+        live history,旧树保留为旁支、绝不拿它回写日志。空树 = n=0 特例(吸收全部,
+        即旧 _bootstrap_conv_tree)。幂等:无尾巴 → no-op,可任意重复调用。返回吸收条数。
+
+        判「同一段对话」用**用户提问序列**(`_turn_sig`)而非逐条全等:消息里会被注入
+        易变内容(如 `[WORKING MEMORY]`,只在 tool_result 轮),同一段对话在不同时刻
+        捕获并不逐字节相等;逐条全等会把它误判成分歧、复制出一整条重复 trunk。提问
+        文本在 tool_result 轮之外、稳定不变,是可靠的对话身份。"""
+        history = list(history or [])
+        self._ensure_origin()
+        head = self.head if self.head in self.nodes else self.root_id
+        known = self.rebuild_history(head)
+        n = len(known)
+        if self._turn_sig(history[:n]) != self._turn_sig(known):
+            # 分歧(提问序列不同):不信任陈旧树。退回空起点,后续 append 只反映 live history。
+            self.rewind_head(self.root_id)
+            n = len(self.rebuild_history(self.root_id))   # origin 无 conv → 0
+        if len(history) <= n:
+            return 0
+        # 按用户提问边界切尾巴 [n, len);逐段 commit(history=history[:段末]),
+        # commit 内部 delta = history[parent.hist_len:段末]。清 _touched 保证纯 conv-only。
+        starts = [i for i in range(n, len(history))
+                  if self._msg_user_text(history[i]).strip()]
+        if not starts or starts[0] > n:
+            starts = [n] + starts
+        self._touched.clear()
+        absorbed = 0
+        for p, s in enumerate(starts):
+            end = starts[p + 1] if p + 1 < len(starts) else len(history)
+            title = next((self._msg_user_text(history[i]).strip()
+                          for i in range(s, end)
+                          if self._msg_user_text(history[i]).strip()), "")
+            title = (title or "（外部续接）").replace("\n", " ").strip()[:80]
+            self.commit(title or "（外部续接）", kind="edit", history=list(history[:end]))
+            absorbed += end - s
+        return absorbed
+
+    def first_user_message(self, node_id) -> dict | None:
+        """node_id 对话增量里的首条 `role==user` 消息（原始 dict）；无则 None。
+
+        供 rewind 后精确 prefill（取「该提问本身」，不靠会漂的绝对下标）。文本提取
+        交调用方（消息内容格式是 GA backend 私有的）。"""
+        for msg in self._node_conv(node_id):
+            if isinstance(msg, dict) and msg.get("role") == "user":
+                return msg
+        return None
+
+
+# ============================================================================
+# 世界线视图模型 + 压缩 + 导航(从 rewind_tree_view.py 抽出的 UI 无关后端)
+# ============================================================================
+# 节点**语义**(字形 + 文字标签);**呈现色由前端决定**(颜色不属于后端)。
+KIND_GLYPH = {"current": "◉", "rewind": "↩", "origin": "●"}  # ◉=当前所在;●=普通/根
+KIND_LABEL = {"current": "当前位置", "rewind": "回退来源", "origin": "会话起点"}
+
+
+def kind_glyph(kind: str) -> str:
+    return KIND_GLYPH.get(kind, "●")
+
+
+def kind_label(kind: str) -> str:
+    return KIND_LABEL.get(kind, "")
+
+
+def rel_time(ago_s) -> str:
+    if ago_s is None:
+        return ""
+    if ago_s < 60:
+        return "刚刚"
+    m = ago_s // 60
+    if m < 60:
+        return f"{m} 分钟前"
+    h = m // 60
+    if h < 24:
+        return f"{h} 小时前"
+    return f"{h // 24} 天前"
+
+
+def files_summary(files: List[str]) -> str:
+    if not files:
+        return "无变更"
+    if len(files) <= 3:
+        return "、".join(files)
+    return "、".join(files[:3]) + f" (+{len(files) - 3})"
+
+
+_TITLE_MAX_CELLS = 40
+
+
+def ellipsize(s: str, max_cells: int = _TITLE_MAX_CELLS) -> str:
+    """按显示宽度(中文算 2 格)截断,超长加 `…`。用于左树/右上的长提问标题。"""
+    s = (s or "").replace("\n", " ").strip()
+    if cell_len(s) <= max_cells:
+        return s
+    return set_cell_size(s, max(1, max_cells - 1)).rstrip() + "…"
+
+
+# --------------------------------------------------------------- 数据模型
+@dataclass
+class CheckpointNode:
+    id: str
+    title: str
+    parent_id: Optional[str] = None
+    children: List[str] = field(default_factory=list)
+    kind: str = "edit"
+    files: List[str] = field(default_factory=list)
+    ago: Optional[int] = 0
+
+
+class CheckpointTree:
+    """只读视图树(供压缩/渲染);从 RewindStore 构造。"""
+
+    def __init__(self) -> None:
+        self.nodes: Dict[str, CheckpointNode] = {}
+        self.root_id: Optional[str] = None
+
+
+def _changed_files(store, node_id) -> List[str]:
+    import os
+    nd = store.nodes[node_id]
+    par = nd.get("parent")
+    pf = store.nodes[par]["files"] if par in store.nodes else {}
+    out: List[str] = []
+    for k, v in nd["files"].items():
+        if pf.get(k) != v:
+            b = os.path.basename(k)
+            if b not in out:
+                out.append(b)
+    return out
+
+
+def tree_from_store(store, now: float) -> CheckpointTree:
+    """把 RewindStore 的真实树投影成只读 CheckpointTree;HEAD 标 current。"""
+    t = CheckpointTree()
+    for nid, nd in store.nodes.items():
+        t.nodes[nid] = CheckpointNode(
+            id=nid,
+            title=nd.get("title") or "（空）",
+            parent_id=nd.get("parent"),
+            children=[c for c in nd.get("children", []) if c in store.nodes],
+            kind="current" if nid == store.head else nd.get("kind", "edit"),
+            files=_changed_files(store, nid),
+            ago=int(max(0, now - nd.get("created", now))),
+        )
+    t.root_id = store.root_id
+    return t
+
+
+# --------------------------------------------- 压缩(强制折叠线性段,§4.2)
+@dataclass
+class DisplayNode:
+    key: int
+    kind: str  # 'real' | 'fold'
+    depth: int = 0
+    parent_key: Optional[int] = None
+    children: List[int] = field(default_factory=list)
+    node_id: Optional[str] = None
+    seg: List[str] = field(default_factory=list)
+    end_id: Optional[str] = None
+
+
+class CompressedTree:
+    def __init__(self, tree: CheckpointTree) -> None:
+        self.tree = tree
+        self.disp: Dict[int, DisplayNode] = {}
+        self.roots: List[int] = []   # 顶层显示节点 keys(通常一个 = origin)
+        self._k = 0
+        # 顶层节点(origin「会话起点」)常驻独立显示作锚点;它下面的真实对话链
+        # 照常折叠(§4.2)。origin 是「第一轮对话之前」的空状态,不是某轮对话,
+        # 所以独立显示语义清晰、不会像"第一轮对话被强行拎出"那样让人困惑。
+        for top in self._top_level():
+            self._build_root_node(top)
+
+    def _top_level(self) -> List[str]:
+        return [nid for nid, n in self.tree.nodes.items()
+                if n.parent_id is None or n.parent_id not in self.tree.nodes]
+
+    def _new_key(self) -> int:
+        k = self._k
+        self._k += 1
+        return k
+
+    def _build_root_node(self, root_id: str) -> int:
+        key = self._new_key()
+        self.disp[key] = DisplayNode(key=key, kind="real", node_id=root_id, depth=0)
+        self.roots.append(key)
+        for child_id in self.tree.nodes[root_id].children:
+            self._build_chain(child_id, 1, key)
+        return key
+
+    def _build_chain(self, start_id: str, depth: int, parent: Optional[int]) -> int:
+        seg = [start_id]
+        cur = start_id
+        while len(self.tree.nodes[cur].children) == 1:
+            cur = self.tree.nodes[cur].children[0]
+            seg.append(cur)
+        end = seg[-1]
+        key = self._new_key()
+        if len(seg) == 1:
+            self.disp[key] = DisplayNode(key=key, kind="real", node_id=end,
+                                         depth=depth, parent_key=parent)
+        else:
+            self.disp[key] = DisplayNode(key=key, kind="fold", depth=depth,
+                                         parent_key=parent, seg=list(seg), end_id=end)
+        if parent is None:
+            self.roots.append(key)
+        else:
+            self.disp[parent].children.append(key)
+        for child_id in self.tree.nodes[end].children:
+            self._build_chain(child_id, depth + 1, key)
+        return key
+
+    def flatten(self) -> List[int]:
+        order: List[int] = []
+
+        def dfs(k: int) -> None:
+            order.append(k)
+            for c in self.disp[k].children:
+                dfs(c)
+
+        for r in self.roots:
+            dfs(r)
+        return order
+
+    def end_node(self, key: int) -> CheckpointNode:
+        d = self.disp[key]
+        return self.tree.nodes[d.node_id if d.kind == "real" else d.end_id]
+
+    def label(self, key: int) -> str:
+        # 真实/折叠都只放末端标题(截断);折叠的 [N nodes] 标记放在 glyph 位(标题前)。
+        d = self.disp[key]
+        nid = d.node_id if d.kind == "real" else d.end_id
+        return ellipsize(self.tree.nodes[nid].title)
+
+    def glyph(self, key: int) -> str:
+        # 折叠节点开头用 [N nodes] 替代原来的 … 省略号(→ "[3 nodes] 标题");
+        # 真实节点仍用语义字形(● / ↩ / ◉)。
+        d = self.disp[key]
+        if d.kind == "fold":
+            return f"[{len(d.seg)} nodes]"
+        return kind_glyph(self.tree.nodes[d.node_id].kind)
+
+
+# ----------------------------------------------------- 导航(纯计算)
+def _order_depths(ct: CompressedTree) -> List[tuple[int, int]]:
+    return [(k, ct.disp[k].depth) for k in ct.flatten()]
+
+
+def next_same_depth(order, sel, direction):
+    idx = next(i for i, (k, _) in enumerate(order) if k == sel)
+    depth = order[idx][1]
+    same = [i for i, (_, d) in enumerate(order) if d == depth]
+    pos = same.index(idx)
+    return order[same[(pos + direction) % len(same)]][0]
+
+
+def nearest_depth_node(order, sel, delta):
+    idx = next(i for i, (k, _) in enumerate(order) if k == sel)
+    target = order[idx][1] + delta
+    if target < 0:
+        return sel
+    cand = [i for i, (_, d) in enumerate(order) if d == target]
+    if not cand:
+        return sel
+    if delta > 0:
+        best = min(cand, key=lambda i: (abs(i - idx), 0 if i >= idx else 1, i))
+    else:
+        best = min(cand, key=lambda i: (abs(i - idx), 0 if i <= idx else 1, -i))
+    return order[best][0]
+
+
+def parent_sibling_first_child(ct, sel, direction):
+    d = ct.disp[sel]
+    if d.parent_key is None:
+        return sel
+    parent = ct.disp[d.parent_key]
+    if parent.parent_key is None:
+        return sel
+    siblings = ct.disp[parent.parent_key].children
+    if parent.key not in siblings or len(siblings) <= 1:
+        return sel
+    start = siblings.index(parent.key)
+    step = 1 if direction >= 0 else -1
+    for off in range(1, len(siblings)):
+        sib = ct.disp[siblings[(start + step * off) % len(siblings)]]
+        if sib.children:
+            return sib.children[0]
+    return sel
+
+
+# ============================================================================
+# 恢复编排(UI 无关):算出回退后的对话/文件/prefill 并落地,前端只刷新自己的显示
+# ============================================================================
+def user_msg_text(entry) -> str:
+    """从一条 user 消息里取出用户可见文本(content 为 str 或 text block 列表)。"""
+    c = entry.get("content") if isinstance(entry, dict) else None
+    if isinstance(c, str):
+        return c
+    if isinstance(c, list):
+        parts = [b.get("text", "") for b in c
+                 if isinstance(b, dict) and b.get("type") == "text"]
+        return "\n".join(p for p in parts if p)
+    return ""
+
+
+def render_native_history(history, ts=None):
+    """Inverse of `continue_cmd._parse_native_history`: render a `backend.history`
+    (alternating user/assistant) back into the native `=== Prompt/Response ===`
+    log text. Lives here (not continue_cmd) because the rewind tree is its only
+    caller — it rewrites `model_responses_<key>.txt` as a linear projection of
+    the current HEAD path so /continue + other UIs get a clean single-branch view
+    (the TUI itself reads only the tree). Round-trip holds:
+    `_parse_native_history(_pairs(render_native_history(h))) == h`.
+
+    Byte-for-byte matches llmcore's `_write_llm_log` for the tool backend:
+    Prompt = `json.dumps(merged, ensure_ascii=False, indent=2)`; Response =
+    `str(content_blocks)` which for a list equals `repr(...)` (survives
+    True/False/None that JSON would emit as true/false/null and break
+    `ast.literal_eval`). Only complete (user, assistant) pairs are emitted."""
+    ts = ts or datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    out, i, n = [], 0, len(history)
+    while i < n:
+        u = history[i]
+        if isinstance(u, dict) and u.get('role') == 'user' and i + 1 < n:
+            a = history[i + 1]
+            if isinstance(a, dict) and a.get('role') == 'assistant':
+                out.append(f"=== Prompt === {ts}\n{json.dumps(u, ensure_ascii=False, indent=2)}\n\n")
+                out.append(f"=== Response === {ts}\n{a.get('content')!r}\n\n")
+                i += 2
+                continue
+        i += 1
+    return "".join(out)
+
+
+def rewrite_projection(store, target, log_path: str) -> bool:
+    """把 `model_responses_<key>.txt` 重写成 root→target 的线性投影(native
+    `=== Prompt/Response ===` 格式,`continue_cmd._parse_native_history` 可解析)。
+
+    给其他 UI + /continue 的兼容视角;消除 rewind/fork 后多分支混排。故障静默。"""
+    if store is None or not log_path:
+        return False
+    try:
+        text = render_native_history(store.rebuild_history(target))
+        # 回退到「会话起点」(origin)时 history 为空 → 日志被写空(0 字节)。这是【硬】回退:
+        # 日志恒等于树 HEAD,无错位,reconcile 不会复制分支。空日志会被普通 UI 的
+        # list_sessions(sz<32) 无害跳过;带 worldline 的 UI 靠 list_sessions(rewind_root=...)
+        # 的树感知发现 + continue_inplace(allow_empty=True) 仍能找回并恢复(空对话 + 重连树)。
+        tmp = log_path + ".tmp"
+        with open(tmp, "w", encoding="utf-8", errors="replace") as f:
+            f.write(text)
+        os.replace(tmp, log_path)
+        return True
+    except Exception:
+        return False
+
+
+def restore_plan(store, node_id, mode: str = "both", to: str = "before",
+                 log_path: str = "") -> Optional[dict]:
+    """UI 无关的回退编排。`to`:
+      - **before**(选中段内某节点):回到该提问**之前**(连该节点一起清除),prefill 其提问;
+        target = parent(node) / origin。
+      - **at**(末尾占位项):在该节点处**继续**(HEAD→node,不清除、无 prefill)。
+    `mode`: both/conv/code。会就地:重建对话(返回 history,调用方自行赋给 backend)、
+    `apply_code`(还原文件,前自动留 redo 点)、移 HEAD、重写投影日志。
+
+    返回 None(无效) 或 dict:
+      {history: list|None(仅 conv 变更时), changed: [(rel,action)], prefill: str,
+       at_origin: bool, target: str, title: str, to: str}
+    —— 前端据此:赋 backend.history、重建界面消息、prefill 输入框、刷新。"""
+    if store is None or not node_id or node_id not in store.nodes:
+        return None
+    nd = store.nodes[node_id]
+    prefill = ""
+    if to == "at":
+        target = node_id
+        at_origin = nd.get("kind") == "origin"
+    else:
+        parent = nd.get("parent")
+        parent = parent if parent in store.nodes else None
+        target = parent if parent is not None else node_id
+        at_origin = parent is None
+        if not at_origin:
+            um = store.first_user_message(node_id)
+            prefill = (user_msg_text(um) if um else "") or nd.get("title", "")
+
+    history = None
+    if mode in ("both", "conv"):
+        history = store.rebuild_history(target)
+    changed = []
+    if mode in ("both", "code"):
+        try:
+            changed = store.apply_code(target)
+        except Exception:
+            changed = []
+    store.rewind_head(target)
+    if mode in ("both", "conv") and log_path:
+        rewrite_projection(store, target, log_path)
+    return {
+        "history": history,
+        "changed": changed,
+        "prefill": prefill,
+        "at_origin": at_origin,
+        "target": target,
+        "title": nd.get("title", ""),
+        "to": to,
+    }

--- a/frontends/worldline.py
+++ b/frontends/worldline.py
@@ -183,6 +183,15 @@ class RewindStore:
             conv = self._put_blob(
                 json.dumps(delta, ensure_ascii=False, default=str).encode("utf-8"))
 
+        # 工作记忆默认【从 history 派生】(与 reconcile 同口径 → 树的 WM 恒由日志重建、彼此
+        # 对齐)。显式传入才尊重(测试/特殊调用)。关键:/continue 会把 handler.history_info
+        # 清空,若仍取 live 纪要,长度与树派生的不一致 → 增量算空、续接后新轮纪要补不进树。
+        # 从 history(集成层喂日志全量)派生则永远对齐,不受 live 纪要被重置影响。
+        if history is not None and hist_info is None:
+            hist_info = self._derive_hist_info(history)
+        if history is not None and key_info is None:
+            key_info = self._key_info_of(history)
+
         # 工作记忆增量(与 conv 同构):history_info 轮级摘要切本段增量存 blob;key_info
         # 覆盖式小便签直接内联。两者皆可选,老树/外部续接未传则为 None(恢复时跳过,不动现场)。
         hinfo = None

--- a/frontends/worldline.py
+++ b/frontends/worldline.py
@@ -1177,15 +1177,13 @@ def restore_plan(store, node_id, mode: str = "both", to: str = "before",
     if mode == "both":
         history = store.rebuild_history(target)
         hist_info, key_info = _wm_at(target)
-        try:
-            changed = store.apply_code(target)
-        except Exception:
-            changed = []
+        changed, code_error = _apply_code_safe(store, target)
         store.rewind_head(target)
         if log_path:
             rewrite_projection(store, target, log_path)
         return _res(history, hist_info, key_info, changed, prefill,
-                    at_origin, target, store._strip_project_mode(nd.get("title", "")), to)
+                    at_origin, target, store._strip_project_mode(nd.get("title", "")), to,
+                    code_error=code_error)
 
     # ---- conv:对话退到 target、代码留 old_head。桥接挂 fork(=parent(target),或 target 若 origin)
     if mode == "conv":
@@ -1214,10 +1212,7 @@ def restore_plan(store, node_id, mode: str = "both", to: str = "before",
     # ---- code:代码退到 target、对话留 old_head。桥接按会话拓扑挂在 old_head 的父节点,
     #      自带 old_head 这一轮对话/WM,文件显式覆盖为 target 的代码状态。
     if mode == "code":
-        try:
-            changed = store.apply_code(target)
-        except Exception:
-            changed = []
+        changed, code_error = _apply_code_safe(store, target)
         conv_parent = store.nodes.get(old_head, {}).get("parent")
         conv_parent = conv_parent if conv_parent in store.nodes else old_head
         conv_delta = list(store._node_conv(old_head) or [])
@@ -1231,14 +1226,25 @@ def restore_plan(store, node_id, mode: str = "both", to: str = "before",
         # 对话没动 → history=None(前端不重赋 backend.history)、不重写投影日志、
         # 不 prefill(对话未回退,输入框不该被塞入选中节点的旧提问)。
         return _res(None, None, None, changed, "",
-                    at_origin, bridge_id, store._strip_project_mode(nd.get("title", "")), to)
+                    at_origin, bridge_id, store._strip_project_mode(nd.get("title", "")), to,
+                    code_error=code_error)
 
     return None  # 未知 mode
 
 
+def _apply_code_safe(store, target) -> "tuple[list, Optional[str]]":
+    """还原工作区代码,失败不静默:返回 (changed, code_error)。code_error 非 None 时
+    表示写盘中途出错(权限/磁盘…),工作区可能处于部分回退状态——交由前端提示用户,
+    而非当作「无变更」悄悄放过(apply_code 直接写用户文件,失败半径不为零)。"""
+    try:
+        return store.apply_code(target), None
+    except Exception as e:
+        return [], f"{type(e).__name__}: {e}"
+
+
 def _res(history, hist_info, key_info, changed, prefill,
-         at_origin, target, title, to) -> dict:
-    """restore_plan 的返回 dict 构造器。"""
+         at_origin, target, title, to, *, code_error=None) -> dict:
+    """restore_plan 的返回 dict 构造器。code_error:代码回退失败信息(None=成功)。"""
     return {
         "history": history,
         "hist_info": hist_info,
@@ -1249,4 +1255,5 @@ def _res(history, hist_info, key_info, changed, prefill,
         "target": target,
         "title": title,
         "to": to,
+        "code_error": code_error,
     }

--- a/frontends/worldline.py
+++ b/frontends/worldline.py
@@ -151,12 +151,17 @@ class RewindStore:
             self.tracked.add(rel)
 
     def commit(self, title: str, hist_len: int | None = None, kind: str = "edit",
-               history: list | None = None) -> str:
+               history: list | None = None, hist_info: list | None = None,
+               key_info: str | None = None) -> str:
         """段末落节点：继承 HEAD.files，把本段触碰文件的「改后」内容写进新节点。
 
         `history` 给定时(对话树化)：切 `history[parent.hist_len:当前]` 为本轮对话增量，
         存成 content-addressable conv blob，节点记其 hash + `hist_len=len(history)`。
         此刻索引可靠 → 增量精确，恢复时沿路径拼回即可，不再靠会漂的绝对下标。
+
+        `hist_info`/`key_info` 给定时(工作记忆树化)：`hist_info` 是轮级摘要列表,与 conv
+        同构切增量存 blob;`key_info` 是小便签(<200 token),直接内联进节点。rewind 时
+        一并恢复 → 纪要与历史**硬同步**,杜绝旧 rewind「历史回退了、纪要没回」的串味。
 
         无触碰文件时也会落节点（纯对话推进也是 checkpoint）。返回新节点 id。"""
         self._ensure_origin()        # 第一次提交前先确保有「会话起点」根
@@ -174,6 +179,18 @@ class RewindStore:
             conv = self._put_blob(
                 json.dumps(delta, ensure_ascii=False, default=str).encode("utf-8"))
 
+        # 工作记忆增量(与 conv 同构):history_info 轮级摘要切本段增量存 blob;key_info
+        # 覆盖式小便签直接内联。两者皆可选,老树/外部续接未传则为 None(恢复时跳过,不动现场)。
+        hinfo = None
+        hinfo_len = None
+        if hist_info is not None:
+            parent_hlen = self.nodes[parent].get("hinfo_len") if parent is not None else 0
+            parent_hlen = parent_hlen or 0
+            hdelta = list(hist_info[parent_hlen:])
+            hinfo_len = len(hist_info)
+            hinfo = self._put_blob(
+                json.dumps(hdelta, ensure_ascii=False, default=str).encode("utf-8"))
+
         nid = self._new_id()
         self.nodes[nid] = {
             "parent": parent,
@@ -184,6 +201,9 @@ class RewindStore:
             "hist_len": hist_len,
             "files": files,
             "conv": conv,
+            "hinfo": hinfo,
+            "hinfo_len": hinfo_len,
+            "kinfo": key_info,
         }
         if parent is not None:
             self.nodes[parent]["children"].append(nid)
@@ -362,6 +382,9 @@ class RewindStore:
             ch = node.get("conv")          # 对话增量 blob 也是引用
             if ch:
                 referenced.add(ch)
+            hh = node.get("hinfo")         # 工作记忆纪要增量 blob 同样是引用
+            if hh:
+                referenced.add(hh)
         for h in self.baseline.values():
             if h is not _ABSENT:
                 referenced.add(h)
@@ -529,6 +552,45 @@ class RewindStore:
         for nid in self.path_to(node_id):
             hist.extend(self._node_conv(nid))
         return hist
+
+    # ------------------------------------------------------ 工作记忆(随对话回退)
+    def _node_hinfo(self, node_id) -> list:
+        """单节点的 working-memory 纪要增量（list）。无 / 读失败 → []（容错降级）。"""
+        h = self.nodes.get(node_id, {}).get("hinfo")
+        if not h:
+            return []
+        try:
+            data = json.loads(self._get_blob(h).decode("utf-8"))
+            return data if isinstance(data, list) else []
+        except Exception:
+            return []
+
+    def rebuild_hist_info(self, node_id) -> list:
+        """沿 root→node_id 拼接各节点纪要增量，重建 `handler.history_info`。
+        与 `rebuild_history` 同构：纪要随对话一起精确回退，恢复后两者自洽。"""
+        out: list = []
+        for nid in self.path_to(node_id):
+            out.extend(self._node_hinfo(nid))
+        return out
+
+    def key_info_at(self, node_id) -> str:
+        """node_id 处生效的 key_info：沿 root→node 取最后一个非 None 的 `kinfo`
+        （key_info 是覆盖式小便签，不像纪要那样累加）。无则空串。"""
+        ki = ""
+        for nid in self.path_to(node_id):
+            v = self.nodes[nid].get("kinfo")
+            if v is not None:
+                ki = v
+        return ki
+
+    def path_has_wm(self, node_id) -> bool:
+        """root→node 路径上是否记录过工作记忆（hinfo/kinfo）。老树（本特性之前）
+        全为 None → False：恢复时据此跳过 WM 同步，不抹掉现场纪要（向后兼容）。"""
+        for nid in self.path_to(node_id):
+            nd = self.nodes.get(nid, {})
+            if nd.get("hinfo") is not None or nd.get("kinfo") is not None:
+                return True
+        return False
 
     # ----------------------------------------------------- 对账(防外部改写灾难)
     @staticmethod
@@ -926,9 +988,10 @@ def restore_plan(store, node_id, mode: str = "both", to: str = "before",
     `apply_code`(还原文件,前自动留 redo 点)、移 HEAD、重写投影日志。
 
     返回 None(无效) 或 dict:
-      {history: list|None(仅 conv 变更时), changed: [(rel,action)], prefill: str,
+      {history: list|None(仅 conv 变更时), hist_info: list|None, key_info: str|None,
+       changed: [(rel,action)], prefill: str,
        at_origin: bool, target: str, title: str, to: str}
-    —— 前端据此:赋 backend.history、重建界面消息、prefill 输入框、刷新。"""
+    —— 前端据此:赋 backend.history、同步 working memory、重建界面消息、prefill 输入框、刷新。"""
     if store is None or not node_id or node_id not in store.nodes:
         return None
     nd = store.nodes[node_id]
@@ -946,8 +1009,14 @@ def restore_plan(store, node_id, mode: str = "both", to: str = "before",
             prefill = (user_msg_text(um) if um else "") or nd.get("title", "")
 
     history = None
+    hist_info = None
+    key_info = None
     if mode in ("both", "conv"):
         history = store.rebuild_history(target)
+        # 工作记忆随对话一起回退;仅当树确实记过 WM 才返回(老树 → None,调用方跳过不动现场)。
+        if store.path_has_wm(target):
+            hist_info = store.rebuild_hist_info(target)
+            key_info = store.key_info_at(target)
     changed = []
     if mode in ("both", "code"):
         try:
@@ -959,6 +1028,8 @@ def restore_plan(store, node_id, mode: str = "both", to: str = "before",
         rewrite_projection(store, target, log_path)
     return {
         "history": history,
+        "hist_info": hist_info,
+        "key_info": key_info,
         "changed": changed,
         "prefill": prefill,
         "at_origin": at_origin,

--- a/frontends/worldline.py
+++ b/frontends/worldline.py
@@ -746,6 +746,17 @@ class RewindStore:
                 return msg
         return None
 
+    def first_question(self) -> Optional[str]:
+        """当前 HEAD 路径上**第一条真实用户提问**的文本;空树 → None。沿路径读各节点
+        conv（通常首个真实节点即命中,O(1) blob 读）。供集成层**廉价检测 backend.history
+        是否被删头**:删头先 pop 掉首问,故 live 首问与此对不上 ⇒ 删过头(该回退到日志)。"""
+        for nid in self.path_to(self.head):
+            for msg in self._node_conv(nid):
+                t = self._msg_user_text(msg).strip()
+                if t:
+                    return t
+        return None
+
 
 # ============================================================================
 # 世界线视图模型 + 压缩 + 导航(从 rewind_tree_view.py 抽出的 UI 无关后端)

--- a/frontends/worldline.py
+++ b/frontends/worldline.py
@@ -1154,7 +1154,10 @@ def restore_plan(store, node_id, mode: str = "both", to: str = "before",
         at_origin = parent is None
         if not at_origin:
             um = store.first_user_message(node_id)
-            prefill = (user_msg_text(um) if um else "") or store._strip_project_mode(nd.get("title", ""))
+            # 剥离 project_mode 注入块:回填输入框的是用户原话,不能夹带注入内容。
+            # 树里的 user 消息取自 native 日志(含注入),user_msg_text 逐字取文本不清洗,
+            # 故在此统一 _strip_project_mode(幂等,无注入块则原样返回)。
+            prefill = store._strip_project_mode((user_msg_text(um) if um else "") or nd.get("title", ""))
 
     old_head = store.head  # 回退前的 HEAD(代码/对话的「另一侧」来源)
 
@@ -1166,7 +1169,9 @@ def restore_plan(store, node_id, mode: str = "both", to: str = "before",
 
     def _prompt_of(node_id):
         um = store.first_user_message(node_id)
-        return (user_msg_text(um) if um else "") or store._strip_project_mode(store.nodes.get(node_id, {}).get("title", ""))
+        # 同 prefill:桥接节点标题也要剥离 project_mode 注入,取用户原话。
+        return store._strip_project_mode(
+            (user_msg_text(um) if um else "") or store.nodes.get(node_id, {}).get("title", ""))
 
     # ---- both:直接还原到 target(对话+代码),无桥接
     if mode == "both":

--- a/frontends/worldline.py
+++ b/frontends/worldline.py
@@ -66,8 +66,6 @@ class RewindStore:
 
         # 段内暂存：本段触碰过的相对路径（commit 时落定）。
         self._touched: set[str] = set()
-        # 最近一次 restore 的 redo 点（内存级软保险②），结构同 node.files。
-        self._redo: dict | None = None
 
         self.load()
         if self.nodes:
@@ -226,6 +224,56 @@ class RewindStore:
         self.save()
         return nid
 
+    def commit_bridge(self, *, parent: str, conv_delta: list | None,
+                      hinfo_delta: list | None, kinfo: str | None,
+                      files_override: dict | None, title: str,
+                      rw_tag: str) -> str:
+        """落一个**桥接节点**(仅会话/仅代码回退用):承载「对话与代码来自不同节点」的
+        交叉态,使该状态成为树里的一等节点(三种回退模式对它都可用)。
+
+        与 `commit` 的区别:不走 `_touched`/继承派生,对话/WM 增量与文件均**显式给定**。
+        - `conv_delta`/`hinfo_delta`:本节点自带的对话/纪要增量(list),存 blob(内容寻址,
+          大多复用已有 blob);None 则不带(空会话桥接)。
+        - `kinfo`:覆盖式便签,直接内联。
+        - `files_override`:显式 files map;None → 继承 parent。
+        - `rw_tag`:来源标注(`仅会话回退`/`仅代码回退`/`仅会话回退到聊天起点`),独立于 title。
+
+        parent 必须是现存节点(由 restore_plan 保证)。返回新节点 id,HEAD 指向它。"""
+        if parent not in self.nodes:
+            parent = self.root_id if self.root_id in self.nodes else self.head
+        files = (dict(files_override) if files_override is not None
+                 else dict(self.nodes[parent]["files"]))
+        conv = None
+        if conv_delta:
+            conv = self._put_blob(
+                json.dumps(conv_delta, ensure_ascii=False, default=str).encode("utf-8"))
+        hinfo = None
+        hinfo_len = None
+        if hinfo_delta:
+            hinfo_len = len(self.rebuild_hist_info(parent)) + len(hinfo_delta)
+            hinfo = self._put_blob(
+                json.dumps(hinfo_delta, ensure_ascii=False, default=str).encode("utf-8"))
+        nid = self._new_id()
+        self.nodes[nid] = {
+            "parent": parent,
+            "children": [],
+            "title": title,
+            "created": time.time(),
+            "kind": "edit",
+            "hist_len": len(self.rebuild_history(parent)) + len(conv_delta or []),
+            "files": files,
+            "conv": conv,
+            "hinfo": hinfo,
+            "hinfo_len": hinfo_len,
+            "kinfo": kinfo,
+            "rw_tag": rw_tag,
+        }
+        self.nodes[parent]["children"].append(nid)
+        self.head = nid
+        self._touched.clear()
+        self.save()
+        return nid
+
     # ------------------------------------------------------------- navigation
     def rewind_head(self, node_id) -> None:
         """移动 HEAD(不动文件)。从非叶 HEAD 下次 commit 即 append 子节点 = fork。
@@ -255,17 +303,10 @@ class RewindStore:
         """把工作区文件还原到 node_id 的状态。`node_id=None` → 还原到 baseline
         (任何 checkpoint 之前的原始状态,用于「回退到根之前」)。
 
-        - **只动本 store 追踪过的路径**（self.tracked），绝不碰未记录文件（软保险①）。
-        - restore 前先把这些路径的当前内容存进 redo 点（软保险②）——误覆盖也能找回。
+        - **只动本 store 追踪过的路径**（self.tracked），绝不碰未记录文件。
         返回 [(rel, action)]，action ∈ {restored, deleted}。"""
         if node_id is not None and node_id not in self.nodes:
             raise KeyError(node_id)
-
-        # 软保险②：redo 点（记录当前 = 即将被覆盖的状态）。
-        redo_files: dict[str, str | None] = {}
-        for rel in self.tracked:
-            redo_files[rel] = self._snapshot(self._abs(rel))
-        self._redo = {"from": self.head, "files": redo_files}
 
         changed: list[tuple[str, str]] = []
         for rel in self.tracked:
@@ -400,10 +441,6 @@ class RewindStore:
         for h in self.baseline.values():
             if h is not _ABSENT:
                 referenced.add(h)
-        if self._redo:
-            for h in self._redo["files"].values():
-                if h is not _ABSENT:
-                    referenced.add(h)
         removed = 0
         if not os.path.isdir(self.objects_dir):
             return 0
@@ -817,6 +854,7 @@ class CheckpointNode:
     kind: str = "edit"
     files: List[str] = field(default_factory=list)
     ago: Optional[int] = 0
+    rw_tag: Optional[str] = None  # 桥接来源标注(仅会话/仅代码回退);普通节点 None
 
 
 class CheckpointTree:
@@ -853,6 +891,7 @@ def tree_from_store(store, now: float) -> CheckpointTree:
             kind="current" if nid == store.head else nd.get("kind", "edit"),
             files=_changed_files(store, nid),
             ago=int(max(0, now - nd.get("created", now))),
+            rw_tag=nd.get("rw_tag"),
         )
     t.root_id = store.root_id
     return t
@@ -981,24 +1020,6 @@ def nearest_depth_node(order, sel, delta):
     return order[best][0]
 
 
-def parent_sibling_first_child(ct, sel, direction):
-    d = ct.disp[sel]
-    if d.parent_key is None:
-        return sel
-    parent = ct.disp[d.parent_key]
-    if parent.parent_key is None:
-        return sel
-    siblings = ct.disp[parent.parent_key].children
-    if parent.key not in siblings or len(siblings) <= 1:
-        return sel
-    start = siblings.index(parent.key)
-    step = 1 if direction >= 0 else -1
-    for off in range(1, len(siblings)):
-        sib = ct.disp[siblings[(start + step * off) % len(siblings)]]
-        if sib.children:
-            return sib.children[0]
-    return sel
-
 
 # ============================================================================
 # 恢复编排(UI 无关):算出回退后的对话/文件/prefill 并落地,前端只刷新自己的显示
@@ -1073,13 +1094,17 @@ def restore_plan(store, node_id, mode: str = "both", to: str = "before",
         target = parent(node) / origin。
       - **at**(末尾占位项):在该节点处**继续**(HEAD→node,不清除、无 prefill)。
     `mode`: both/conv/code。会就地:重建对话(返回 history,调用方自行赋给 backend)、
-    `apply_code`(还原文件,前自动留 redo 点)、移 HEAD、重写投影日志。
+    `apply_code`(还原文件)、移 HEAD、重写投影日志。
 
     返回 None(无效) 或 dict:
-      {history: list|None(仅 conv 变更时), hist_info: list|None, key_info: str|None,
+      {history: list|None(对话变更时), hist_info: list|None, key_info: str|None,
        changed: [(rel,action)], prefill: str,
        at_origin: bool, target: str, title: str, to: str}
-    —— 前端据此:赋 backend.history、同步 working memory、重建界面消息、prefill 输入框、刷新。"""
+    `target` 字段:both = 落点节点;conv/code = 桥接节点 id(前端 cursor 标它)。
+    —— 前端据此:赋 backend.history、同步 working memory、重建界面消息、prefill 输入框、刷新。
+
+    conv/code 落一个**桥接节点**承载「对话/代码交叉态」(见 `commit_bridge`),使该状态成为
+    一等节点;both 直接还原到 target,无桥接。"""
     if store is None or not node_id or node_id not in store.nodes:
         return None
     nd = store.nodes[node_id]
@@ -1096,24 +1121,83 @@ def restore_plan(store, node_id, mode: str = "both", to: str = "before",
             um = store.first_user_message(node_id)
             prefill = (user_msg_text(um) if um else "") or nd.get("title", "")
 
-    history = None
-    hist_info = None
-    key_info = None
-    if mode in ("both", "conv"):
+    old_head = store.head  # 回退前的 HEAD(代码/对话的「另一侧」来源)
+
+    def _wm_at(node_id):
+        """(hist_info, key_info) @ node;树无 WM 记录 → (None, None),调用方跳过不动现场。"""
+        if store.path_has_wm(node_id):
+            return store.rebuild_hist_info(node_id), store.key_info_at(node_id)
+        return None, None
+
+    def _prompt_of(node_id):
+        um = store.first_user_message(node_id)
+        return (user_msg_text(um) if um else "") or store.nodes.get(node_id, {}).get("title", "")
+
+    # ---- both:直接还原到 target(对话+代码),无桥接
+    if mode == "both":
         history = store.rebuild_history(target)
-        # 工作记忆随对话一起回退;仅当树确实记过 WM 才返回(老树 → None,调用方跳过不动现场)。
-        if store.path_has_wm(target):
-            hist_info = store.rebuild_hist_info(target)
-            key_info = store.key_info_at(target)
-    changed = []
-    if mode in ("both", "code"):
+        hist_info, key_info = _wm_at(target)
         try:
             changed = store.apply_code(target)
         except Exception:
             changed = []
-    store.rewind_head(target)
-    if mode in ("both", "conv") and log_path:
-        rewrite_projection(store, target, log_path)
+        store.rewind_head(target)
+        if log_path:
+            rewrite_projection(store, target, log_path)
+        return _res(history, hist_info, key_info, changed, prefill,
+                    at_origin, target, nd.get("title", ""), to)
+
+    # ---- conv:对话退到 target、代码留 old_head。桥接挂 fork(=parent(target),或 target 若 origin)
+    if mode == "conv":
+        tp = store.nodes[target].get("parent")
+        fork = tp if tp in store.nodes else target          # target=origin → fork=origin(空会话)
+        at_start = (fork == target)                          # 空会话:对话退空,无 delta 可带
+        conv_delta = None if at_start else store._node_conv(target)
+        hinfo_delta = None if at_start else store._node_hinfo(target)
+        bridge_files = dict(store.nodes[old_head]["files"]) if old_head in store.nodes else {}
+        if at_start:
+            b_title, rw_tag = prefill or "会话起点", "仅会话回退到聊天起点"
+        else:
+            b_title, rw_tag = _prompt_of(target), "仅会话回退"
+        bridge_id = store.commit_bridge(
+            parent=fork, conv_delta=conv_delta, hinfo_delta=hinfo_delta,
+            kinfo=store.key_info_at(target), files_override=bridge_files,
+            title=b_title, rw_tag=rw_tag)
+        history = store.rebuild_history(target)
+        hist_info, key_info = _wm_at(target)
+        store.rewind_head(bridge_id)
+        if log_path:
+            rewrite_projection(store, target, log_path)
+        return _res(history, hist_info, key_info, [], prefill,
+                    at_origin, bridge_id, nd.get("title", ""), to)
+
+    # ---- code:代码退到 target、对话留 old_head。桥接按会话拓扑挂在 old_head 的父节点,
+    #      自带 old_head 这一轮对话/WM,文件显式覆盖为 target 的代码状态。
+    if mode == "code":
+        try:
+            changed = store.apply_code(target)
+        except Exception:
+            changed = []
+        conv_parent = store.nodes.get(old_head, {}).get("parent")
+        conv_parent = conv_parent if conv_parent in store.nodes else old_head
+        conv_delta = list(store._node_conv(old_head) or [])
+        hinfo_delta = list(store._node_hinfo(old_head) or []) or None
+        bridge_files = dict(store.nodes[target]["files"])
+        bridge_id = store.commit_bridge(
+            parent=conv_parent, conv_delta=conv_delta, hinfo_delta=hinfo_delta,
+            kinfo=store.key_info_at(old_head), files_override=bridge_files,
+            title=_prompt_of(old_head), rw_tag="仅代码回退")
+        store.rewind_head(bridge_id)
+        # 对话没动 → history=None(前端不重赋 backend.history)、不重写投影日志
+        return _res(None, None, None, changed, prefill,
+                    at_origin, bridge_id, nd.get("title", ""), to)
+
+    return None  # 未知 mode
+
+
+def _res(history, hist_info, key_info, changed, prefill,
+         at_origin, target, title, to) -> dict:
+    """restore_plan 的返回 dict 构造器。"""
     return {
         "history": history,
         "hist_info": hist_info,
@@ -1122,6 +1206,6 @@ def restore_plan(store, node_id, mode: str = "both", to: str = "before",
         "prefill": prefill,
         "at_origin": at_origin,
         "target": target,
-        "title": nd.get("title", ""),
+        "title": title,
         "to": to,
     }

--- a/frontends/worldline.py
+++ b/frontends/worldline.py
@@ -173,8 +173,11 @@ class RewindStore:
 
         conv = None
         if history is not None:
-            parent_len = self.nodes[parent].get("hist_len") if parent is not None else 0
-            parent_len = parent_len or 0          # None(旧节点) / origin → 0
+            # 增量起点用【树重建的真实长度】而非 stored hist_len。原因:_rw_commit 喂的 history
+            # 取自日志全量(见集成层),而 stored hist_len 可能是早先压缩态 commit 留下的脏值;
+            # 删头后绝对下标会越界丢轮。以树实际已有长度为准:delta = 日志里树还没有的尾部 →
+            # 既不丢轮,也能自愈此前因压缩漏掉的轮(日志只增不改,恒 ⊇ 树)。
+            parent_len = len(self.rebuild_history(parent)) if parent is not None else 0
             delta = list(history[parent_len:])
             hist_len = len(history)
             conv = self._put_blob(
@@ -185,8 +188,7 @@ class RewindStore:
         hinfo = None
         hinfo_len = None
         if hist_info is not None:
-            parent_hlen = self.nodes[parent].get("hinfo_len") if parent is not None else 0
-            parent_hlen = parent_hlen or 0
+            parent_hlen = len(self.rebuild_hist_info(parent)) if parent is not None else 0
             hdelta = list(hist_info[parent_hlen:])
             hinfo_len = len(hist_info)
             hinfo = self._put_blob(

--- a/frontends/worldline.py
+++ b/frontends/worldline.py
@@ -51,7 +51,7 @@ class RewindStore:
 
     def __init__(self, root: str, cwd: str) -> None:
         self.root = os.path.abspath(root)
-        self.cwd = os.path.abspath(cwd)
+        self.cwd = os.path.realpath(cwd)   # realpath：与 key() 同基准，解析 junction/symlink
         self.objects_dir = os.path.join(self.root, "objects")
         self.tree_path = os.path.join(self.root, "tree.json")
 
@@ -98,8 +98,11 @@ class RewindStore:
 
     # ------------------------------------------------------------------ paths
     def key(self, abs_path: str) -> str:
-        """绝对路径在 cwd 下 → 存相对（参考 CC maybeShortenFilePath）；否则原样。"""
-        ap = os.path.abspath(abs_path)
+        """路径 → 规范 key：realpath 解析 junction/symlink，使同一物理文件只有一个身份
+        （workspace 的 junction 相对路径与真实绝对路径不再分裂成两个 key，避免 apply_code
+        对同一文件重复回写而损坏内容）；落在 cwd 下则存相对（参考 CC maybeShortenFilePath），
+        否则存绝对。"""
+        ap = os.path.realpath(abs_path)
         try:
             if os.path.commonpath([ap, self.cwd]) == self.cwd:
                 return os.path.relpath(ap, self.cwd).replace(os.sep, "/")
@@ -388,6 +391,18 @@ class RewindStore:
             out.append({"rel": rel, "old": self._text(ph), "new": self._text(nh)})
         return out
 
+    def node_line_delta(self, node_id) -> tuple[int, int]:
+        """本节点相对父节点的 (新增行, 删除行) 合计，仅计 file_write/file_patch 追踪的
+        文件。供 rewind/worldline 显示「代码变动行数」。"""
+        ins = dele = 0
+        for f in self.node_diff(node_id):
+            for line in difflib.ndiff(f["old"].splitlines(), f["new"].splitlines()):
+                if line.startswith("+ "):
+                    ins += 1
+                elif line.startswith("- "):
+                    dele += 1
+        return ins, dele
+
     def _text(self, h: str | None) -> str:
         if h is _ABSENT:
             return ""
@@ -581,8 +596,18 @@ class RewindStore:
         return chain
 
     # ----------------------------------------------------------- conversation
+    _PM_BLOCK_RE = re.compile(r"\s*-{3,}\s*\[PROJECT MODE:.*?(?:\n-{3,}\s*|$)", re.DOTALL)
+
+    @classmethod
+    def _strip_project_mode(cls, text: str) -> str:
+        """剔除 project_mode 插件注入块(可出现在旧 WORKING MEMORY 文本中间)。"""
+        return cls._PM_BLOCK_RE.sub("", text or "")
+
     def _node_conv(self, node_id) -> list:
-        """单节点的对话增量（list）。无 conv / 读失败 → []（容错降级）。"""
+        """单节点的对话增量（list）。无 conv / 读失败 → []（容错降级）。
+
+        runtime history 尊重当时真实 prompt,包括 project_mode 的当轮注入;用户可见
+        投影(标题/prefill/turn_sig/history_info)在各自入口清洗。"""
         h = self.nodes.get(node_id, {}).get("conv")
         if not h:
             return []
@@ -610,7 +635,9 @@ class RewindStore:
             return []
         try:
             data = json.loads(self._get_blob(h).decode("utf-8"))
-            return data if isinstance(data, list) else []
+            if not isinstance(data, list):
+                return []
+            return [self._strip_project_mode(str(x)) for x in data]
         except Exception:
             return []
 
@@ -642,20 +669,28 @@ class RewindStore:
         return False
 
     # ----------------------------------------------------- 对账(防外部改写灾难)
-    @staticmethod
-    def _msg_user_text(msg) -> str:
-        """真实用户提问文本;非 user / 纯 tool_result 回填 → ""(不算提问边界)。"""
+    @classmethod
+    def _msg_user_text(cls, msg) -> str:
+        """真实用户提问文本;非 user / 自动注入轮 → ""(不算提问边界)。"""
         if not isinstance(msg, dict) or msg.get("role") != "user":
             return ""
         c = msg.get("content")
         if isinstance(c, str):
-            return c
-        if isinstance(c, list):
+            text = cls._strip_project_mode(c)
+        elif isinstance(c, list):
             if any(isinstance(b, dict) and b.get("type") == "tool_result" for b in c):
                 return ""
-            return " ".join(b.get("text", "") for b in c
-                            if isinstance(b, dict) and b.get("type") == "text")
-        return ""
+            text = cls._strip_project_mode(" ".join(
+                b.get("text", "") for b in c
+                if isinstance(b, dict) and b.get("type") == "text"))
+        else:
+            return ""
+        text = (text or "").strip()
+        inject_markers = ("### [WORKING MEMORY]", "[SYSTEM TIPS]", "[DANGER]",
+                          "### [总结提炼经验]", "Continue from where you left off")
+        if not text or text.startswith(inject_markers):
+            return ""
+        return text
 
     @classmethod
     def _turn_sig(cls, msgs) -> list:
@@ -833,7 +868,7 @@ def files_summary(files: List[str]) -> str:
     return "、".join(files[:3]) + f" (+{len(files) - 3})"
 
 
-_TITLE_MAX_CELLS = 40
+_TITLE_MAX_CELLS = 54   # 左树标题截断宽度，对应 worldline 左栏 60%（3:2 布局）
 
 
 def ellipsize(s: str, max_cells: int = _TITLE_MAX_CELLS) -> str:
@@ -885,7 +920,7 @@ def tree_from_store(store, now: float) -> CheckpointTree:
     for nid, nd in store.nodes.items():
         t.nodes[nid] = CheckpointNode(
             id=nid,
-            title=nd.get("title") or "（空）",
+            title=store._strip_project_mode(nd.get("title") or "（空）").replace("\n", " ").strip() or "（空）",
             parent_id=nd.get("parent"),
             children=[c for c in nd.get("children", []) if c in store.nodes],
             kind="current" if nid == store.head else nd.get("kind", "edit"),
@@ -1119,7 +1154,7 @@ def restore_plan(store, node_id, mode: str = "both", to: str = "before",
         at_origin = parent is None
         if not at_origin:
             um = store.first_user_message(node_id)
-            prefill = (user_msg_text(um) if um else "") or nd.get("title", "")
+            prefill = (user_msg_text(um) if um else "") or store._strip_project_mode(nd.get("title", ""))
 
     old_head = store.head  # 回退前的 HEAD(代码/对话的「另一侧」来源)
 
@@ -1131,7 +1166,7 @@ def restore_plan(store, node_id, mode: str = "both", to: str = "before",
 
     def _prompt_of(node_id):
         um = store.first_user_message(node_id)
-        return (user_msg_text(um) if um else "") or store.nodes.get(node_id, {}).get("title", "")
+        return (user_msg_text(um) if um else "") or store._strip_project_mode(store.nodes.get(node_id, {}).get("title", ""))
 
     # ---- both:直接还原到 target(对话+代码),无桥接
     if mode == "both":
@@ -1145,7 +1180,7 @@ def restore_plan(store, node_id, mode: str = "both", to: str = "before",
         if log_path:
             rewrite_projection(store, target, log_path)
         return _res(history, hist_info, key_info, changed, prefill,
-                    at_origin, target, nd.get("title", ""), to)
+                    at_origin, target, store._strip_project_mode(nd.get("title", "")), to)
 
     # ---- conv:对话退到 target、代码留 old_head。桥接挂 fork(=parent(target),或 target 若 origin)
     if mode == "conv":
@@ -1169,7 +1204,7 @@ def restore_plan(store, node_id, mode: str = "both", to: str = "before",
         if log_path:
             rewrite_projection(store, target, log_path)
         return _res(history, hist_info, key_info, [], prefill,
-                    at_origin, bridge_id, nd.get("title", ""), to)
+                    at_origin, bridge_id, store._strip_project_mode(nd.get("title", "")), to)
 
     # ---- code:代码退到 target、对话留 old_head。桥接按会话拓扑挂在 old_head 的父节点,
     #      自带 old_head 这一轮对话/WM,文件显式覆盖为 target 的代码状态。
@@ -1188,9 +1223,10 @@ def restore_plan(store, node_id, mode: str = "both", to: str = "before",
             kinfo=store.key_info_at(old_head), files_override=bridge_files,
             title=_prompt_of(old_head), rw_tag="仅代码回退")
         store.rewind_head(bridge_id)
-        # 对话没动 → history=None(前端不重赋 backend.history)、不重写投影日志
-        return _res(None, None, None, changed, prefill,
-                    at_origin, bridge_id, nd.get("title", ""), to)
+        # 对话没动 → history=None(前端不重赋 backend.history)、不重写投影日志、
+        # 不 prefill(对话未回退,输入框不该被塞入选中节点的旧提问)。
+        return _res(None, None, None, changed, "",
+                    at_origin, bridge_id, store._strip_project_mode(nd.get("title", "")), to)
 
     return None  # 未知 mode
 

--- a/frontends/worldline.py
+++ b/frontends/worldline.py
@@ -20,6 +20,7 @@ import difflib
 import hashlib
 import json
 import os
+import re
 import shutil
 import time
 from datetime import datetime
@@ -614,10 +615,71 @@ class RewindStore:
         故不含注入的易变内容)。用于 reconcile 判两段是否同一对话。"""
         return [t for t in (cls._msg_user_text(m).strip() for m in msgs) if t]
 
+    # ---------------------------------- 从日志/历史重建工作记忆(reconcile 吸收外部轮时补 WM)
+    @staticmethod
+    def _all_text(msg) -> str:
+        """消息里所有 text block 的拼接(含 tool_result 轮注入的 WORKING MEMORY 文本)。"""
+        if not isinstance(msg, dict):
+            return ""
+        c = msg.get("content")
+        if isinstance(c, str):
+            return c
+        if isinstance(c, list):
+            return "\n".join(b.get("text", "") for b in c
+                             if isinstance(b, dict) and b.get("type") == "text")
+        return ""
+
+    @classmethod
+    def _summary_of(cls, msg) -> str:
+        """从 assistant 消息提取 `<summary>`(GA 轮级纪要的来源);无则退化取首行。
+        与 ga.turn_end_callback 的提取口径一致,使从日志重建的 history_info 贴近原值。"""
+        text = re.sub(r'```.*?```|<thinking>.*?</thinking>', '',
+                      cls._all_text(msg), flags=re.DOTALL)
+        m = re.search(r'<summary>(.*?)</summary>', text, re.DOTALL)
+        if m and m.group(1).strip():
+            return m.group(1).strip()[:80]
+        for line in text.splitlines():
+            if line.strip():
+                return line.strip()[:80]
+        return "（无摘要）"
+
+    @classmethod
+    def _derive_hist_info(cls, history) -> list:
+        """从对话历史重建 `handler.history_info`(轮级纪要):真实用户提问 → `[USER]: …`;
+        每条 assistant(=一轮) → `[Agent] <summary>`。这正是 GA 原本构建 history_info 的
+        方式,故 reconcile 从日志吸收外部/老会话轮次时可据此把工作记忆补回(否则续接后
+        rewind 到这些轮,纪要会缺失 → 串味)。"""
+        out: list = []
+        for m in history:
+            if not isinstance(m, dict):
+                continue
+            role = m.get("role")
+            if role == "user":
+                q = cls._msg_user_text(m).strip()   # tool_result 轮 → ""(非提问,不计)
+                if q:
+                    out.append(f"[USER]: {q}")
+            elif role == "assistant":
+                out.append(f"[Agent] {cls._summary_of(m)}")
+        return out
+
+    @classmethod
+    def _key_info_of(cls, history) -> Optional[str]:
+        """取历史里最后一个注入的 `<key_info>…</key_info>`(agent 便签);无则 None。"""
+        ki = None
+        for m in history:
+            for mt in re.finditer(r'<key_info>(.*?)</key_info>', cls._all_text(m), re.DOTALL):
+                ki = mt.group(1).strip()
+        return ki
+
     def reconcile(self, history: list) -> int:
-        """把 live history 里树尚未记录的尾部轮次吸收成 conv-only 节点,使树追平日志。
-        供「带 worldline 的 UI」在打开世界线 / 接管日志前调用 —— 别的(不更新树的)
-        UI 往同一日志追加后,若不对账,树会滞后;一旦在滞后状态 rewind,
+        """把 live history 里树尚未记录的尾部轮次吸收成节点,使树追平日志。
+
+        ⚠️ **契约**:`history` 必须是**日志解析出的全量历史**(`_parse_native_history`),
+        **禁止传压缩态的 `backend.history`**。对账是「日志 ↔ 树」两个全量真相源之间的事;
+        喂压缩/删头后的内存会让全量的树去迁就残缺副本——前缀比对失败 → 误判分歧 → 弃树
+        另起(详见下方安全闸)。调用方负责从日志取全量历史。
+
+        用途:别的(不更新树的)UI 往同一日志追加后树会滞后;一旦在滞后状态 rewind,
         `rewrite_projection` 会拿陈旧树回写、**抹掉那些外部轮次**(灾难性丢失)。
         对账后树恒 ⊇ 日志,故 rewind 物理上不可能 clobber 未见过的轮次。
 
@@ -655,7 +717,11 @@ class RewindStore:
                           for i in range(s, end)
                           if self._msg_user_text(history[i]).strip()), "")
             title = (title or "（外部续接）").replace("\n", " ").strip()[:80]
-            self.commit(title or "（外部续接）", kind="edit", history=list(history[:end]))
+            seg_hist = list(history[:end])
+            # 吸收时一并从日志重建工作记忆 → 续接/外部轮也能随 rewind 同步纪要(修缺口B)。
+            self.commit(title or "（外部续接）", kind="edit", history=seg_hist,
+                        hist_info=self._derive_hist_info(seg_hist),
+                        key_info=self._key_info_of(seg_hist))
             absorbed += end - s
         return absorbed
 


### PR DESCRIPTION
## 概要

为 tui_v2 增加**持久化 checkpoint 树 rewind（「世界线」）**：每轮对话落一个 checkpoint 节点，支持 `/rewind`（内联卡片，三列：用户提问 · 上次时间 · 代码增删）与 `/worldline`（全屏压缩树浏览器 + 逐行 diff）回退，可选 **对话 / 代码 / 两者** 三种恢复模式，`/continue` 后不复活（落盘到 `temp/.ga_rewind/`）。

## 改动范围

仅 3 个文件，`+2606 / -48`：
- `frontends/worldline.py`（新增）— UI 无关的核心：`RewindStore` 持久层（content-addressable blob + delta 链）/ `CheckpointTree`+`CompressedTree` 视图模型 / `restore_plan` 恢复编排 / native 日志读写。
- `frontends/tuiapp_v2.py` — TUI 集成：`/rewind` 卡片、`/worldline` 面板、`_rw_commit`/`_rw_restore_node` 只做「赋 backend + 刷新」，编排全在 worldline。
- `frontends/continue_cmd.py` — `parse_native_log` 公共封装、`/continue` 的 opt-in `restore_wm`。

## 关键设计

- **日志为真相源**：树每轮从 append-only 的 `model_responses_*.txt` 全量重建，天然免疫上下文压缩/删头；对账（reconcile）**只在 `/continue`（未压缩日志刚载入）时做**，会话进行中不拿被压缩的 live history 对账，避免误判分歧而弃树。
- **约束进结构**：唯一虚拟根消除 forest/HEAD=None 特例；`_turn_sig` 前缀比对把「树 ⊇ 日志」做成可执行安全闸。
- **回退失败不静默**：`apply_code` 中途出错回传 `code_error`，UI 提示「代码回退未完成，请检查」，而非当作无变更悄悄放过。
- **工作记忆同步**：rewind 时纪要/便签随对话硬同步到回退点。

## 兼容性

- 全部 opt-in、默认关；`store is None` 处处兜底 → 对其它前端（tui_v3 / desktop / stapp）**零影响**。
- workspace 场景修复：`realpath` 归一化 junction/symlink，同一物理文件只产生一个 checkpoint key（修双 key 导致的误覆写）。

## 测试

本地回归：世界线包含语义 29/29、project-mode 剥离 10/10、rewind prefill 无注入 9/9、workspace 双 key 6/6。三前端文件 `py_compile` + `import` 通过。
