### PR TITLE
fix(stapp): raise Loop prompt textarea height from 1 to 68 to satisfy Streamlit minimum (closes #632)

### DIFF
--- a/frontends/stapp.py
+++ b/frontends/stapp.py
@@ -142,7 +142,7 @@ def render_sidebar():
         field-sizing: content; min-height: 1.6em !important; height: auto !important;
     }
     </style>""", unsafe_allow_html=True)
-    st.text_area("Loop prompt", value=st.session_state.get('loop_prompt_input', "继续" if LANG=='zh' else 'next'), key="loop_prompt_input", height=1)
+    st.text_area("Loop prompt", value=st.session_state.get('loop_prompt_input', "继续" if LANG=='zh' else 'next'), key="loop_prompt_input", height=68)
     if st.session_state.get('loop_enabled'):
         if st.button("⏹️ Stop Loop"):
             st.session_state.loop_enabled = False


### PR DESCRIPTION
## Summary

Raise the Loop prompt textarea minimum height from 1px to 68px to satisfy Streamlit's hard lower bound on `st.text_area`, which was throwing `StreamlitAPIException` during sidebar render and collapsing the whole page so the main chat input never appeared.

## Root Cause

The exception originates at `frontends/stapp.py:145` (was line 124 at the time the issue was filed):

```python
st.text_area("Loop prompt", ..., height=1)
```

Streamlit's runtime validation rejects `height=1` with:

> `StreamlitAPIException: Invalid height 1px for st.text_area - must be at least 68 pixels.`

Sidebar rendering fails → the entire page collapses → the user sees no chat input dialog.

## Fix

```diff
-    st.text_area("Loop prompt", ..., key="loop_prompt_input", height=1)
+    st.text_area("Loop prompt", ..., key="loop_prompt_input", height=68)
```

68px is exactly Streamlit's documented minimum. The existing sidebar CSS still overrides the visible height (`min-height: 1.6em !important; height: auto !important`), so the field continues to grow with content — this change only unblocks Streamlit's API gate.

## Scope

- 1 line changed in `frontends/stapp.py`
- No tests added: the failure is a UI-rendering crash on Streamlit side, not a unit-testable logic path.

Closes #632