### PR TITLE
refactor(ga): wrap cr_header read in context manager to close file handle

### DIFF
--- a/ga.py
+++ b/ga.py
@@ -24,7 +24,8 @@ def code_run(code, code_type="python", timeout=60, cwd=None, code_cwd=None, stop
     if code_type in ["python", "py"]:
         tmp_file = tempfile.NamedTemporaryFile(suffix=".ai.py", delete=False, mode='w', encoding='utf-8', dir=code_cwd)
         cr_header = os.path.join(script_dir, 'assets', 'code_run_header.py')
-        if os.path.exists(cr_header): tmp_file.write(open(cr_header, encoding='utf-8').read())
+        if os.path.exists(cr_header):
+            with open(cr_header, encoding='utf-8') as _h: tmp_file.write(_h.read())
         tmp_file.write(code)
         tmp_path = tmp_file.name
         tmp_file.close()


### PR DESCRIPTION
## Summary

Wrap the `cr_header` file read inside `code_run` in a `with` block so the file descriptor is closed deterministically instead of relying on garbage collection.

## Change

`ga.py` ~L27 — the only remaining bare `open(...).read()` in the `code_run` Python path:

```diff
-        if os.path.exists(cr_header): tmp_file.write(open(cr_header, encoding='utf-8').read())
+        if os.path.exists(cr_header):
+            with open(cr_header, encoding='utf-8') as _h: tmp_file.write(_h.read())
```

## Why

- Same pattern as PR #575 / #98 — the rest of the codebase already moved to `with` for file reads.
- `code_run` is on every agent action; over a long session this leaks descriptors until GC. With Windows + Python 3.12 + a chatty session, this can show up as `ResourceWarning: unclosed file <_io.TextIOWrapper ...>`.
- PR #488 (closed) targeted this area; PR #575 (open) did not include this specific site.

## Scope

- 1 file (`ga.py`), 2 insertions, 1 deletion. Net behavior identical.
- No tests added: the failure mode is a runtime warning, not a unit-testable branch.

## Risk

Minimal. The file is opened, fully read into memory, then written to `tmp_file`. Behavior with `with` is identical to naked `open` except the FD is closed at block exit.