### PR TITLE
fix(tui-v2): detach tool subprocess stdin

### DIFF
--- a/frontends/tuiapp_v2.py
+++ b/frontends/tuiapp_v2.py
@@ -1469,7 +1469,8 @@ _HAS_WAYLAND = bool(os.environ.get("WAYLAND_DISPLAY"))
 
 def _clipboard_run(cmd: list[str], input: bytes | None = None, timeout: float = 3.0) -> bytes | None:
     try:
-        r = subprocess.run(cmd, input=input, capture_output=True, timeout=timeout)
+        stdin = subprocess.DEVNULL if input is None else None
+        r = subprocess.run(cmd, input=input, stdin=stdin, capture_output=True, timeout=timeout)
         return r.stdout if r.returncode == 0 else None
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return None
@@ -6365,7 +6366,7 @@ class GenericAgentTUI(App[None]):
         out = ''; rc = 0
         try:
             r = subprocess.run(
-                shell_argv + [cmd], capture_output=True,
+                shell_argv + [cmd], stdin=subprocess.DEVNULL, capture_output=True,
                 timeout=30, encoding='utf-8', errors='replace',
             )
             out = (r.stdout or '') + (r.stderr or '')

--- a/ga.py
+++ b/ga.py
@@ -56,7 +56,8 @@ def code_run(code, code_type="python", timeout=60, cwd=None, code_cwd=None, stop
 
     try:
         process = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            cmd, stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
             bufsize=0, cwd=cwd, startupinfo=startupinfo,
             creationflags=0x08000000 if os.name == 'nt' else 0
         )


### PR DESCRIPTION
## Summary
- Stop `code_run` tool subprocesses from inheriting the TUI terminal stdin.
- Do the same for tuiapp_v2 `!shell` commands.
- Keep clipboard copy helpers from inheriting stdin when they are not fed input.

## Why
On POSIX terminals, child processes that inherit fd 0 can race Textual for keyboard input while tools are running. This shows up most often on macOS/Linux with multiple active tui2 sessions as randomly swallowed letters, spaces, or Enter.

## Notes
- Windows behavior is unchanged.
- Clipboard helpers still receive stdin when `input=` is provided.
- This intentionally does not change `memory/checklist_helper.py` from #656.

## Verification
- `PYTHONIOENCODING=utf-8 py -3.12 -m py_compile ga.py frontends/tuiapp_v2.py`
- `code_run` smoke test: Python child sees stdin EOF (`sys.stdin.read() == ''`) while stdout capture still works.
