### PR TITLE
fix: make long-prompt temp files unique under concurrency

### DIFF
--- a/agentmain.py
+++ b/agentmain.py
@@ -146,7 +146,7 @@ class GenericAgent:
                 self.task_queue.task_done(); continue
             self.is_running = True
             if len(raw_query) > 2000:
-                task_file = os.path.join(script_dir, 'temp', f'user_prompt_{int(time.time())}.md')
+                task_file = os.path.join(script_dir, 'temp', f'user_prompt_{os.getpid()}_{time.time_ns()}.md')
                 with open(task_file, 'w', encoding='utf-8') as f: f.write(raw_query)
                 raw_query = f'Long user prompt saved to {task_file}. Read and execute.'
             rquery = smart_format(raw_query.replace('\n', ' '), max_str_len=200)


### PR DESCRIPTION
## Summary
Fixes #665

When a prompt exceeds 2000 chars, `agentmain.py` writes it to:
```python
temp/user_prompt_{int(time.time())}.md
```

Second-granularity names collide under concurrent `--func` / `run_subagents` runs, so one task can read another task's prompt.

## Change
```python
temp/user_prompt_{os.getpid()}_{time.time_ns()}.md
```

This matches the issue's suggested fix and keeps the same write/read flow.

## Testing
- Inspected the single call site in `agentmain.py`
- Naming now includes pid + nanosecond timestamp, so same-second concurrent processes cannot share a path