### PR TITLE
feat(desktop): macos remove system top bar to enhance ui

### DIFF
--- a/frontends/desktop/src-tauri/capabilities/default.json
+++ b/frontends/desktop/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "core:window:allow-show",
     "core:window:allow-hide",
     "core:window:allow-set-focus",
+    "core:window:allow-start-dragging",
     "core:window:allow-close",
     "core:window:allow-get-all-windows",
     "core:webview:default",

--- a/frontends/desktop/src-tauri/src/lib.rs
+++ b/frontends/desktop/src-tauri/src/lib.rs
@@ -946,11 +946,15 @@ pub fn run() {
     let no_autostart = args.iter().any(|a| a == "--no-autostart");
     let dev_mode = args.iter().any(|a| a == "--dev");
 
-    // Resolve the effective config once. project_dir is ALWAYS the bundle's own (方案三: we run
-    // our own bridge/frontend); the external核, if any, is injected via GA_ROOT in
-    // sanitize_bundle_env. Identity/takeover must compare against the EFFECTIVE ga_root (what the
-    // bridge will report), not the bundle script dir.
-    let (eff_py, eff_project) = get_or_discover_config();
+    // Resolve the effective config once. Development must use the checkout that produced this
+    // binary; otherwise a persisted path from an installed macOS app can make `tauri dev` serve
+    // stale frontend files from /Applications. Do not persist the temporary dev paths.
+    // Packaged builds still use their bundled runtime (or the normal saved-config discovery).
+    let (eff_py, eff_project) = if dev_mode {
+        (find_python(), find_project_dir().unwrap_or_default())
+    } else {
+        get_or_discover_config()
+    };
     let effective_ga_root = valid_ga_source_override().unwrap_or_else(|| eff_project.clone());
     let needs_prepare = needs_first_run_prepare(&eff_project);
 

--- a/frontends/desktop/src-tauri/tauri.macos.conf.json
+++ b/frontends/desktop/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,33 @@
+{
+  "app": {
+    "windows": [
+      {
+        "title": "GenericAgent",
+        "label": "main",
+        "width": 1280,
+        "height": 800,
+        "resizable": true,
+        "decorations": true,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "trafficLightPosition": {
+          "x": 18,
+          "y": 26
+        },
+        "maximized": false,
+        "visible": false,
+        "url": "loading.html"
+      },
+      {
+        "title": "GenericAgent — Setup",
+        "label": "setup",
+        "width": 600,
+        "height": 580,
+        "resizable": false,
+        "visible": false,
+        "center": true,
+        "url": "fallback.html"
+      }
+    ]
+  }
+}

--- a/frontends/desktop/static/index.html
+++ b/frontends/desktop/static/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <title>GenericAgent</title>
 <link rel="stylesheet" href="assets/fonts/fonts.css?v=2">
-<link rel="stylesheet" href="styles.css?v=186">
+<link rel="stylesheet" href="styles.css?v=192">
 <!-- KaTeX: LaTeX 公式渲染 -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
 <!-- highlight.js: 代码高亮 -->
@@ -41,6 +41,11 @@
   var hljs=document.getElementById('hljs-theme');
   if(hljs&&app==='dark') hljs.href='https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css';
   try{ var sraw=localStorage.getItem('ga_sessions'); if(sraw && JSON.parse(sraw).length) document.documentElement.dataset.bootHasSessions='1'; }catch(_){}
+  var nav_platform=navigator.platform;
+  document.documentElement.dataset.platform =
+    /Mac/i.test(nav_platform) ? 'macos' :
+    /Win/i.test(nav_platform) ? 'windows' :
+    'linux';
 })();
 </script>
 </head>
@@ -52,7 +57,8 @@
 
     <!-- ① 左侧边栏 -->
     <aside class="sidebar">
-      <div class="brand">
+      <div class="sidebar-top-drag-region" data-tauri-drag-region="deep"></div>
+      <div class="brand" data-tauri-drag-region="deep">
         <div class="brand-text">
           <div class="brand-name ga-wordmark">Generic Agent</div>
           <div class="brand-sub" data-i18n="brand.sub"></div>
@@ -131,6 +137,7 @@
 
     <!-- 中间主区 -->
     <main class="main">
+      <div class="main-top-drag-region" data-tauri-drag-region="deep"></div>
 
       <div id="pages">
 

--- a/frontends/desktop/static/loading.html
+++ b/frontends/desktop/static/loading.html
@@ -7,6 +7,7 @@
 :root{font-family:-apple-system,BlinkMacSystemFont,"SF Pro Text","Segoe UI","Microsoft YaHei UI","Helvetica Neue",Helvetica,Arial,sans-serif;background:#fff;color:#111}
 @media(prefers-color-scheme:dark){:root{background:#1a1a1a;color:#eee}}
 html,body{height:100%;margin:0;display:flex;align-items:center;justify-content:center}
+.window-drag-region{position:fixed;inset:0 0 auto;height:42px;z-index:10;-webkit-user-select:none;user-select:none}
 .card{text-align:center;opacity:.85;width:280px}
 .spinner{width:28px;height:28px;margin:0 auto 14px;border:3px solid #9994;border-top-color:currentColor;border-radius:50%;animation:spin 1s linear infinite}
 @keyframes spin{to{transform:rotate(360deg)}}
@@ -41,6 +42,7 @@ document.addEventListener('DOMContentLoaded', function(){
 </script>
 </head>
 <body>
+  <div class="window-drag-region" data-tauri-drag-region="deep"></div>
   <div class="card">
     <div class="spinner"></div>
     <div id="ga-status" data-i18n="loading.starting_app"></div>

--- a/frontends/desktop/static/styles.css
+++ b/frontends/desktop/static/styles.css
@@ -2,6 +2,7 @@
    仅布局与视觉占位。所有颜色均走 CSS 变量，主题可整体切换（无硬编码颜色）。 */
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
+[data-tauri-drag-region]{ -webkit-user-select:none; user-select:none; }
 
 /* —— 全局滚动条 —— */
 ::-webkit-scrollbar{ width:6px; height:6px; }
@@ -504,9 +505,17 @@ body{ background:var(--bg); color:var(--txt); font-size:13px; overflow:hidden; f
   border-right:1px solid var(--divider); border-radius:0; box-shadow:none;
   overflow:hidden; display:flex; flex-direction:column;
   padding:var(--shell-pad) 12px 12px;
+  position:relative;
   box-sizing:border-box;
   transition:width .2s, padding .2s, opacity .15s;
 }
+.sidebar-top-drag-region{
+  position:absolute; inset:0 0 auto; height:var(--shell-pad);
+}
+html[data-platform="macos"] .sidebar{
+  padding-top:52px;
+}
+html[data-platform="macos"] .sidebar-top-drag-region{ height:52px; }
 .brand{
   display:flex; align-items:center; gap:0;
   flex:0 0 var(--shell-head-h);
@@ -652,7 +661,11 @@ body{ background:var(--bg); color:var(--txt); font-size:13px; overflow:hidden; f
   border:0;
   border-radius:0; box-shadow:none; overflow:hidden;
   padding-top:var(--shell-pad);
+  position:relative;
   box-sizing:border-box;
+}
+.main-top-drag-region{
+  position:absolute; inset:0 0 auto; height:var(--shell-pad);
 }
 
 .topbar{
@@ -689,6 +702,7 @@ body{ background:var(--bg); color:var(--txt); font-size:13px; overflow:hidden; f
 .pt-icon svg{ width:16px; height:16px; transition:transform .2s; }
 .body.sb-collapsed .pt-sb-toggle svg,
 .body.rp-collapsed .pt-rp-toggle svg{ transform:rotate(180deg); }
+html[data-platform="macos"] .body.sb-collapsed .pt-sb-toggle{ margin-left:75px; }
 .pt-spacer{ flex:1 1 auto; }
 .tb-left{ display:flex; align-items:center; gap:14px; font-size:12px; }
 .pill{


### PR DESCRIPTION
The macOS version of Generic Agent desktop application got system top bar:

<img width="700" alt="Screenshot 2026-07-22 at 14 35 25" src="https://github.com/user-attachments/assets/acaebddc-696c-4fc4-b919-bd35469607bb" />

However, nowadays macOS applications don't have system top bar anymore. Removing system top bar makes the application look more modern. For example, Codex (macOS version) don't have system top bar.

<img width="700" alt="Screenshot 2026-07-22 at 15 20 39" src="https://github.com/user-attachments/assets/8711f8d6-75a8-4586-865b-af6f93c02a7a" />

This PR removes such system top bar with minimal diff. Window dragging ability is kept. Experiences on non-macOS systems are not affected. By doing this, the UI of the macOS application is enhanced.

<img width="700" alt="Screenshot 2026-07-23 at 14 30 15" src="https://github.com/user-attachments/assets/48ec99d2-0c3b-4e4a-be03-f66b9db8df61" />

<img width="700" alt="Screenshot 2026-07-22 at 15 15 02" src="https://github.com/user-attachments/assets/7a5c1a46-c861-420c-b355-8c3c1d85bf72" />
