### PR TITLE
fix(agentmain): reject unknown CLI arguments (v3, re-roll onto current main)

### DIFF
--- a/agentmain.py
+++ b/agentmain.py
@@ -207,6 +207,12 @@ if __name__ == '__main__':
     parser.add_argument('--nolog', action='store_true')
     parser.add_argument('--no-user-tools', action='store_true')
     args, _unknown = parser.parse_known_args()
+    if _unknown and not args.reflect:
+        # Reject unknown CLI flags unless we are in --reflect mode, where
+        # extra key/value pairs are forwarded to the reflect script as parameters.
+        # Without this guard, typos like `--goal` silently fall through to
+        # interactive mode and the process looks alive without doing any work.
+        parser.error(f"unrecognized arguments: {' '.join(_unknown)}")
     _extra_args = dict(zip([k.lstrip('-') for k in _unknown[::2]], _unknown[1::2])) if _unknown else {}
 
     if (args.func or args.task) and not args.nobg:


### PR DESCRIPTION
## Summary

Reject unsupported command-line arguments before GenericAgent initializes. This makes mistyped launch modes such as `--goal` fail with argparse's non-zero error instead of falling through to the interactive path.

## Problem

`agentmain.py` used `parse_known_args()` and silently ignored unknown flags. A typo like `--goal` (intended for a different launcher) was accepted without warning, causing the process to fall through to interactive mode and hang without dispatching any work — users reported "agent launched but did nothing."

## Fix

Single-source change in `agentmain.py`: when `_unknown` (leftover from `parse_known_args()`) is non-empty AND `--reflect` is not active, call `parser.error()` to print usage and exit non-zero.

`--reflect` mode is exempted because reflect scripts receive the extra key/value pairs as parameters and need them forwarded (existing behavior preserved).

```python
args, _unknown = parser.parse_known_args()
if _unknown and not args.reflect:
    # Reject unknown CLI flags unless we are in --reflect mode, where
    # extra key/value pairs are forwarded to the reflect script as parameters.
    # Without this guard, typos like `--goal` silently fall through to
    # interactive mode and the process looks alive without doing any work.
    parser.error(f"unrecognized arguments: {' '.join(_unknown)}")
_extra_args = dict(zip([k.lstrip('-') for k in _unknown[::2]], _unknown[1::2])) if _unknown else {}
```

## Verification

- `python3 -m py_compile agentmain.py` — syntax OK
- Regression harness at `/tmp/test_issue_566.py` — 4 checks:
  - **test_source_has_guard**: confirms `if _unknown and not args.reflect` + `parser.error` are present.
  - **test_unknown_arg_rejected**: `python3 agentmain.py --goal /tmp/foo.json` exits with code 2 and the message `unrecognized arguments: --goal /tmp/foo.json`.
  - **test_help_still_works**: `--help` exits 0 without the new guard firing.
  - **test_extra_args_dict_still_populated_for_reflect**: the `_extra_args` dict assignment is untouched.
- Three-step dance (stash → test fails on main → pop → test passes with fix) confirms the test catches the regression.

## Scope

- 1 file, +6/-0 lines
- Single argparse guard, no runtime logic change
- Closes #566
