### PR TITLE
fix(agentmain): make /resume fall back to L4 archives (v2, re-roll onto current main)

### DIFF
--- a/agentmain.py
+++ b/agentmain.py
@@ -130,7 +130,14 @@ class GenericAgent:
             display_queue.put({'done': smart_format(f"✅ session.{k} = {repr(v)}", max_str_len=500), 'source': 'system'})
             return None
         if raw_query.strip() == '/resume':
-            return r'帮我看看最近有哪些会话可以恢复。读model_responses/目录，按修改时间取最近10个文件，从每个文件里找最后一个<history>...</history>块，用一句话总结每个会话在聊什么，列表给我选。注意读文件后要把字面的\n替换成真换行才能正确匹配。'
+            return (r'帮我看看最近有哪些会话可以恢复。'
+                    r'先列 temp/model_responses/ 目录（按修改时间取最近10个文件）。'
+                    r'如果该目录里的 .txt 少于 5 个（L4 归档已清理原始文件），'
+                    r'回退读 memory/L4_raw_sessions/all_histories.txt（汇总的会话历史），'
+                    r'或解压 memory/L4_raw_sessions/{YYYY-MM}.zip 取最近的月度归档。'
+                    r'从每个文件里找最后一个<history>...</history>块，'
+                    r'用一句话总结每个会话在聊什么，列表给我选。'
+                    r'注意读文件后要把字面的\n替换成真换行才能正确匹配。')
         return raw_query
 
     def run(self):


### PR DESCRIPTION
## Summary

Extend the `/resume` slash command prompt so the agent falls back to L4 archive artifacts (`all_histories.txt`, `{YYYY-MM}.zip` in `memory/L4_raw_sessions/`) when fewer than 5 raw `.txt` files remain in `temp/model_responses/`.

## Problem

`memory/L4_raw_sessions/compress_session.py` archives raw session `.txt` files once it merges them into `all_histories.txt` and the monthly `{YYYY-MM}.zip` archives. The `/resume` handler in `agentmain.py` hardcoded the prompt to read `temp/model_responses/` only — so users who ran `/resume` after L4 archival completed saw an empty session list, even though their history was recoverable from the archives.

## Fix

Single-source change in `agentmain.py`: extend the `/resume` prompt so the agent first tries `temp/model_responses/` (live), and on `<5 files remaining` falls back to `memory/L4_raw_sessions/all_histories.txt` (consolidated history) or `memory/L4_raw_sessions/{YYYY-MM}.zip` (monthly archive).

```python
if raw_query.strip() == '/resume':
    return (r'帮我看看最近有哪些会话可以恢复。'
            r'先列 temp/model_responses/ 目录（按修改时间取最近10个文件）。'
            r'如果该目录里的 .txt 少于 5 个（L4 归档已清理原始文件），'
            r'回退读 memory/L4_raw_sessions/all_histories.txt（汇总的会话历史），'
            r'或解压 memory/L4_raw_sessions/{YYYY-MM}.zip 取最近的月度归档。'
            r'从每个文件里找最后一个<history>...</history>块，'
            r'用一句话总结每个会话在聊什么，列表给我选。'
            r'注意读文件后要把字面的\n替换成真换行才能正确匹配。')
```

## Verification

- `python3 -m py_compile agentmain.py` — syntax OK
- Regression harness at `/tmp/test_issue_630.py` — 4 checks:
  - **test_old_prompt_gone**: confirms the original `/resume` prompt string was removed.
  - **test_new_prompt_present**: confirms `all_histories.txt`, `memory/L4_raw_sessions`, `{YYYY-MM}.zip`, and `少于 5 个` (fallback threshold) are all present.
  - **test_resume_branch_still_wired**: confirms `if raw_query.strip() == '/resume':` is still in the file.
  - **test_resume_returns_nonempty_string**: confirms the `return` statement still starts with the resume directive.
- Three-step dance (stash → test fails on main → pop → test passes with fix) confirms the test catches the regression.

## Scope

- 1 file, +8/-1 lines
- Pure prompt string change — no runtime logic, no schema impact, no migration
- Closes #630
