### PR TITLE
fix: reasoning_effort "max" silently became "medium" for Claude

### DIFF
--- a/llmcore.py
+++ b/llmcore.py
@@ -588,7 +588,7 @@ class BaseSession:
                     thinking["budget_tokens"] = self.thinking_budget_tokens; payload["thinking"] = thinking
             else: payload["thinking"] = thinking
         if self.reasoning_effort:
-            effort = {'low': 'low', 'medium': 'medium', 'high': 'high', 'xhigh': 'max'}.get(self.reasoning_effort)
+            effort = {'low': 'low', 'medium': 'medium', 'high': 'high', 'xhigh': 'max', 'max': 'max'}.get(self.reasoning_effort)
             if effort: payload["output_config"] = {"effort": effort}
             else: print(f"[WARN] reasoning_effort {self.reasoning_effort!r} is unsupported for Claude output_config.effort, ignored.")
     def ask(self, prompt):


### PR DESCRIPTION
## What
Add `'max': 'max'` to the Claude `reasoning_effort` mapping in `_apply_claude_thinking` (llmcore.py).

## Why
`reasoning_effort` accepts `max` at config level (`_enum` includes it), but the Claude mapping only knew `low/medium/high/xhigh`. Setting `max` hit the WARN branch and dropped the field entirely; then the `fake_cc_system_prompt` path injected the default `{"effort": "medium"}` — so a user who configured `max` silently sent `medium` to the API.

`xhigh -> max` still works unchanged; `max` is now a direct alias.

## Testing
- `py_compile` passes.
- Unit-exercised `_apply_claude_thinking` on a stub: `max -> max`, `xhigh -> max`, `medium -> medium`, `none -> WARN/ignored` (unchanged).
