### PR TITLE
feat: add Atlas Cloud provider preset

### DIFF
--- a/assets/configure_mykey.py
+++ b/assets/configure_mykey.py
@@ -82,6 +82,25 @@ LLM_PROVIDERS = [
     },
     # ═══════════════════════════ 直连 API（按旗舰能力降序）═══════════════════════════
     {
+        'id': 'atlascloud',
+        'name': 'Atlas Cloud (DeepSeek / Qwen)',
+        'desc': 'OpenAI 兼容的多模型 API，支持 DeepSeek、Qwen 等模型',
+        'type': 'native_oai',
+        'template': {
+            'name': 'atlascloud', 'apikey': '<your-atlas-cloud-key>',
+            'apibase': 'https://api.atlascloud.ai/v1',
+            'model': 'deepseek-ai/deepseek-v4-pro',
+            'api_mode': 'chat_completions', 'reasoning_effort': 'high',
+            'max_retries': 3, 'connect_timeout': 10, 'read_timeout': 120,
+        },
+        'key_hint': '在 https://www.atlascloud.ai/ 获取 API Key',
+        'model_choices': [
+            'deepseek-ai/deepseek-v4-pro',
+            'deepseek-ai/deepseek-v4-flash',
+            'qwen/qwen3.5-flash',
+        ],
+    },
+    {
         'id': 'deepseek',
         'name': 'DeepSeek (v4-Pro / Flash)',
         'desc': '开源模型，v4-Pro 旗舰 1M 上下文',

--- a/tests/test_configure_mykey.py
+++ b/tests/test_configure_mykey.py
@@ -1,0 +1,42 @@
+import importlib.util
+import json
+import pathlib
+import unittest
+from unittest import mock
+
+
+MODULE_PATH = pathlib.Path(__file__).parents[1] / 'assets' / 'configure_mykey.py'
+SPEC = importlib.util.spec_from_file_location('configure_mykey', MODULE_PATH)
+CONFIGURE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CONFIGURE)
+
+
+class ProviderConfigurationTest(unittest.TestCase):
+    def test_atlascloud_preset_uses_native_oai(self):
+        provider = next(p for p in CONFIGURE.LLM_PROVIDERS if p['id'] == 'atlascloud')
+
+        self.assertEqual(provider['type'], 'native_oai')
+        self.assertEqual(provider['template']['apibase'], 'https://api.atlascloud.ai/v1')
+        self.assertEqual(provider['template']['model'], 'deepseek-ai/deepseek-v4-pro')
+        self.assertEqual(provider['template']['api_mode'], 'chat_completions')
+
+    @mock.patch.object(CONFIGURE, '_get_proxy_handler', return_value=None)
+    @mock.patch.object(CONFIGURE.urllib.request, 'build_opener')
+    def test_atlascloud_model_probe_uses_bearer_auth(self, build_opener, _proxy):
+        opener = build_opener.return_value
+        response = opener.open.return_value.__enter__.return_value
+        response.read.return_value = json.dumps(
+            {'data': [{'id': 'z-model'}, {'id': 'a-model'}]}
+        ).encode()
+        provider = next(p for p in CONFIGURE.LLM_PROVIDERS if p['id'] == 'atlascloud')
+
+        models = CONFIGURE.probe_models(provider, 'test-key')
+
+        self.assertEqual(models, ['a-model', 'z-model'])
+        request = opener.open.call_args.args[0]
+        self.assertEqual(request.full_url, 'https://api.atlascloud.ai/v1/models')
+        self.assertEqual(request.get_header('Authorization'), 'Bearer test-key')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- add Atlas Cloud as a first-class `native_oai` provider preset
- default to the OpenAI-compatible `/v1` endpoint and `deepseek-ai/deepseek-v4-pro`
- cover the preset and Bearer-authenticated `/models` discovery contract with focused tests

Closes #708

## Validation

- `python3 -m unittest tests/test_configure_mykey.py` (2 passed)
- `python3 -m compileall -q assets/configure_mykey.py tests/test_configure_mykey.py`
- `git diff --check`
- live provider probe: 121 models returned; all three preset model IDs found

No README or dependency changes.