### PR TITLE
fix(llmcore): use neutral default identity for native Claude sessions (closes #712)

### DIFF
--- a/llmcore.py
+++ b/llmcore.py
@@ -775,7 +775,7 @@ class NativeClaudeSession(BaseSession):
             tools = [dict(t) for t in claude_tools]; tools[-1]["cache_control"] = {"type": "ephemeral"}
             payload["tools"] = tools
         else: print("[ERROR] No tools provided for this session.")
-        payload['system'] = [{"type": "text", "text": "You are Claude Code, Anthropic's official CLI for Claude.", "cache_control": {"type": "ephemeral"}}]
+        payload['system'] = [{"type": "text", "text": "You are Claude Code, Anthropic's official CLI for Claude." if self.fake_cc_system_prompt else "You are a capable AI assistant running in GenericAgent framework.", "cache_control": {"type": "ephemeral"}}]
         #payload['system'][0]['text'] += f"\nPlatform: {sys.platform}"
         if self.system:
             if self.fake_cc_system_prompt: payload["system"].append({"type": "text", "text": self.system})


### PR DESCRIPTION
## Summary

The `NativeClaudeSession.raw_ask` default identity prompt was hard-coded to
`You are Claude Code, Anthropic's official CLI for Claude.`. On machines
where `self.system` is empty (e.g. a freshly-copied portable directory that
fails to load `mykey.py`), the model retained the Claude Code identity and
introduced itself as Claude Code.

This PR swaps the unconditional default for a neutral identity and only
emits the Claude Code framing when the user has explicitly opted into the
CC-protocol relay via `fake_cc_system_prompt=True`. Existing
`fake_cc_system_prompt=True` setups are preserved bit-for-bit.

## Fix

`llmcore.py` line 778 — the literal string is replaced with a conditional
expression:

```diff
-        payload['system'] = [{"type": "text", "text": "You are Claude Code, Anthropic's official CLI for Claude.", "cache_control": {"type": "ephemeral"}}]
+        payload['system'] = [{"type": "text", "text": "You are Claude Code, Anthropic's official CLI for Claude." if self.fake_cc_system_prompt else "You are a capable AI assistant running in GenericAgent framework.", "cache_control": {"type": "ephemeral"}}]
```

The downstream branches (`if self.fake_cc_system_prompt: payload["system"].append(...)` vs
`else: payload["system"] = [...]`) already condition on `fake_cc_system_prompt`,
so only the unconditional seed prompt needed gating.

## Scope

- 1 file changed: `llmcore.py`
- 1 insertion, 1 deletion
- No new tests added to `tests/` (the repo has no pytest suite); the
  regression harness lives at `/tmp/test_issue_712.py` and is documented below.

## Verification

`/tmp/test_issue_712.py` exercises `NativeClaudeSession.raw_ask` with a
stubbed `requests.post` and asserts the outgoing `system` payload:

| # | Scenario | `system[0].text` | `system[1].text` (if `self.system`) |
|---|----------|-------------------|--------------------------------------|
| 1 | `fake_cc_system_prompt=False`, `self.system=""` | neutral identity | (absent) |
| 2 | `fake_cc_system_prompt=True`, `self.system="Custom system prompt"` | Claude Code identity | Custom system prompt |

Three-step dance (stash → test fails on main because the literal still
contains `You are Claude Code` → pop → test passes with the fix) confirms
the harness catches the regression.

```text
$ python3 -m py_compile llmcore.py
✓ py_compile OK

$ python3 /tmp/test_issue_712.py
all identity prompt checks passed
```

## Backward compatibility

- `fake_cc_system_prompt=True` (the documented path for CC relay channels
  per `mykey_template.py`) keeps emitting the original Claude Code
  identity text byte-for-byte.
- `self.system` is still prepended as before for CC relay channels, and
  used to override the default for the standard Anthropic path.
- The new default is short and avoids leaking upstream branding to portable
  users who have not configured their own system prompt.

## Refs

Closes #712
