### PR TITLE
fix(agent-loop): complete direct answers without a fake tool retry

### DIFF
--- a/agent_loop.py
+++ b/agent_loop.py
@@ -24,6 +24,7 @@ class BaseHandler:
             _hook('tool_after', locals())
             return ret
         elif tool_name == 'bad_json': return StepOutcome(None, next_prompt=args.get('msg', 'bad_json'), should_exit=False)
+        elif tool_name == 'no_tool': return StepOutcome(response.content, next_prompt=None, should_exit=False)
         else:
             yield f"未知工具: {tool_name}\n"
             return StepOutcome(None, next_prompt=f"未知工具 {tool_name}", should_exit=False)

--- a/tests/test_agent_loop_no_tool.py
+++ b/tests/test_agent_loop_no_tool.py
@@ -1,0 +1,58 @@
+import unittest
+from types import SimpleNamespace
+
+from agent_loop import BaseHandler, exhaust, agent_runner_loop
+
+
+class StubClient:
+    def __init__(self):
+        self.last_tools = ""
+
+    def chat(self, messages, tools):
+        response = SimpleNamespace(content="final answer", tool_calls=[])
+
+        def gen():
+            if False:
+                yield None
+            return response
+
+        return gen()
+
+
+class StubHandler(BaseHandler):
+    def __init__(self):
+        self.parent = SimpleNamespace(task_dir=None)
+        self._done_hooks = []
+        self.turns = []
+
+    def turn_end_callback(self, response, tool_calls, tool_results, turn, next_prompt, exit_reason):
+        self.turns.append({
+            "tool_calls": tool_calls,
+            "next_prompt": next_prompt,
+            "exit_reason": exit_reason,
+        })
+        return next_prompt
+
+
+class AgentLoopNoToolTests(unittest.TestCase):
+    def test_direct_answer_completes_without_fake_unknown_tool_retry(self):
+        handler = StubHandler()
+        result = exhaust(agent_runner_loop(
+            StubClient(),
+            "system",
+            "user",
+            handler,
+            tools_schema=[],
+            max_turns=1,
+            verbose=False,
+        ))
+
+        self.assertEqual(result["result"], "CURRENT_TASK_DONE")
+        self.assertEqual(len(handler.turns), 1)
+        self.assertEqual(handler.turns[0]["tool_calls"][0]["tool_name"], "no_tool")
+        self.assertEqual(handler.turns[0]["next_prompt"], "")
+        self.assertNotIn("未知工具", handler.turns[0]["next_prompt"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

When the model returns a final text response with no tool calls, `agent_runner_loop()` creates the internal pseudo-call `no_tool`. `GenericAgentHandler.turn_end_callback()` explicitly recognizes that pseudo-call as a direct answer, but `BaseHandler.dispatch()` did not. It fell through to the unknown-tool branch, producing `未知工具 no_tool` and forcing another turn.

With `max_turns=1`, a valid direct answer therefore ended as `MAX_TURNS_EXCEEDED` instead of `CURRENT_TASK_DONE`.

## Fix

Teach `BaseHandler.dispatch()` the existing internal `no_tool` sentinel and return a normal `StepOutcome` with no next prompt. The loop then follows its existing completion path. Done hooks remain supported because `CURRENT_TASK_DONE` still passes through the existing done-hook logic.

## Verification

TDD was performed on a separate validation branch:

1. Regression-only GitHub Actions run `31165930923` failed on current `main`: the direct answer returned `MAX_TURNS_EXCEEDED` instead of `CURRENT_TASK_DONE`
2. The one-line dispatch fix passed run `31165988879`: compile, focused regression, and `git diff --check`
3. The final contribution branch was rebuilt directly from current `main` as one clean commit containing only the production change and focused regression test

## Scope

- 1 core production file modified
- 1 focused regression-test file added
- 1 clean commit on top of current `main`
- no dependency or configuration changes
