### PR TITLE
fix(cli): launch subcommands with the active Python interpreter

### DIFF
--- a/ga_cli/cli.py
+++ b/ga_cli/cli.py
@@ -32,6 +32,8 @@ def launch_frontend(cmd_parts, args=None):
     # 插入额外参数
     if args:
         full_cmd.extend(args)
+    if full_cmd and full_cmd[0] == "python":
+        full_cmd[0] = sys.executable
 
     print(f"🚀 {' '.join(full_cmd)}")
     sys.stdout.flush()

--- a/tests/test_ga_cli_interpreter.py
+++ b/tests/test_ga_cli_interpreter.py
@@ -1,0 +1,32 @@
+import sys
+import unittest
+from unittest import mock
+
+from ga_cli import cli
+
+
+class GaCliInterpreterTests(unittest.TestCase):
+    def test_python_launcher_uses_current_interpreter(self):
+        proc = mock.Mock()
+        with mock.patch.object(cli.subprocess, "Popen", return_value=proc) as popen, \
+             mock.patch.object(cli.os, "chdir"):
+            cli.launch_frontend(["python", "{PROJECT_DIR}/agentmain.py"], ["--help"])
+
+        popen.assert_called_once()
+        command = popen.call_args.args[0]
+        self.assertEqual(command[0], sys.executable)
+        self.assertTrue(command[1].endswith("agentmain.py"))
+        self.assertEqual(command[2:], ["--help"])
+        proc.wait.assert_called_once_with()
+
+    def test_non_python_launcher_is_not_rewritten(self):
+        proc = mock.Mock()
+        with mock.patch.object(cli.subprocess, "Popen", return_value=proc) as popen, \
+             mock.patch.object(cli.os, "chdir"):
+            cli.launch_frontend(["custom-runtime", "script"], None)
+
+        self.assertEqual(popen.call_args.args[0][0], "custom-runtime")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The `ga` console script can be installed and run from a virtual environment or another explicit Python interpreter, but every Python-based frontend command in `ga_cli/cli.py` starts with the literal executable name `python`.

That can resolve to a different interpreter than the one running `ga`, or fail entirely on systems where only `python3` exists. It also conflicts with `cmd_update()`, which already uses `sys.executable` correctly.

## Fix

Normalize only Python launcher commands inside `launch_frontend()`: when the command's first token is exactly `python`, replace it with `sys.executable`. Non-Python runtimes are left untouched.

This keeps the command registry readable and avoids editing each command definition separately.

## Verification

TDD was performed on a separate validation branch:

1. Regression-only GitHub Actions run `31166383679` failed because `launch_frontend()` passed `python` instead of the active interpreter path; the non-Python launcher case already passed
2. The minimal dispatcher fix passed run `31166445434`: compile, both regression tests, and `git diff --check`
3. This contribution branch is rebuilt directly from current `main` as one clean commit with no temporary CI files

## Scope

- 1 CLI production file modified
- 1 focused regression-test file added
- 1 clean commit on top of current `main`
- no dependency or configuration changes
