### PR TITLE
feat(llmcore): support api_key_header override for NativeClaudeSession

### DIFF
--- a/llmcore.py
+++ b/llmcore.py
@@ -746,6 +746,7 @@ class NativeClaudeSession(BaseSession):
         self._device_id = uuid.uuid4().hex + uuid.uuid4().hex[:32]
         self.tools = None
         if self.user_agent == self.default_ua: self.user_agent = self.native_ua
+        self.api_key_header = str(cfg.get('api_key_header', 'auto')).strip().lower()
     def raw_ask(self, messages):
         if self.max_tokens is None: self.max_tokens = 8192
         model = self.model
@@ -759,7 +760,9 @@ class NativeClaudeSession(BaseSession):
             "anthropic-beta": ",".join(beta_parts), "anthropic-dangerous-direct-browser-access": "true",
             "user-agent": self.user_agent, "x-app": "cli"}
         headers.update({"Accept": "application/json", "X-Claude-Code-Session-Id": self._session_id, "X-Stainless-Arch": "x64", "X-Stainless-Lang": "js", "X-Stainless-OS": "Windows", "X-Stainless-Package-Version": "0.94.0", "X-Stainless-Retry-Count": "0", "X-Stainless-Runtime": "node", "X-Stainless-Runtime-Version": "v24.3.0", "X-Stainless-Timeout": "600"})
-        if self.api_key.startswith("sk-ant-"): headers["x-api-key"] = self.api_key
+        if self.api_key_header == 'x-api-key': headers["x-api-key"] = self.api_key
+        elif self.api_key_header == 'bearer': headers["authorization"] = f"Bearer {self.api_key}"
+        elif self.api_key.startswith("sk-ant-"): headers["x-api-key"] = self.api_key
         else: headers["authorization"] = f"Bearer {self.api_key}"
         payload = {"model": model, "messages": messages, "max_tokens": self.max_tokens, "stream": self.stream}
         #if self.fake_cc_system_prompt: payload["max_tokens"] = 64000

--- a/mykey_template.py
+++ b/mykey_template.py
@@ -189,6 +189,26 @@ mixin_config = {
 #     # 'fake_cc_system_prompt': False,        # bool 默认 False；真 Anthropic 端点不需开
 # }
 
+# ── 1b′. Anthropic Messages 端点 + 手动指定鉴权头（api_key_header）──────────────
+#  某些中转渠道（如 opencode.ai）提供 Anthropic /v1/messages 端点，但 apikey 非
+#  sk-ant- 前缀。NativeClaudeSession 对非 sk-ant- 的 key 默认发 Authorization: Bearer；
+#  若目标端点只接受 x-api-key（如 opencode.ai 的 /v1/messages 只认 x-api-key，
+#  Bearer 会返回 401 Missing API key），用 api_key_header 手动强制鉴权头。
+#  api_key_header 合法值: 'auto'（默认，按 sk-ant- 前缀自动判断）
+#                        / 'x-api-key'（强制 x-api-key 头）
+#                        / 'bearer'（强制 Authorization: Bearer 头）
+# native_claude_config_opencode = {
+#     'name': 'opencode-deepseek-native',
+#     'apikey': '<your-key>',                  # 非 sk-ant- 前缀
+#     'apibase': 'https://opencode.ai/zen/go/v1',
+#     'model': 'deepseek-v4-flash',
+#     'api_key_header': 'x-api-key',           # ← 强制 x-api-key（否则 auto 发 Bearer→401）
+#     'thinking_type': 'adaptive',
+#     'reasoning_effort': 'low',
+#     'max_retries': 5,
+#     'read_timeout': 180,
+# }
+
 # ── 1c. CRS 反代 Claude Max ─────────────────────────────────────────────────
 #  CRS 需要 fake_cc_system_prompt=True
 # native_claude_config_crs = {


### PR DESCRIPTION
## Problem

`NativeClaudeSession.raw_ask` chose the auth header purely by key prefix:
`sk-ant-` keys → `x-api-key`, everything else → `Authorization: Bearer`.

Channels that expose a **full Anthropic `/v1/messages` endpoint but issue
non-`sk-ant-` keys** (e.g. opencode.ai's `https://opencode.ai/zen/go/v1`)
were broken: the client sent `Bearer`, the endpoint replied
`401 Missing API key`, so the native Claude protocol (tools loop, thinking,
context_management) could not be used against those relays.

## Change

Add an optional `api_key_header` config field to `NativeClaudeSession`:

- `auto` (default) — existing behavior unchanged
  (`sk-ant-` → `x-api-key`, otherwise `Bearer`)
- `x-api-key` — force the `x-api-key` header
- `bearer` — force `Authorization: Bearer`

Also documents the new field in `mykey_template.py` (new 1b' example
targeting an opencode.ai-style channel).

## Testing

- New path: `NativeClaudeSession` + `api_key_header='x-api-key'` +
  `https://opencode.ai/zen/go/v1` → HTTP 200, full native protocol reply.
- Regression: default `auto` (sk-Gq key → `Bearer` → `/chat/completions`)
  still returns HTTP 200, unchanged behavior.
