### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,11 +806,11 @@ GA Web 工具运行在**真实、持久化的 Chrome/Chromium 会话**中，而�
 
 <div align="center">
 
-<a href="https://star-history.com/#lsdefine/GenericAgent&Date">
+<a href="https://star-history.dera.page/#lsdefine/GenericAgent&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=lsdefine/GenericAgent&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=lsdefine/GenericAgent&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=lsdefine/GenericAgent&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=lsdefine/GenericAgent&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=lsdefine/GenericAgent&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=lsdefine/GenericAgent&type=Date" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer renders, which hides the project's adoption from visitors. This change updates the chart and its link to a working mirror so the graph shows up again.