### PR TITLE
test: make release report path portable

### DIFF
--- a/frontends/tests/test_release_qualification.py
+++ b/frontends/tests/test_release_qualification.py
@@ -408,8 +408,9 @@ def test_package_start_injects_only_the_isolated_e2e_conductor_port(tmp_path, mo
     candidate.process_log.close()
 
     assert captured["env"]["GA_DESKTOP_E2E_CONDUCTOR_PORT"] == "29890"
-    assert captured["env"]["GA_DESKTOP_E2E_REPORT_DIR"].endswith(
-        "bootstrap/first-launch"
+    assert Path(captured["env"]["GA_DESKTOP_E2E_REPORT_DIR"]).parts[-2:] == (
+        "bootstrap",
+        "first-launch",
     )
     assert candidate.report["pids"] == [{"scenario": "first-launch", "app": 44120}]
 


### PR DESCRIPTION
## Summary

- compare the isolated E2E report directory by path components
- make the release-qualification test portable across POSIX and Windows separators

Closes #794.

## Validation

- `python -m pytest frontends/tests/test_release_qualification.py -q` — 35 passed
- `python -m pytest frontends/tests -q` — 273 passed; 2 existing Windows symlink-privilege failures
- `python -m compileall -q .`
- `ruff check frontends/tests/test_release_qualification.py`
- `git diff --check`

No production behavior or dependencies change.
